### PR TITLE
Decide UI styling approach/framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,3 +34,23 @@ This is a Next.js 14 App Router project with Tailwind CSS and Supabase auth.
 - Vitest with `environment: 'node'`.
 - `lib/supabase` is fully mocked via `vi.mock`; tests import the route handler functions directly and call them with `new Request(...)`.
 - Tests live in `__tests__/` and are matched by the glob `__tests__/**/*.test.ts`.
+
+## Styling Guidelines
+
+Tailwind CSS is the single, project-wide approach to styling — no CSS Modules, styled-components, or component libraries. Every page and component styles exclusively through Tailwind utility classes.
+
+**Design tokens — the source of truth:**
+- Brand colors are defined once as CSS custom properties in `app/globals.css` (`:root`, prefixed `--rc-*`), then exposed as named Tailwind colors under the `brand` key in `tailwind.config.js` (`theme.extend.colors.brand`). Use these tokens (`bg-brand-navy`, `text-brand-purple`, `border-brand-navy-border`, …) instead of writing raw hex values like `bg-[#7C4DFF]`.
+- Available tokens: `brand-navy` / `brand-navy-2` / `brand-navy-border` / `brand-void` (dark surfaces), `brand-purple` / `brand-purple-dark` / `brand-purple-glow` (primary accent), `brand-teal` / `brand-teal-dark` / `brand-teal-ink` (secondary accent), `brand-gold` (rewards/XP/achievements only), `brand-danger` / `brand-danger-light` (errors, destructive actions), `brand-ink` / `brand-ink-muted` (text on dark surfaces).
+- For the light/white content areas (inside `AppShell`'s `<main>`), use Tailwind's built-in gray scale (`text-gray-500`, `bg-gray-50`, `border-gray-100`) rather than inventing new grays.
+- Border radius: use `rounded-brand-sm` (9px, small icon buttons), `rounded-brand-md` (10px, inputs/buttons/nav items), `rounded-brand-lg` (20px, cards/panels), or Tailwind's built-in `rounded-full` (pills, avatars). Don't add new arbitrary `rounded-[Npx]` values.
+- Spacing: use Tailwind's default spacing scale (`p-4`, `gap-2.5`, `mb-5`, …) — no arbitrary pixel spacing.
+- Typography: the font family is set once in `app/globals.css` (`body { font-family: ... }`). Don't override `font-family` in individual components.
+
+**Rules for new pages/components:**
+- No inline `style={{ ... }}` for anything expressible as a Tailwind class. Inline styles are only for genuinely dynamic, per-instance values (e.g. per-sparkle animation offsets in `components/PasswordField.tsx`).
+- No new raw hex colors in `className`. If a needed color isn't in the `brand` palette yet, add it as a `--rc-*` variable in `app/globals.css` and a matching token in `tailwind.config.js` first, then use the token.
+- Reuse existing shared components before writing new markup: `components/AppShell.tsx` (page shell/nav for authenticated pages), `components/ActivityCard.tsx`, `components/QuestionCard.tsx`, `components/FeedbackCard.tsx`, `components/PasswordField.tsx`. Prefer extending one of these over duplicating its markup.
+- Custom CSS animations that Tailwind utilities can't express (`@keyframes`, gradient-text glow, etc.) use `<style jsx>` (styled-jsx, built into Next.js) scoped to the component — see `app/dashboard/page.tsx` and `components/PasswordField.tsx`. Reference the `--rc-*` variables inside these blocks instead of hardcoding new hex values, so raw CSS and Tailwind classes never drift apart.
+
+**Known gap:** existing pages/components still contain literal arbitrary-value classes (e.g. `bg-[#7C4DFF]`) that predate this token system. New code should use the `brand-*` tokens above; migrating existing files onto the tokens is a separate follow-up, not required for this to take effect going forward.

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,25 @@
 
 :root {
   color-scheme: dark;
+
+  /* Brand design tokens: single source of truth, consumed both by
+     tailwind.config.js (theme.extend.colors.brand) and by raw CSS in
+     styled-jsx blocks (e.g. app/dashboard/page.tsx). */
+  --rc-navy: #1b1642;
+  --rc-navy-2: #241f52;
+  --rc-navy-border: #332b6b;
+  --rc-void: #0e0b1e;
+  --rc-purple: #7c4dff;
+  --rc-purple-dark: #6234d1;
+  --rc-purple-glow: #8b5cf6;
+  --rc-teal: #2dd4bf;
+  --rc-teal-dark: #0f7d70;
+  --rc-teal-ink: #04241f;
+  --rc-gold: #ffd666;
+  --rc-danger: #ff6b57;
+  --rc-danger-light: #ff8a75;
+  --rc-text: #f3f1ff;
+  --rc-text-muted: #a79fc9;
 }
 
 html, body {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,36 @@
 module.exports = {
   content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        // Namespaced under `brand` so it never collides with Tailwind's
+        // own default palette (e.g. bg-purple-500). Values point at the
+        // CSS custom properties defined in app/globals.css, which is the
+        // single source of truth for the app's colors.
+        brand: {
+          navy: 'var(--rc-navy)',
+          'navy-2': 'var(--rc-navy-2)',
+          'navy-border': 'var(--rc-navy-border)',
+          void: 'var(--rc-void)',
+          purple: 'var(--rc-purple)',
+          'purple-dark': 'var(--rc-purple-dark)',
+          'purple-glow': 'var(--rc-purple-glow)',
+          teal: 'var(--rc-teal)',
+          'teal-dark': 'var(--rc-teal-dark)',
+          'teal-ink': 'var(--rc-teal-ink)',
+          gold: 'var(--rc-gold)',
+          danger: 'var(--rc-danger)',
+          'danger-light': 'var(--rc-danger-light)',
+          ink: 'var(--rc-text)',
+          'ink-muted': 'var(--rc-text-muted)',
+        },
+      },
+      borderRadius: {
+        'brand-sm': '9px',
+        'brand-md': '10px',
+        'brand-lg': '20px',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
resolve #44 

How styling works technically from now on:

1. One source of truth: All brand colors are defined once as CSS 
variables in `app/globals.css` (`:root`, prefix `--rc-*`) — e.g. 
`--rc-purple: #7c4dff;`.
2. Tailwind consumes them: `tailwind.config.js` maps these variables 
under the `brand` namespace to Tailwind color utilities, e.g. 
`bg-brand-purple`, `text-brand-teal`, `border-brand-navy-border`. The 
`brand` namespace was chosen deliberately so it doesn't collide with 
Tailwind's built-in color palette (e.g. `purple-500` already exists in 
Tailwind and would be something completely different).
3. Raw CSS stays in sync too: Wherever Tailwind isn't enough (e.g. the 
animated glow/sparkle effects in `app/dashboard/page.tsx` and 
`components/PasswordField.tsx`, implemented via `<style jsx>`), 
`var(--rc-purple)` is referenced directly — same source, no second set 
of values.
4. There are now also three fixed radius steps (`rounded-brand-sm/md/lg`) 
instead of freely invented pixel values.

How new team members should apply this:

* Need a color? → Use `bg-brand-navy`, `text-brand-purple`, 
  `border-brand-teal`, etc. instead of typing `bg-[#whatever]`.
* Missing color in the set? → First add it as a `--rc-*` variable in 
  `app/globals.css` AND as a token in `tailwind.config.js`, only then 
  use it in the component.
* Building a new page? → Use `<AppShell>` for logged-in areas instead 
  of rebuilding it from scratch.
* Spacing/radii always come from the Tailwind scale or the three 
  `brand-*` radius steps — no invented pixel values.

Where to look this up:

* Rules/guidelines (prose): `CLAUDE.md`, "Styling Guidelines" section
* Color values (the one source of truth): `app/globals.css`, `:root` 
  block (`--rc-*` variables)
* Tailwind token names actually typed in code: `tailwind.config.js`, 
  `theme.extend.colors.brand` and `theme.extend.borderRadius`