### PR TITLE
Added route to receive all active sessions

### DIFF
--- a/__tests__/api/sessions-in-progress.test.ts
+++ b/__tests__/api/sessions-in-progress.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Hoisted so the vi.mock factory below can close over it safely.
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    inserts: [] as { table: string; payload: unknown }[],
+    tables: [] as string[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      in: () => builder,
+      order: () => builder,
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly.
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+/** Queues the result the next `from(table)` chain resolves to. */
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'user-123' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/sessions/in-progress/route';
+
+const ACTIVITY_TYPE = 'IDENTIFY_WEAK_USER_STORIES';
+
+function sessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    session_id: 'session-1',
+    user_id: 'user-123',
+    activity_type: ACTIVITY_TYPE,
+    difficulty_level: 1,
+    started_at: '2026-07-29T10:00:00.000Z',
+    ended_at: null,
+    status: 'in-progress',
+    cumulative_score: 50,
+    max_score: 100,
+    passed: false,
+    badge_id: null,
+    ...overrides,
+  };
+}
+
+/** The 4 drawn questions of session-1, deliberately queued out of order. */
+const drawnQuestions = [
+  { session_id: 'session-1', position: 2, question_id: 'q-3' },
+  { session_id: 'session-1', position: 0, question_id: 'q-1' },
+  { session_id: 'session-1', position: 3, question_id: 'q-4' },
+  { session_id: 'session-1', position: 1, question_id: 'q-2' },
+];
+
+function req(query = '', token: string | null = 'valid-token') {
+  return new Request(`http://localhost/api/sessions/in-progress${query}`, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe('GET /api/sessions/in-progress', () => {
+  beforeEach(() => {
+    h.state.queues = {};
+    h.state.inserts = [];
+    h.state.tables = [];
+  });
+
+  it('returns 401 without a token', async () => {
+    expect((await GET(req(`?activityType=${ACTIVITY_TYPE}`, null))).status).toBe(401);
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    expect((await GET(req(`?activityType=${ACTIVITY_TYPE}`, 'bad-token'))).status).toBe(401);
+  });
+
+  it('returns 400 for an unknown activity type', async () => {
+    const response = await GET(req('?activityType=NOT_AN_ACTIVITY'));
+
+    expect(response.status).toBe(400);
+    expect(h.state.tables).toHaveLength(0);
+  });
+
+  // AC 1: status, difficulty level, cumulative score, the 4 question ids, last question index.
+  it('returns the in-progress session for the activity type', async () => {
+    queue('session_log', { data: [sessionRow()], error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+    queue('answered_question_log', {
+      data: [
+        { session_id: 'session-1', question_id: 'q-1' },
+        { session_id: 'session-1', question_id: 'q-2' },
+      ],
+      error: null,
+    });
+
+    const response = await GET(req(`?activityType=${ACTIVITY_TYPE}`));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(1);
+    expect(body.sessions[0]).toMatchObject({
+      session_id: 'session-1',
+      status: 'in-progress',
+      difficulty_level: 1,
+      cumulative_score: 50,
+      answeredCount: 2,
+      questionCount: 4,
+      nextPosition: 2,
+    });
+    // Presentation order, not the order the rows came back in.
+    expect(body.sessions[0].questionIds).toEqual(['q-1', 'q-2', 'q-3', 'q-4']);
+    expect(body.sessions[0].lastQuestionIndex).toBe(1);
+  });
+
+  it('reports a null last question index while nothing is answered', async () => {
+    queue('session_log', { data: [sessionRow({ cumulative_score: 0 })], error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+    queue('answered_question_log', { data: [], error: null });
+
+    const body = await (await GET(req(`?activityType=${ACTIVITY_TYPE}`))).json();
+
+    expect(body.sessions[0].lastQuestionIndex).toBeNull();
+    expect(body.sessions[0].nextPosition).toBe(0);
+  });
+
+  // AC 2.
+  it('returns 404 when no session is in progress for that activity type', async () => {
+    queue('session_log', { data: [], error: null });
+
+    const response = await GET(req(`?activityType=${ACTIVITY_TYPE}`));
+
+    expect(response.status).toBe(404);
+    // Nothing to look up once there is no session.
+    expect(h.state.tables).toEqual(['session_log']);
+  });
+
+  // AC 3: the filter is on the id from the token, so a foreign session is simply not returned
+  // and looks exactly like a missing one.
+  it("returns 404 for another student's session", async () => {
+    queue('session_log', { data: [], error: null });
+
+    expect((await GET(req(`?activityType=${ACTIVITY_TYPE}`))).status).toBe(404);
+  });
+
+  it('returns every running session when no activity type is given', async () => {
+    queue('session_log', {
+      data: [
+        sessionRow(),
+        sessionRow({ session_id: 'session-2', activity_type: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA' }),
+      ],
+      error: null,
+    });
+    queue('session_to_question', {
+      data: [
+        ...drawnQuestions,
+        { session_id: 'session-2', position: 0, question_id: 'q-9' },
+      ],
+      error: null,
+    });
+    queue('answered_question_log', {
+      data: [{ session_id: 'session-1', question_id: 'q-1' }],
+      error: null,
+    });
+
+    const response = await GET(req());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(2);
+    expect(body.sessions[0].questionIds).toEqual(['q-1', 'q-2', 'q-3', 'q-4']);
+    expect(body.sessions[0].lastQuestionIndex).toBe(0);
+    expect(body.sessions[1].questionIds).toEqual(['q-9']);
+    expect(body.sessions[1].lastQuestionIndex).toBeNull();
+  });
+
+  // Nothing running at all is a normal state for an overview, not a missing record.
+  it('returns an empty list rather than 404 without an activity type', async () => {
+    queue('session_log', { data: [], error: null });
+
+    const response = await GET(req());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toEqual([]);
+    expect(h.state.tables).toEqual(['session_log']);
+  });
+
+  it('returns 500 when the session lookup fails', async () => {
+    queue('session_log', { data: null, error: { message: 'boom' } });
+
+    expect((await GET(req(`?activityType=${ACTIVITY_TYPE}`))).status).toBe(500);
+  });
+
+  it('never writes', async () => {
+    queue('session_log', { data: [sessionRow()], error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+    queue('answered_question_log', { data: [], error: null });
+
+    await GET(req(`?activityType=${ACTIVITY_TYPE}`));
+
+    expect(h.state.inserts).toHaveLength(0);
+  });
+});

--- a/app/api/sessions/in-progress/route.ts
+++ b/app/api/sessions/in-progress/route.ts
@@ -1,0 +1,91 @@
+import { getSupabaseClient } from '../../../../lib/supabase';
+import { isActivityType } from '../../../../lib/activityTypes';
+import { SESSION_COLUMNS } from '../../../../lib/sessionRules';
+import { loadProgressForSessions } from '../../../../lib/sessionQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/sessions/in-progress — the student's running sessions (REQ-PL-2.1, REQ-DL-3).
+ *
+ * Always answers with { sessions: [...] }, so the client can build its own lookup from one
+ * shape instead of branching on the response.
+ *
+ * With ?activityType=…  narrowed to that activity, or 404. This is the check the opening page
+ * makes before it decides whether to offer "resume" or "start fresh"; uq_session_log_one_active
+ * means the list holds at most one entry then.
+ *
+ * Without the parameter, every running session across all activity types. The empty list is a
+ * 200 there — "no activity is running" is a normal state for an overview, while the
+ * per-activity check asks about one specific record that either exists or does not.
+ *
+ * Each record carries what REQ-DL-3.1 asks for: status, difficulty level, cumulative score,
+ * the drawn question ids in presentation order, and the index of the last answered question.
+ * The last two are derived from session_to_question and answered_question_log rather than
+ * stored — see lastAnsweredPosition.
+ *
+ * Question prompts and options are not included: this endpoint answers "is something
+ * running?", and the resume itself goes through GET /api/sessions/current, which ships the
+ * questions.
+ */
+export async function GET(request: Request) {
+  const token = getToken(request);
+  if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const activityType = new URL(request.url).searchParams.get('activityType');
+
+  if (activityType !== null && !isActivityType(activityType)) {
+    return Response.json({ error: 'Unknown activity type.' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  // The student id comes from the auth session, never from the query string — this is the
+  // whole of "only returns sessions belonging to the requesting student".
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
+
+  let query = supabase
+    .from('session_log')
+    .select(SESSION_COLUMNS)
+    .eq('user_id', user.id)
+    .eq('status', 'in-progress');
+
+  if (activityType !== null) query = query.eq('activity_type', activityType);
+
+  const { data: rows, error } = await query.order('started_at', { ascending: false });
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  const sessions = (rows ?? []) as { session_id: string }[];
+
+  // A session belonging to somebody else was already filtered out above, so it is
+  // indistinguishable from one that does not exist.
+  if (activityType !== null && sessions.length === 0) {
+    return Response.json({ error: 'No in-progress session for this activity type.' }, { status: 404 });
+  }
+
+  const { progress, error: progressError } = await loadProgressForSessions(
+    supabase,
+    sessions.map((session) => session.session_id),
+  );
+
+  if (progressError) return Response.json({ error: progressError.message }, { status: 500 });
+
+  const withProgress = sessions.map((session) => ({
+    ...session,
+    ...(progress!.get(session.session_id) ?? {
+      questionCount: 0,
+      answeredCount: 0,
+      nextPosition: null,
+      questionIds: [],
+      lastQuestionIndex: null,
+    }),
+  }));
+
+  return Response.json({ sessions: withProgress }, { status: 200 });
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -78,14 +78,18 @@ export async function GET(request: Request) {
 
   return Response.json(
     {
-      sessions: sessions.map((session) => ({
-        ...session,
-        ...(progress!.get(session.session_id) ?? {
-          questionCount: 0,
-          answeredCount: 0,
-          nextPosition: null,
-        }),
-      })),
+      // Picked field by field rather than spread: loadProgressForSessions also carries the
+      // drawn question ids, and a list view has no use for them.
+      sessions: sessions.map((session) => {
+        const sessionProgress = progress!.get(session.session_id);
+
+        return {
+          ...session,
+          questionCount: sessionProgress?.questionCount ?? 0,
+          answeredCount: sessionProgress?.answeredCount ?? 0,
+          nextPosition: sessionProgress?.nextPosition ?? null,
+        };
+      }),
     },
     { status: 200 },
   );

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -161,6 +161,9 @@ export type SessionProgress = {
   questionCount: number;
   answeredCount: number;
   nextPosition: number | null;
+  /** The drawn question ids in presentation order (REQ-DL-3.1). */
+  questionIds: string[];
+  lastQuestionIndex: number | null;
 };
 
 /**
@@ -204,10 +207,14 @@ export async function loadProgressForSessions(supabase: SupabaseClient, sessionI
   const progress = new Map<string, SessionProgress>();
 
   for (const [sessionId, { positions, answered }] of grouped) {
+    const ordered = [...positions].sort((a, b) => a.position - b.position);
+
     progress.set(sessionId, {
       questionCount: positions.length,
       answeredCount: answered.size,
       nextPosition: nextUnansweredPosition(positions, answered),
+      questionIds: ordered.map((row) => row.question_id),
+      lastQuestionIndex: lastAnsweredPosition(positions, answered),
     });
   }
 
@@ -228,4 +235,23 @@ export function nextUnansweredPosition(
   return positions
     .filter((row) => !answeredQuestionIds.has(row.question_id))
     .sort((a, b) => a.position - b.position)[0]?.position ?? null;
+}
+
+/**
+ * The highest position that already has an answer, or null when nothing is answered yet —
+ * REQ-DL-3.1's "index of the last question answered".
+ *
+ * Derived for the same reason as nextUnansweredPosition: a stored index is the one value two
+ * devices could disagree about. Highest rather than most recent, because answers can only be
+ * submitted for the next unanswered position, so the two coincide.
+ */
+export function lastAnsweredPosition(
+  positions: SessionPosition[],
+  answeredQuestionIds: Set<string>,
+): number | null {
+  const answered = positions
+    .filter((row) => answeredQuestionIds.has(row.question_id))
+    .sort((a, b) => b.position - a.position);
+
+  return answered[0]?.position ?? null;
 }


### PR DESCRIPTION
Added a route to receive all active sessions as json object to create an overview page of all active sessions.
resolves #24 