### PR TITLE
Cache student score in localStorage to cut repeat API calls

### DIFF
--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { AppShell } from '../../../../components/AppShell';
 import { FeedbackCard } from '../../../../components/FeedbackCard';
 import { QuestionCard } from '../../../../components/QuestionCard';
+import { useUser } from '../../../../components/UserProvider';
 import { getActivity } from '../../../../lib/activityContent';
 import {
   type CurrentSessionResult,
@@ -13,6 +14,7 @@ import {
   type SessionQuestion,
   loadCurrentSession,
   loadFeedback,
+  loadStudentScore,
   submitAnswer,
 } from '../../../../lib/sessionClient';
 import { useAccessToken } from '../../../../lib/useAccessToken';
@@ -28,6 +30,7 @@ type AnswerOutcome = {
 export default function PlayActivityPage({ params }: { params: { slug: string } }) {
   const router = useRouter();
   const { token, loading } = useAccessToken();
+  const { profile } = useUser();
   const activity = getActivity(params.slug);
 
   const [session, setSession] = useState<CurrentSessionResult | null>(null);
@@ -152,6 +155,9 @@ export default function PlayActivityPage({ params }: { params: { slug: string } 
   function handleContinue() {
     if (!outcome) return;
     if (outcome.completed) {
+      if (token && profile?.user_id) {
+        void loadStudentScore(token, profile.user_id, { forceRefresh: true });
+      }
       router.push(`/activities/${activity!.slug}`);
       return;
     }

--- a/lib/scoreStore.ts
+++ b/lib/scoreStore.ts
@@ -1,0 +1,33 @@
+// Local cache for the student's cumulative score (GET /api/students/{id}/score), so
+// AppShell doesn't have to hit the network on every page navigation. Same shape as
+// lib/activityStore.ts's storage helpers: a versioned key, an SSR-guarded read/write pair,
+// and only typed getter/setter functions exported — never the raw store.
+const STORAGE_KEY = 'rc_score_v1';
+
+type ScoreStore = Partial<Record<string, number>>;
+
+function readStore(): ScoreStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as ScoreStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: ScoreStore) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedScore(studentId: string): number | null {
+  const store = readStore();
+  return store[studentId] ?? null;
+}
+
+export function setCachedScore(studentId: string, score: number): void {
+  const store = readStore();
+  store[studentId] = score;
+  writeStore(store);
+}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -9,6 +9,7 @@
 // from the feedback route, and only after the answer has been committed.
 
 import type { ActivityType } from './activityTypes';
+import { getCachedScore, setCachedScore } from './scoreStore';
 
 export type SessionRecord = {
   session_id: string;
@@ -197,17 +198,36 @@ export function loadCompletedAttempts(token: string, activityType: ActivityType)
 
 /**
  * The student's cumulative score: the sum of their best passing score at each difficulty level
- * of each activity type (REQ-GAM-DL-1). Derived from session history on every call, never
- * stored, so it needs no invalidation — a fresh read after finishing an activity is enough.
+ * of each activity type (REQ-GAM-DL-1). Cached in localStorage (lib/scoreStore.ts) keyed by
+ * studentId, since it otherwise gets refetched on every AppShell mount i.e. every navigation.
+ * A plain call is served from the cache when present; pass forceRefresh to bypass it and
+ * re-cache the server's answer — the play flow does this once a session completes, since
+ * that's the only thing that actually changes the score.
  *
  * studentId has to be the authenticated student; the route answers 403 for anyone else.
  */
-export function loadStudentScore(token: string, studentId: string) {
+export function loadStudentScore(
+  token: string,
+  studentId: string,
+  options: { forceRefresh?: boolean } = {},
+) {
+  if (!options.forceRefresh) {
+    const cached = getCachedScore(studentId);
+    if (cached !== null) {
+      return Promise.resolve<ApiResult<{ score: number }>>({ ok: true, data: { score: cached } });
+    }
+  }
+
   return request<{ score: number }>(
     `/api/students/${encodeURIComponent(studentId)}/score`,
     { method: 'GET' },
     token,
-  );
+  ).then((result) => {
+    if (result.ok) {
+      setCachedScore(studentId, result.data.score);
+    }
+    return result;
+  });
 }
 
 /**


### PR DESCRIPTION
AppShell refetches /api/students/{id}/score on every page navigation. Add a scoreStore cache (mirrors activityStore's pattern) that loadStudentScore reads before hitting the network, and force-refresh it once a quiz completes so the cache stays current.
resolve #72 