### PR TITLE
Cache completed sessions in localStorage to cut repeat API calls

### DIFF
--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -14,6 +14,7 @@ import {
   type SessionQuestion,
   loadCurrentSession,
   loadFeedback,
+  loadSessions,
   loadStudentScore,
   submitAnswer,
 } from '../../../../lib/sessionClient';
@@ -173,6 +174,7 @@ export default function PlayActivityPage({ params }: { params: { slug: string } 
     if (outcome.completed) {
       if (token && profile?.user_id) {
         void loadStudentScore(token, profile.user_id, { forceRefresh: true });
+        void loadSessions(token, 'completed', { studentId: profile.user_id, forceRefresh: true });
       }
       router.push(`/activities/${activity!.slug}`);
       return;

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -49,7 +49,7 @@ export default function DashboardPage() {
     if (!token) return;
     let cancelled = false;
 
-    loadSessions(token, "completed").then((result) => {
+    loadSessions(token, "completed", { studentId: profile?.user_id }).then((result) => {
       if (cancelled) return;
       if (result.ok) setRecent(result.data.sessions.slice(0, RECENT_LIMIT));
     });
@@ -57,7 +57,7 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, profile?.user_id]);
 
   if (loading) return null;
 

--- a/lib/completedSessionsStore.ts
+++ b/lib/completedSessionsStore.ts
@@ -1,0 +1,35 @@
+// Local cache for the student's completed-sessions list (GET /api/sessions?status=completed),
+// so the dashboard doesn't have to hit the network on every mount. Same shape as
+// lib/scoreStore.ts: a versioned key, an SSR-guarded read/write pair, and only typed
+// getter/setter functions exported — never the raw store.
+import type { SessionListEntry } from './sessionClient';
+
+const STORAGE_KEY = 'rc_completed_sessions_v1';
+
+type CompletedSessionsStore = Partial<Record<string, SessionListEntry[]>>;
+
+function readStore(): CompletedSessionsStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as CompletedSessionsStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: CompletedSessionsStore) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedCompletedSessions(studentId: string): SessionListEntry[] | null {
+  const store = readStore();
+  return store[studentId] ?? null;
+}
+
+export function setCachedCompletedSessions(studentId: string, sessions: SessionListEntry[]): void {
+  const store = readStore();
+  store[studentId] = sessions;
+  writeStore(store);
+}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -9,6 +9,7 @@
 // from the feedback route, and only after the answer has been committed.
 
 import type { ActivityType } from './activityTypes';
+import { getCachedCompletedSessions, setCachedCompletedSessions } from './completedSessionsStore';
 import { getCachedScore, setCachedScore } from './scoreStore';
 
 export type SessionRecord = {
@@ -175,13 +176,40 @@ export function loadCurrentSession(token: string, activityType: ActivityType) {
  *
  * The cross-activity counterpart to loadCompletedAttempts: this one answers "what did I do
  * lately", that one "how did I do at this activity". Neither carries questions or answers.
+ *
+ * The 'completed' list is cached in localStorage (lib/completedSessionsStore.ts) keyed by
+ * studentId, since it's the one status the dashboard actually asks for on every mount.
+ * Pass studentId to opt into that cache; without it (or for 'in-progress'/'abandoned') this
+ * always hits the network, unchanged. forceRefresh bypasses the cache and re-caches the
+ * server's answer — the play flow does this once a session completes.
  */
-export function loadSessions(token: string, status: 'in-progress' | 'completed' | 'abandoned') {
+export function loadSessions(
+  token: string,
+  status: 'in-progress' | 'completed' | 'abandoned',
+  options: { studentId?: string; forceRefresh?: boolean } = {},
+) {
+  const { studentId, forceRefresh } = options;
+
+  if (status === 'completed' && studentId && !forceRefresh) {
+    const cached = getCachedCompletedSessions(studentId);
+    if (cached !== null) {
+      return Promise.resolve<ApiResult<{ sessions: SessionListEntry[] }>>({
+        ok: true,
+        data: { sessions: cached },
+      });
+    }
+  }
+
   return request<{ sessions: SessionListEntry[] }>(
     `/api/sessions?status=${status}`,
     { method: 'GET' },
     token,
-  );
+  ).then((result) => {
+    if (result.ok && status === 'completed' && studentId) {
+      setCachedCompletedSessions(studentId, result.data.sessions);
+    }
+    return result;
+  });
 }
 
 /**


### PR DESCRIPTION
loadSessions now checks a cached list for status=completed before hitting the network, and the play flow force-refreshes it once a quiz finishes so the cache stays current.
resolve #77 