### PR TITLE
changed route for #26

### DIFF
--- a/__tests__/api/answers.test.ts
+++ b/__tests__/api/answers.test.ts
@@ -89,6 +89,19 @@ const wrongOption = {
   answer: { answer_id: 'a-1-wrong', is_correct: false, explanation: 'Incorrect: no technical detail.' },
 };
 
+/** The answered_question_log row the insert echoes back, as the database would return it. */
+function answerLogRow(overrides: Record<string, unknown> = {}) {
+  return {
+    log_id: 'log-1',
+    session_id: SESSION_ID,
+    question_id: 'q-1',
+    answer_id: 'a-1-correct',
+    score: 25,
+    submitted_at: '2026-07-29T10:05:00.000Z',
+    ...overrides,
+  };
+}
+
 function req(body?: object, token: string | null = 'valid-token') {
   return new Request(`http://localhost/api/sessions/${SESSION_ID}/answers`, {
     method: 'POST',
@@ -111,15 +124,21 @@ function queueSubmission({
   option = correctOption,
   alreadyAnswered = [] as string[],
   submitted = 'q-1',
-  insertResult = { data: null, error: null } as Result,
+  insertResult = null as Result | null,
   cumulativeAfter = 25,
   maxScore = 25 as number | null,
 } = {}) {
+  // The insert echoes back the row it wrote, so by default it mirrors what was submitted.
+  const echoed: Result = insertResult ?? {
+    data: answerLogRow({ question_id: submitted, answer_id: option.answer.answer_id }),
+    error: null,
+  };
+
   queue('session_log', { data: sessionRow(), error: null });                    // ownership + status
   queue('session_to_question', { data: sessionQuestions, error: null });        // the 4 drawn questions
   queue('question_to_answer', { data: option, error: null });                   // option belongs to question
   queue('question', { data: { max_score: maxScore }, error: null });            // points available
-  queue('answered_question_log', insertResult);                                 // the insert
+  queue('answered_question_log', echoed);                                       // the insert
   // loadProgress
   queue('session_log', { data: sessionRow({ cumulative_score: cumulativeAfter }), error: null });
   queue('answered_question_log', {
@@ -241,6 +260,41 @@ describe('POST /api/sessions/{sessionId}/answers', () => {
     expect(log.log_id).toEqual(expect.any(String));
   });
 
+  // REQ-DL-4.1: the caller gets back the record that was created, not just the outcome.
+  it('returns the created answer log record', async () => {
+    queueSubmission({
+      insertResult: { data: answerLogRow({ log_id: 'log-42' }), error: null },
+    });
+
+    const response = await POST(req({ questionId: 'q-1', selectedOptionId: 'a-1-correct' }), ctx);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.answer).toEqual({
+      logId: 'log-42',
+      sessionId: SESSION_ID,
+      questionId: 'q-1',
+      selectedOptionId: 'a-1-correct',
+      score: 25,
+      submittedAt: '2026-07-29T10:05:00.000Z',
+    });
+  });
+
+  // The write is committed even if the row does not come back, so the submission must not fail:
+  // only the timestamp, which exists solely in the database, is reported as unknown.
+  it('still returns the record when the insert does not echo the row back', async () => {
+    queueSubmission({ insertResult: { data: null, error: null } });
+
+    const response = await POST(req({ questionId: 'q-1', selectedOptionId: 'a-1-correct' }), ctx);
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.answer.submittedAt).toBeNull();
+    expect(body.answer.questionId).toBe('q-1');
+    expect(body.answer.selectedOptionId).toBe('a-1-correct');
+    expect(body.answer.logId).toEqual(expect.any(String));
+  });
+
   it('records a wrong answer with score 0', async () => {
     queueSubmission({ option: wrongOption, cumulativeAfter: 0 });
 
@@ -299,8 +353,10 @@ describe('POST /api/sessions/{sessionId}/answers', () => {
     expect(body.error).toMatch(/already been answered/i);
     expect(body.session.cumulative_score).toBe(25);
     expect(body.nextPosition).toBe(1);
-    // The conflict must not leak the outcome of an answer that was not recorded.
+    // The conflict must not leak the outcome of an answer that was not recorded, and there is
+    // no new log record to hand back — the first write is the one that stands.
     expect(body).not.toHaveProperty('correct');
+    expect(body).not.toHaveProperty('answer');
     expect(h.state.updates).toHaveLength(0);
   });
 

--- a/app/api/sessions/[sessionId]/answers/route.ts
+++ b/app/api/sessions/[sessionId]/answers/route.ts
@@ -9,6 +9,10 @@ import {
 
 const UNIQUE_VIOLATION = '23505';
 
+// What a caller needs to identify the record it just created (REQ-DL-4.1). user_id is left
+// out on purpose — it is the requesting student's own id, a filter rather than payload.
+const ANSWER_LOG_COLUMNS = 'log_id, session_id, question_id, answer_id, score, submitted_at';
+
 type SessionRow = {
   session_id: string;
   status: string;
@@ -17,6 +21,15 @@ type SessionRow = {
 };
 
 type SubmittedOption = { answer_id: string; is_correct: boolean; explanation: string | null };
+
+type AnswerLogRow = {
+  log_id: string;
+  session_id: string;
+  question_id: string;
+  answer_id: string;
+  score: number;
+  submitted_at: string;
+};
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -125,16 +138,24 @@ export async function POST(request: Request, { params }: { params: { sessionId: 
 
   const score = scoreForAnswer(option.is_correct, (questionRow as { max_score: number | null } | null)?.max_score ?? null);
 
-  const { error: insertError } = await supabase
+  const logRow = {
+    log_id: crypto.randomUUID(),
+    session_id: sessionId,
+    user_id: user.id,
+    question_id: questionId,
+    answer_id: option.answer_id,
+    score,
+  };
+
+  // The written row is read back rather than assumed: submitted_at is a database default
+  // (now()), so REQ-DL-4.1's timestamp only exists after the insert — neither the client nor
+  // this route can supply it. The column list stays explicit for the same reason
+  // COMPLETED_ATTEMPT_COLUMNS is: user_id is the filter here, not part of the payload.
+  const { data: inserted, error: insertError } = await supabase
     .from('answered_question_log')
-    .insert({
-      log_id: crypto.randomUUID(),
-      session_id: sessionId,
-      user_id: user.id,
-      question_id: questionId,
-      answer_id: option.answer_id,
-      score,
-    });
+    .insert(logRow)
+    .select(ANSWER_LOG_COLUMNS)
+    .maybeSingle();
 
   if (insertError) {
     // uq_answered_question_log_session_question: this question was already answered.
@@ -166,6 +187,7 @@ export async function POST(request: Request, { params }: { params: { sessionId: 
 
   return Response.json(
     {
+      answer: answerRecord(inserted as AnswerLogRow | null, logRow),
       correct: option.is_correct,
       explanation: option.explanation,
       score,
@@ -176,6 +198,29 @@ export async function POST(request: Request, { params }: { params: { sessionId: 
     },
     { status: 201 },
   );
+}
+
+/**
+ * The answer log record as the client sees it (REQ-DL-4.1), camelCased like FeedbackResult.
+ *
+ * `written` is what the insert echoed back; `sent` is what we asked it to store. They only
+ * differ if the echo is missing, which the insert succeeding says should not happen — but if
+ * it ever does, the row is committed all the same. Failing the request at that point would
+ * tell the student their answer was not recorded while it was, and their retry would come
+ * back as a 409. So the request stands and only submittedAt, the one value that exists solely
+ * in the database, is reported as unknown.
+ */
+function answerRecord(written: AnswerLogRow | null, sent: Omit<AnswerLogRow, 'submitted_at'>) {
+  const row = written ?? sent;
+
+  return {
+    logId: row.log_id,
+    sessionId: row.session_id,
+    questionId: row.question_id,
+    selectedOptionId: row.answer_id,
+    score: row.score,
+    submittedAt: written?.submitted_at ?? null,
+  };
 }
 
 /**

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -72,7 +72,20 @@ export type CurrentSessionResult = {
   completed?: boolean;
 };
 
+/** The answered_question_log row created by a submission (REQ-DL-4.1). */
+export type SubmittedAnswerRecord = {
+  logId: string;
+  sessionId: string;
+  questionId: string;
+  /** The answer_id that was recorded — named after the request field that carried it. */
+  selectedOptionId: string;
+  score: number;
+  /** Set by the database, so null only in the pathological case where the write did not echo it back. */
+  submittedAt: string | null;
+};
+
 export type SubmitAnswerResult = {
+  answer: SubmittedAnswerRecord;
   correct: boolean;
   explanation: string | null;
   score: number;


### PR DESCRIPTION
PR-Titel:
Return the created answer log record on answer submission (REQ-DL-4.1)

PR-Beschreibung:
Closes #26

## What changed

`POST /api/sessions/{sessionId}/answers` now returns the `answered_question_log`
record it just created, in addition to the existing outcome fields:

```json
"answer": {
  "logId": "…",
  "sessionId": "…",
  "questionId": "…",
  "selectedOptionId": "…",
  "score": 25,
  "submittedAt": "2026-08-03T…"
}