### PR TITLE
Added a test for the titles route

### DIFF
--- a/__tests__/api/titles.test.ts
+++ b/__tests__/api/titles.test.ts
@@ -7,12 +7,18 @@ const h = vi.hoisted(() => {
   const state = {
     queues: {} as Record<string, Result[]>,
     tables: [] as string[],
+    // Which rows the titles are built from is the whole definition of the response, so the
+    // filters are recorded rather than swallowed.
+    filters: [] as { table: string; column: string; value: unknown }[],
   };
 
   function makeBuilder(table: string, result: Result) {
     const builder: Record<string, unknown> = {
       select: () => builder,
-      eq: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
       // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly.
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),
@@ -75,6 +81,7 @@ describe('GET /api/students/{studentId}/titles', () => {
   beforeEach(() => {
     h.state.queues = {};
     h.state.tables = [];
+    h.state.filters = [];
   });
 
   it('returns 401 without a token', async () => {
@@ -104,6 +111,16 @@ describe('GET /api/students/{studentId}/titles', () => {
 
     expect(response.status).toBe(200);
     expect(body.titles).toEqual([]);
+  });
+
+  // REQ-GAM-BL-1.1 scopes the session lookup to the requesting student; title_definition is
+  // the same for everyone, so it is fetched unfiltered.
+  it('scopes the session_log query to the requesting student', async () => {
+    queueLookup([]);
+
+    await GET(req(), ctx);
+
+    expect(h.state.filters).toEqual([{ table: 'session_log', column: 'user_id', value: STUDENT_ID }]);
   });
 
   // AC 3: attempted but never passed.


### PR DESCRIPTION
- In order to give /api/students/{studentId}/titles the same safety net every other route has, as a maintainer, I want a test file in tests/api/ covering it, copying the mocking harness from the nearest existing test (e.g. score.test.ts).