### PR TITLE
Make first_name and last_name mandatory

### DIFF
--- a/__tests__/api/profile.test.ts
+++ b/__tests__/api/profile.test.ts
@@ -76,25 +76,35 @@ describe('Profile API routes', () => {
   });
 
   it('POST creates a new profile', async () => {
-    const response = await POST(req('POST', { username: 'testuser', biography: 'Hello!' }));
+    const response = await POST(req('POST', { username: 'testuser', biography: 'Hello!', first_name: 'Test', last_name: 'User' }));
     expect(response.status).toBe(201);
     expect(await response.json()).toEqual({ profile: mockProfile });
   });
 
   it('POST defaults role to student when the token carries no instructor metadata', async () => {
-    await POST(req('POST', { username: 'testuser', biography: 'Hello!' }));
+    await POST(req('POST', { username: 'testuser', biography: 'Hello!', first_name: 'Test', last_name: 'User' }));
     const insertedRow = mockBuilder.insert.mock.calls[0][0];
     expect(insertedRow).toMatchObject({ role: 'student' });
   });
 
   it('POST sets role to instructor when the auth user metadata says so (GitHub #82)', async () => {
-    await POST(req('POST', { username: 'prof', biography: 'Hi class' }, 'instructor-token'));
+    await POST(req('POST', { username: 'prof', biography: 'Hi class', first_name: 'Prof', last_name: 'Smith' }, 'instructor-token'));
     const insertedRow = mockBuilder.insert.mock.calls[0][0];
     expect(insertedRow).toMatchObject({ role: 'instructor' });
   });
 
   it('POST returns 400 when username is missing', async () => {
-    const response = await POST(req('POST', { biography: 'Hello!' }));
+    const response = await POST(req('POST', { biography: 'Hello!', first_name: 'Test', last_name: 'User' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('POST returns 400 when first_name is missing', async () => {
+    const response = await POST(req('POST', { username: 'testuser', biography: 'Hello!', last_name: 'User' }));
+    expect(response.status).toBe(400);
+  });
+
+  it('POST returns 400 when last_name is missing', async () => {
+    const response = await POST(req('POST', { username: 'testuser', biography: 'Hello!', first_name: 'Test' }));
     expect(response.status).toBe(400);
   });
 

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -70,13 +70,15 @@ export async function POST(request: Request) {
   const { username, biography, first_name, last_name, age, semester } = body as {
     username?: string;
     biography?: string;
-    first_name?: string | null;
-    last_name?: string | null;
+    first_name?: string;
+    last_name?: string;
     age?: number | null;
     semester?: number | null;
   };
 
   if (!username) return Response.json({ error: 'username is required.' }, { status: 400 });
+  if (!first_name?.trim()) return Response.json({ error: 'first_name is required.' }, { status: 400 });
+  if (!last_name?.trim()) return Response.json({ error: 'last_name is required.' }, { status: 400 });
 
   const ageError = rangeError(age, MIN_AGE, MAX_AGE, 'age');
   if (ageError) return Response.json({ error: ageError }, { status: 400 });
@@ -90,8 +92,8 @@ export async function POST(request: Request) {
       username,
       biography: biography ?? '',
       role: deriveRole(user),
-      first_name: first_name?.trim() || null,
-      last_name: last_name?.trim() || null,
+      first_name: first_name.trim(),
+      last_name: last_name.trim(),
       age: age ?? null,
       semester: semester ?? null,
     })
@@ -114,8 +116,8 @@ export async function PATCH(request: Request) {
   const body = await request.json();
   const { biography, first_name, last_name, age, semester } = body as {
     biography?: string;
-    first_name?: string | null;
-    last_name?: string | null;
+    first_name?: string;
+    last_name?: string;
     age?: number | null;
     semester?: number | null;
   };
@@ -123,8 +125,14 @@ export async function PATCH(request: Request) {
   const updates: Record<string, unknown> = {};
 
   if (biography !== undefined) updates.biography = biography;
-  if (first_name !== undefined) updates.first_name = first_name?.trim() || null;
-  if (last_name !== undefined) updates.last_name = last_name?.trim() || null;
+  if (first_name !== undefined) {
+    if (!first_name.trim()) return Response.json({ error: 'first_name cannot be empty.' }, { status: 400 });
+    updates.first_name = first_name.trim();
+  }
+  if (last_name !== undefined) {
+    if (!last_name.trim()) return Response.json({ error: 'last_name cannot be empty.' }, { status: 400 });
+    updates.last_name = last_name.trim();
+  }
 
   if (age !== undefined) {
     const ageError = rangeError(age, MIN_AGE, MAX_AGE, 'age');

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -13,6 +13,7 @@ import { getInitials } from '../../lib/initials';
 type ProfileDraft = {
   first_name: string;
   last_name: string;
+
   age: string;
   semester: string;
   biography: string;
@@ -126,10 +127,10 @@ export default function ProfilePage() {
     return null;
   }
 
-  function draftFromProfile(p: { first_name: string | null; last_name: string | null; age: number | null; semester: number | null; biography: string }): ProfileDraft {
+  function draftFromProfile(p: { first_name: string; last_name: string; age: number | null; semester: number | null; biography: string }): ProfileDraft {
     return {
-      first_name: p.first_name ?? '',
-      last_name: p.last_name ?? '',
+      first_name: p.first_name,
+      last_name: p.last_name,
       age: p.age != null ? String(p.age) : '',
       semester: p.semester != null ? String(p.semester) : '',
       biography: p.biography,

--- a/components/UserProvider.tsx
+++ b/components/UserProvider.tsx
@@ -11,8 +11,8 @@ export type Profile = {
   biography: string;
   avatar_url: string | null;
   role: Role;
-  first_name: string | null;
-  last_name: string | null;
+  first_name: string;
+  last_name: string;
   age: number | null;
   semester: number | null;
 };

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -31,8 +31,8 @@ CREATE TABLE "user" (
     -- Issue #61: optional profile fields, filled in on the profile page
     -- after account creation. All nullable — a user_id with a username
     -- is still a valid row without these.
-    first_name text,
-    last_name text,
+    first_name text NOT NULL,
+    last_name text NOT NULL,
     age int2 CHECK (age IS NULL OR (age > 0 AND age < 130)),
     semester int2 CHECK (semester IS NULL OR (semester > 0 AND semester <= 20)),
     PRIMARY KEY (user_id));


### PR DESCRIPTION
Made first_name and last_name mandatory fields in the database schema and updated all related API routes accordingly.

Set first_name and last_name to NOT NULL in supabase/schema.sql
Added validation in POST /api/profile — returns 400 if either field is missing
Added validation in PATCH /api/profile — rejects updates that would clear either field
Updated existing tests and added new ones for the validation
resolve #98