### PR TITLE
fix(play): refresh attempts caches before navigating after completion

### DIFF
--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -180,14 +180,24 @@ export default function PlayActivityPage({
     if (!outcome) return;
     if (outcome.completed) {
       if (token && profile?.user_id) {
-        void loadStudentScore(token, profile.user_id, { forceRefresh: true });
-        void loadSessions(token, "completed", {
-          studentId: profile.user_id,
-          forceRefresh: true,
+        // Refresh the score, the completed-sessions list, and the previous-attempts
+        // table caches BEFORE navigating, so the activity page's history table shows
+        // the new session_log record instead of the stale cached one. These calls
+        // were previously fire-and-forget, so a fast navigation could read the old
+        // cache and leave the table one attempt behind. GitHub #130.
+        void Promise.all([
+          loadStudentScore(token, profile.user_id, { forceRefresh: true }),
+          loadSessions(token, "completed", {
+            studentId: profile.user_id,
+            forceRefresh: true,
+          }),
+          loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
+            forceRefresh: true,
+          }),
+        ]).then(() => {
+          router.push(`/activities/${activity!.slug}`);
         });
-        void loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
-          forceRefresh: true,
-        });
+        return;
       }
       router.push(`/activities/${activity!.slug}`);
       return;


### PR DESCRIPTION
Closes #130

## The bug

After finishing a quiz, `handleContinue` fired three cache refreshes — `loadStudentScore`, `loadSessions(completed)`, `loadCompletedAttempts` — as fire-and-forget (`void`), then navigated to `/activities/[slug]` immediately. The activity page mounted and read the previous-attempts table from the localStorage cache (`loadCompletedAttempts` serves from cache when present). If the network refresh hadn't written the new cache yet, the table showed the pre-completion list — one attempt behind until the user manually reloaded.

## The fix

Await all three `forceRefresh` calls (`Promise.all`) before navigating, so the caches are guaranteed to carry the new `session_log` record when the activity page mounts and re-reads them. Navigation still happens directly when token or profile is unavailable, preserving the original fallback.

## Verification

- `npm test`: 179/179 pass (17 files).
- `npx tsc --noEmit`: same 4 pre-existing errors in `__tests__/api/avatar.test.ts` and `__tests__/api/profile.test.ts` as on the base branch — this change adds none.
- Diff: 1 file, +17/−7, play page only.