### PR TITLE
BUG solved: Shuffle answer options better

### DIFF
--- a/__tests__/api/questions-options.test.ts
+++ b/__tests__/api/questions-options.test.ts
@@ -71,8 +71,15 @@ describe('GET /api/questions/:questionId/options', () => {
     const res = await GET(makeRequest('q-1'), PARAMS('q-1'));
     expect(res.status).toBe(200);
     const body = await res.json();
+    // Order isn't asserted here — GitHub #129 has this route shuffle options, so only the set
+    // (and the shape: no is_correct/explanation) is guaranteed, not a fixed position.
     expect(body.options).toHaveLength(2);
-    expect(body.options[0]).toEqual({ answer_id: 'a-1', option_text: 'Option A' });
+    expect(body.options).toEqual(
+      expect.arrayContaining([
+        { answer_id: 'a-1', option_text: 'Option A' },
+        { answer_id: 'a-2', option_text: 'Option B' },
+      ]),
+    );
     expect(body.options[0]).not.toHaveProperty('is_correct');
     expect(body.options[0]).not.toHaveProperty('explanation');
   });

--- a/__tests__/api/sessions-current.test.ts
+++ b/__tests__/api/sessions-current.test.ts
@@ -169,7 +169,15 @@ describe('GET /api/sessions/current', () => {
     const body = await (await GET(req())).json();
 
     expect(JSON.stringify(body.questions)).not.toContain('is_correct');
-    expect(body.questions[0].options[0]).toEqual({ answer_id: 'a-1-1', option_text: 'Option 1' });
+    // Order isn't asserted here — GitHub #129 has loadSessionQuestions shuffle options, so only
+    // the set (and the shape: no is_correct/explanation) is guaranteed, not a fixed position.
+    expect(body.questions[0].options).toHaveLength(2);
+    expect(body.questions[0].options).toEqual(
+      expect.arrayContaining([
+        { answer_id: 'a-1-1', option_text: 'Option 1' },
+        { answer_id: 'a-1-2', option_text: 'Option 2' },
+      ]),
+    );
   });
 
   // Feedback for questions the student has already committed to is theirs to see.

--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -207,7 +207,15 @@ describe('POST /api/sessions', () => {
     const body = await response.json();
 
     expect(JSON.stringify(body)).not.toContain('is_correct');
-    expect(body.questions[0].options[0]).toEqual({ answer_id: 'a-0-1', option_text: 'Option 1' });
+    // Order isn't asserted here — GitHub #129 has loadSessionQuestions shuffle options, so only
+    // the set (and the shape: no is_correct/explanation) is guaranteed, not a fixed position.
+    expect(body.questions[0].options).toHaveLength(2);
+    expect(body.questions[0].options).toEqual(
+      expect.arrayContaining([
+        { answer_id: 'a-0-1', option_text: 'Option 1' },
+        { answer_id: 'a-0-2', option_text: 'Option 2' },
+      ]),
+    );
   });
 
   // AC 6

--- a/__tests__/lib/shuffleArray.test.ts
+++ b/__tests__/lib/shuffleArray.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { shuffleArray } from '../../lib/shuffleArray';
+
+describe('shuffleArray', () => {
+  it('does not mutate the input array', () => {
+    const input = [1, 2, 3, 4];
+    const copy = [...input];
+    shuffleArray(input);
+    expect(input).toEqual(copy);
+  });
+
+  it('keeps every original element, with no loss or duplication', () => {
+    const input = ['a', 'b', 'c', 'd', 'e'];
+    const result = shuffleArray(input);
+
+    expect(result).toHaveLength(input.length);
+    expect([...result].sort()).toEqual([...input].sort());
+  });
+
+  it('returns an empty array unchanged', () => {
+    expect(shuffleArray([])).toEqual([]);
+  });
+
+  it('produces different orderings across repeated calls (not deterministic)', () => {
+    const input = Array.from({ length: 10 }, (_, i) => i);
+    const orderings = new Set(Array.from({ length: 20 }, () => shuffleArray(input).join(',')));
+
+    // With 10! possible orderings, landing on the exact same one all 20 times would indicate a
+    // broken (non-random, or effectively no-op) shuffle rather than bad luck.
+    expect(orderings.size).toBeGreaterThan(1);
+  });
+
+  it('can place any element first, not just the one already at index 0 (GitHub #129 regression check)', () => {
+    // Mirrors the seed data's real bug: the correct answer was always inserted first, and
+    // nothing downstream reordered it, so options[0] was always the correct one.
+    const input = ['correct', 'wrong-1', 'wrong-2', 'wrong-3'];
+    const firstPositions = new Set(Array.from({ length: 200 }, () => shuffleArray(input)[0]));
+
+    expect(firstPositions.size).toBeGreaterThan(1);
+  });
+});

--- a/app/api/questions/[questionId]/options/route.ts
+++ b/app/api/questions/[questionId]/options/route.ts
@@ -1,4 +1,5 @@
 import { getSupabaseClient } from '../../../../../lib/supabase';
+import { shuffleArray } from '../../../../../lib/shuffleArray';
 
 /**
  * GET /api/questions/:questionId/options
@@ -48,9 +49,13 @@ export async function GET(
 
   if (error) return Response.json({ error: error.message }, { status: 500 });
 
-  const options = ((data ?? []) as unknown as { answer: { answer_id: string; option_text: string } | null }[])
-    .map((row) => row.answer)
-    .filter((answer): answer is { answer_id: string; option_text: string } => answer !== null);
+  // GitHub #129: question_to_answer has no ordering of its own, and seed data always inserts
+  // the correct answer first — shuffle so the UI doesn't display it in a predictable position.
+  const options = shuffleArray(
+    ((data ?? []) as unknown as { answer: { answer_id: string; option_text: string } | null }[])
+      .map((row) => row.answer)
+      .filter((answer): answer is { answer_id: string; option_text: string } => answer !== null),
+  );
 
   return Response.json({ options }, { status: 200 });
 }

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -3,6 +3,7 @@
 
 import { getSupabaseClient } from './supabase';
 import { DEFAULT_QUESTION_MAX_SCORE, SESSION_COLUMNS } from './sessionRules';
+import { shuffleArray } from './shuffleArray';
 
 export type SupabaseClient = NonNullable<ReturnType<typeof getSupabaseClient>>;
 
@@ -77,7 +78,17 @@ export async function findInProgressSession(
   return { session: error ? null : data, error };
 }
 
-/** The drawn questions in presentation order, with options but without the solution. */
+/**
+ * The drawn questions in presentation order, with options but without the solution.
+ *
+ * GitHub #129: question_to_answer carries no ordering of its own, and supabase/seed.sql always
+ * inserts (and maps) the correct answer first — so without shuffling, options[0] is the correct
+ * one for every question, every time. Shuffled here, once per fetch, rather than client-side:
+ * this is the only place a question's options get assembled before going out over the wire, so
+ * every caller (POST /api/sessions on start/resume, GET /api/sessions/current) gets a freshly
+ * randomized order on every call — including resuming or restarting the same activity — while
+ * the client just renders whatever order it received and never re-shuffles on its own re-renders.
+ */
 export async function loadSessionQuestions(supabase: SupabaseClient, sessionId: string) {
   const { data, error } = await supabase
     .from('session_to_question')
@@ -96,9 +107,11 @@ export async function loadSessionQuestions(supabase: SupabaseClient, sessionId: 
       difficulty_level: row.question!.difficulty_level,
       activity_type: row.question!.activity_type,
       max_score: row.question!.max_score ?? DEFAULT_QUESTION_MAX_SCORE,
-      options: (row.question!.question_to_answer ?? [])
-        .map((link) => link.answer)
-        .filter((answer): answer is { answer_id: string; option_text: string } => answer !== null),
+      options: shuffleArray(
+        (row.question!.question_to_answer ?? [])
+          .map((link) => link.answer)
+          .filter((answer): answer is { answer_id: string; option_text: string } => answer !== null),
+      ),
     }));
 
   return { questions, error: null };

--- a/lib/shuffleArray.ts
+++ b/lib/shuffleArray.ts
@@ -1,0 +1,15 @@
+/**
+ * Fisher-Yates (Durstenfeld variant) shuffle — every permutation of `array` is equally likely,
+ * unlike `array.sort(() => Math.random() - 0.5)`, whose comparator-based bias favors some
+ * orderings over others. Returns a new array; the input is never mutated.
+ */
+export function shuffleArray<T>(array: T[]): T[] {
+  const result = array.slice();
+
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+
+  return result;
+}


### PR DESCRIPTION
Fix answer options always showing correct answer first:
question_to_answer had no ordering of its own, and seed.sql always
inserts the correct answer first, so options[0] was the correct
answer for every question. Adds a proper Fisher-Yates shuffleArray()
helper and applies it in loadSessionQuestions (session start/resume)
and GET /api/questions/:questionId/options — the two places option
lists get assembled before going out over the wire.
resolves #129
