### PR TITLE
UI: Create UI Mockup to add questions and answers

### DIFF
--- a/app/instructor/questions/page.tsx
+++ b/app/instructor/questions/page.tsx
@@ -2,45 +2,99 @@
 
 import { useState } from 'react';
 import { AppShell } from '../../../components/AppShell';
-import { ACTIVITIES, type Difficulty, questionsForLevel } from '../../../lib/activityContent';
+import { AddQuestionModal } from '../../../components/AddQuestionModal';
+import { ACTIVITIES, getActivityByType } from '../../../lib/activityContent';
+import type { ActivityType } from '../../../lib/activityTypes';
+import { MOCK_QUESTIONS } from '../../../lib/mockQuestions';
+import type { QuizQuestion } from '../../../lib/quizQuestionTypes';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
-const LEVEL_LABEL: Record<Difficulty, string> = { 1: 'Easy', 2: 'Medium', 3: 'Hard' };
+const LEVEL_LABEL: Record<1 | 2 | 3, string> = { 1: 'Easy', 2: 'Medium', 3: 'Hard' };
 const LEVEL_OPTIONS = ['all', 1, 2, 3] as const;
+const HIGHLIGHT_MS = 4000;
+const TOAST_MS = 3200;
 
 /**
- * Read-only browse of the question bank (GitHub #82, requirement 4: "alle Fragen, alle
- * Quiz-Typen, alle Schwierigkeitsstufen... rein lesend"). Every option renders as a plain div,
- * never a button, and there is no submit/start affordance anywhere on this page — an instructor
- * can see the correct answer and its explanation, not attempt the question.
+ * Read-only browse of the question bank, plus adding a question (GitHub #120) — a popup form,
+ * not a separate page, per the issue. Everything here runs on MOCK_QUESTIONS in local state;
+ * see lib/mockQuestions.ts for what replacing it with a real fetch/mutation involves.
  */
 export default function InstructorQuestionsPage() {
   const { loading, authorized } = useRequireRole('instructor');
-  const [activitySlug, setActivitySlug] = useState(ACTIVITIES[0].slug);
-  const [level, setLevel] = useState<Difficulty | 'all'>('all');
+
+  const [questions, setQuestions] = useState<QuizQuestion[]>(MOCK_QUESTIONS);
+  const [activityType, setActivityType] = useState<ActivityType>(ACTIVITIES[0].activityType);
+  const [level, setLevel] = useState<1 | 2 | 3 | 'all'>('all');
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   if (loading || !authorized) return null;
 
-  const activity = ACTIVITIES.find((item) => item.slug === activitySlug) ?? ACTIVITIES[0];
-  const questions = level === 'all' ? activity.questionBank : questionsForLevel(activity, level);
+  const visibleQuestions = questions.filter((question) => {
+    if (question.quizType !== activityType) return false;
+    if (level !== 'all' && question.level !== level) return false;
+    return true;
+  });
+
+  function handleSaveQuestion(question: QuizQuestion) {
+    setQuestions((current) => [question, ...current]);
+    // Jump the view to wherever the new question landed — otherwise "added" but not visible
+    // (wrong tab/level still selected) would look like saving silently failed.
+    setActivityType(question.quizType);
+    setLevel(question.level);
+    setHighlightedId(question.id);
+    setToastMessage(`Question added to ${getActivityByType(question.quizType)?.name ?? question.quizType}.`);
+
+    window.setTimeout(() => setToastMessage(null), TOAST_MS);
+    window.setTimeout(() => setHighlightedId(null), HIGHLIGHT_MS);
+  }
 
   return (
     <AppShell active="instructor-questions">
       <div className="mx-auto max-w-3xl">
-        <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">Question Bank</h1>
-        <p className="mb-6 max-w-2xl text-sm font-semibold text-gray-500">
-          Every question across every activity and difficulty level — read-only, there is nothing here to answer or start.
-        </p>
+        <div className="mb-1 flex flex-wrap items-start justify-between gap-4">
+          <div>
+            <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">Question Bank</h1>
+            <p className="max-w-2xl text-sm font-semibold text-gray-500">
+              Every question across every activity and difficulty level. Add a new question to any quiz at any level.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowAddModal(true)}
+            className="flex flex-none items-center gap-2 rounded-full bg-brand-purple px-5 py-2.5 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+          >
+            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round">
+              <path d="M12 5v14M5 12h14" />
+            </svg>
+            New Question
+          </button>
+        </div>
 
-        <div className="mb-6 flex flex-wrap items-center gap-4">
+        {toastMessage ? (
+          <div
+            role="status"
+            className="mb-5 mt-5 flex items-center gap-2.5 rounded-brand-md border border-brand-teal/40 bg-brand-teal/10 px-4 py-3 text-sm font-bold text-brand-teal-dark"
+          >
+            <span className="flex h-5 w-5 flex-none items-center justify-center rounded-full bg-brand-teal text-brand-teal-ink">
+              <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round">
+                <path d="M20 6 9 17l-5-5" />
+              </svg>
+            </span>
+            {toastMessage}
+          </div>
+        ) : null}
+
+        <div className="mb-6 mt-6 flex flex-wrap items-center gap-4">
           <div className="flex flex-wrap gap-1.5">
             {ACTIVITIES.map((item) => (
               <button
                 key={item.slug}
                 type="button"
-                onClick={() => setActivitySlug(item.slug)}
+                onClick={() => setActivityType(item.activityType)}
                 className={`rounded-full border px-3.5 py-1.5 text-xs font-bold transition ${
-                  activitySlug === item.slug
+                  activityType === item.activityType
                     ? 'border-brand-purple bg-brand-purple text-white'
                     : 'border-gray-300 bg-white text-gray-600 hover:border-brand-purple hover:text-brand-purple'
                 }`}
@@ -68,38 +122,63 @@ export default function InstructorQuestionsPage() {
         </div>
 
         <div className="space-y-4">
-          {questions.map((question) => (
-            <div key={question.id} className="rounded-brand-lg border border-gray-100 bg-gray-50 p-5">
-              <span className="mb-3 inline-block rounded-full bg-white px-2.5 py-1 text-xs font-extrabold text-gray-500">
-                {LEVEL_LABEL[question.difficulty]} · Level {question.difficulty}
-              </span>
-              <p className="mb-4 text-sm font-bold text-brand-navy">{question.prompt}</p>
-              <div className="space-y-2">
-                {question.options.map((option) => (
-                  <div
-                    key={option.id}
-                    className={`rounded-brand-md border p-3 ${
-                      option.correct ? 'border-brand-teal/40 bg-brand-teal/10' : 'border-gray-200 bg-white'
-                    }`}
-                  >
-                    <div className="flex items-start justify-between gap-2">
-                      <p className={`text-sm font-semibold ${option.correct ? 'text-brand-teal-dark' : 'text-gray-700'}`}>
-                        {option.text}
-                      </p>
-                      {option.correct ? (
-                        <span className="flex-none rounded-full bg-brand-teal/20 px-2 py-0.5 text-[11px] font-extrabold text-brand-teal-dark">
-                          Correct
-                        </span>
-                      ) : null}
+          {visibleQuestions.length === 0 ? (
+            <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
+              No questions yet at this level.
+            </p>
+          ) : (
+            visibleQuestions.map((question) => (
+              <div
+                key={question.id}
+                className={`rounded-brand-lg border bg-gray-50 p-5 transition ${
+                  question.id === highlightedId ? 'border-brand-teal/50 ring-2 ring-brand-teal/30' : 'border-gray-100'
+                }`}
+              >
+                <div className="mb-3 flex flex-wrap items-center gap-2">
+                  <span className="inline-block rounded-full bg-white px-2.5 py-1 text-xs font-extrabold text-gray-500">
+                    {LEVEL_LABEL[question.level]} · Level {question.level}
+                  </span>
+                  {question.id === highlightedId ? (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-brand-teal/20 px-2.5 py-1 text-[11px] font-extrabold text-brand-teal-dark">
+                      ✓ Just added
+                    </span>
+                  ) : null}
+                </div>
+                <p className="mb-4 text-sm font-bold text-brand-navy">{question.questionText}</p>
+                <div className="space-y-2">
+                  {question.answerOptions.map((option) => (
+                    <div
+                      key={option.id}
+                      className={`rounded-brand-md border p-3 ${
+                        option.isCorrect ? 'border-brand-teal/40 bg-brand-teal/10' : 'border-gray-200 bg-white'
+                      }`}
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <p className={`text-sm font-semibold ${option.isCorrect ? 'text-brand-teal-dark' : 'text-gray-700'}`}>
+                          {option.text}
+                        </p>
+                        {option.isCorrect ? (
+                          <span className="flex-none rounded-full bg-brand-teal/20 px-2 py-0.5 text-[11px] font-extrabold text-brand-teal-dark">
+                            Correct
+                          </span>
+                        ) : null}
+                      </div>
                     </div>
-                    <p className="mt-1.5 text-xs font-semibold text-gray-500">{option.explanation}</p>
-                  </div>
-                ))}
+                  ))}
+                </div>
+                <p className="mt-3 text-xs font-semibold text-gray-500">
+                  <span className="font-extrabold text-gray-600">Explanation: </span>
+                  {question.explanation}
+                </p>
               </div>
-            </div>
-          ))}
+            ))
+          )}
         </div>
       </div>
+
+      {showAddModal ? (
+        <AddQuestionModal defaultQuizType={activityType} onClose={() => setShowAddModal(false)} onSave={handleSaveQuestion} />
+      ) : null}
     </AppShell>
   );
 }

--- a/components/AddQuestionModal.tsx
+++ b/components/AddQuestionModal.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { AnswerOptionField } from './AnswerOptionField';
+import type { ActivityType } from '../lib/activityTypes';
+import type { QuizQuestion } from '../lib/quizQuestionTypes';
+
+const QUIZ_OPTIONS: { value: ActivityType; label: string }[] = [
+  { value: 'IDENTIFY_WEAK_USER_STORIES', label: 'Identify Weak User Stories' },
+  { value: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA', label: 'Identify Weak Acceptance Criteria' },
+];
+
+const LEVEL_OPTIONS: { value: 1 | 2 | 3; label: string }[] = [
+  { value: 1, label: 'Easy · Level 1' },
+  { value: 2, label: 'Medium · Level 2' },
+  { value: 3, label: 'Hard · Level 3' },
+];
+
+const OPTION_COUNT = 4;
+const EMPTY_OPTIONS = Array.from({ length: OPTION_COUNT }, () => '');
+
+type FormErrors = {
+  questionText?: string;
+  options?: string;
+  correctOption?: string;
+  explanation?: string;
+};
+
+const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Popup form for adding a question to an existing quiz (GitHub #120). Mounted/unmounted by the
+ * parent (`{showAddModal ? <AddQuestionModal .../> : null}`, the same pattern ImageCropModal
+ * already uses) rather than taking its own `isOpen` prop — existence on the page *is* "open".
+ *
+ * Accessibility: focus moves into the form on mount and returns to whatever had focus before
+ * (the "New Question" button) on close; Escape closes; Tab is trapped inside the panel while
+ * it's open, since this is a true modal — nothing behind it should be reachable by keyboard.
+ */
+export function AddQuestionModal({
+  defaultQuizType,
+  onClose,
+  onSave,
+}: {
+  defaultQuizType: ActivityType;
+  onClose: () => void;
+  onSave: (question: QuizQuestion) => void;
+}) {
+  const [quizType, setQuizType] = useState<ActivityType>(defaultQuizType);
+  const [level, setLevel] = useState<1 | 2 | 3>(1);
+  const [questionText, setQuestionText] = useState('');
+  const [optionTexts, setOptionTexts] = useState<string[]>(EMPTY_OPTIONS);
+  const [correctIndex, setCorrectIndex] = useState<number | null>(null);
+  const [explanation, setExplanation] = useState('');
+  const [errors, setErrors] = useState<FormErrors>({});
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const firstFieldRef = useRef<HTMLSelectElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    firstFieldRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !panelRef.current) return;
+
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function close() {
+    onClose();
+    previouslyFocusedRef.current?.focus();
+  }
+
+  function updateOptionText(index: number, value: string) {
+    setOptionTexts((current) => current.map((text, i) => (i === index ? value : text)));
+  }
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+
+    const nextErrors: FormErrors = {};
+    if (!questionText.trim()) nextErrors.questionText = 'Question text is required.';
+    if (optionTexts.some((text) => !text.trim())) nextErrors.options = `All ${OPTION_COUNT} answer options must be filled in.`;
+    if (correctIndex === null) nextErrors.correctOption = 'Select which answer option is correct.';
+    if (!explanation.trim()) nextErrors.explanation = 'Explanation is required.';
+
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    onSave({
+      id: `q-${Date.now()}`,
+      quizType,
+      level,
+      questionText: questionText.trim(),
+      answerOptions: optionTexts.map((text, index) => ({
+        id: `q-${Date.now()}-opt-${index}`,
+        text: text.trim(),
+        isCorrect: index === correctIndex,
+      })),
+      explanation: explanation.trim(),
+    });
+
+    close();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) close();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-question-title"
+        className="max-h-[90vh] w-full max-w-xl overflow-y-auto rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
+      >
+        <div className="mb-1 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wide text-brand-gold">Question Bank</p>
+            <h2 id="add-question-title" className="mt-1 text-xl font-extrabold text-white">
+              Add a New Question
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-full border border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted transition hover:text-white"
+          >
+            <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-5">
+          <label className="mb-4 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+            Quiz
+            <select
+              ref={firstFieldRef}
+              value={quizType}
+              onChange={(event) => setQuizType(event.target.value as ActivityType)}
+              className="mt-1.5 block w-full rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
+            >
+              {QUIZ_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="mb-4">
+            <span className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">Difficulty Level</span>
+            <div className="flex gap-2">
+              {LEVEL_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setLevel(option.value)}
+                  aria-pressed={level === option.value}
+                  className={`flex-1 rounded-brand-md border px-2.5 py-2 text-xs font-extrabold transition ${
+                    level === option.value
+                      ? 'border-brand-purple bg-brand-purple text-white'
+                      : 'border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted hover:text-white'
+                  }`}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+            Question Prompt
+            <textarea
+              value={questionText}
+              onChange={(event) => setQuestionText(event.target.value)}
+              rows={3}
+              placeholder="e.g. Which of these user stories is the weakest?"
+              className="mt-1.5 block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
+            />
+          </label>
+          {errors.questionText ? <p className="mb-4 text-xs font-bold text-brand-danger">{errors.questionText}</p> : <div className="mb-4" />}
+
+          <span className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">Answer Options</span>
+          {optionTexts.map((text, index) => (
+            <AnswerOptionField
+              key={index}
+              index={index}
+              text={text}
+              isSelected={correctIndex === index}
+              onTextChange={(value) => updateOptionText(index, value)}
+              onSelect={() => setCorrectIndex(index)}
+            />
+          ))}
+          {errors.options ? <p className="mb-1 text-xs font-bold text-brand-danger">{errors.options}</p> : null}
+          {errors.correctOption ? <p className="mb-1 text-xs font-bold text-brand-danger">{errors.correctOption}</p> : null}
+          <p className="mb-4 text-xs font-semibold text-brand-ink-muted">Select the radio button next to the correct answer.</p>
+
+          <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+            Explanation (shown when a student answers incorrectly)
+            <textarea
+              value={explanation}
+              onChange={(event) => setExplanation(event.target.value)}
+              rows={3}
+              placeholder="Explain why the correct option is the strongest answer…"
+              className="mt-1.5 block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
+            />
+          </label>
+          {errors.explanation ? <p className="mb-4 text-xs font-bold text-brand-danger">{errors.explanation}</p> : null}
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={close}
+              className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+            >
+              Save Question
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/AnswerOptionField.tsx
+++ b/components/AnswerOptionField.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+/**
+ * One answer-option row inside AddQuestionModal (GitHub #120): a letter marker, a native radio
+ * button to mark this option as the correct one (single-choice, per REQ-PL-6.4 — native input
+ * rather than a custom-styled control, so keyboard nav and screen readers work for free), and
+ * the option's text field.
+ */
+export function AnswerOptionField({
+  index,
+  text,
+  isSelected,
+  onTextChange,
+  onSelect,
+}: {
+  index: number;
+  text: string;
+  isSelected: boolean;
+  onTextChange: (value: string) => void;
+  onSelect: () => void;
+}) {
+  const letter = String.fromCharCode(65 + index);
+  const inputId = `answer-option-${index}`;
+
+  return (
+    <div className="mb-2.5 flex items-center gap-2.5">
+      <span className="w-5 flex-none text-center text-xs font-extrabold text-brand-ink-muted">{letter}</span>
+      <input
+        type="radio"
+        name="correct-answer"
+        id={`${inputId}-radio`}
+        checked={isSelected}
+        onChange={onSelect}
+        className="h-[18px] w-[18px] flex-none accent-brand-teal"
+        aria-label={`Mark option ${letter} as the correct answer`}
+      />
+      <label htmlFor={inputId} className="sr-only">
+        Answer option {letter}
+      </label>
+      <input
+        type="text"
+        id={inputId}
+        value={text}
+        onChange={(event) => onTextChange(event.target.value)}
+        placeholder={`Answer option ${letter}…`}
+        className="flex-1 rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
+      />
+    </div>
+  );
+}

--- a/lib/mockQuestions.ts
+++ b/lib/mockQuestions.ts
@@ -1,0 +1,233 @@
+import type { QuizQuestion } from './quizQuestionTypes';
+
+function options(
+  texts: [string, string, string, string],
+  correctIndex: number,
+  idPrefix: string,
+): QuizQuestion['answerOptions'] {
+  return texts.map((text, index) => ({
+    id: `${idPrefix}-opt-${index}`,
+    text,
+    isCorrect: index === correctIndex,
+  }));
+}
+
+/**
+ * Placeholder for the real question bank endpoint the Instructor's Question Bank + "Add
+ * Question" flow (GitHub #120) is designed against — nothing behind this reads the database.
+ * Whoever wires up the real backend replaces this export (and the local-state seeding in
+ * app/instructor/questions/page.tsx) with a fetch returning QuizQuestion[]; AddQuestionModal,
+ * AnswerOptionField, and the page's rendering don't change.
+ */
+export const MOCK_QUESTIONS: QuizQuestion[] = [
+  {
+    id: 'mock-wus-1-1',
+    quizType: 'IDENTIFY_WEAK_USER_STORIES',
+    level: 1,
+    questionText: 'Which of these user stories is the weakest?',
+    answerOptions: options(
+      [
+        'As a registered student, I want to log in with my school email, so that only verified students can access the practice activities.',
+        'As a user, I want the app to be good, so that I enjoy using it.',
+        'As a student, I want to see my score right after finishing an activity, so that I know how I did.',
+        'As an instructor, I want a list of my students, so that I can see who is enrolled.',
+      ],
+      1,
+      'mock-wus-1-1',
+    ),
+    explanation: '"Be good" and "enjoy using it" can\'t be tested or estimated — there\'s nothing here a developer could actually build against.',
+  },
+  {
+    id: 'mock-wus-1-2',
+    quizType: 'IDENTIFY_WEAK_USER_STORIES',
+    level: 1,
+    questionText: 'Which of these user stories is the weakest?',
+    answerOptions: options(
+      [
+        'As a student, I want the system to be fast, so that I don\'t get bored.',
+        'As a student, I want to resume an abandoned activity from where I left off, so that I don\'t lose progress.',
+        'As an instructor, I want to export a class\'s results as a spreadsheet, so that I can archive them each semester.',
+        'As a student, I want to see which activity types exist, so that I can choose one to practice.',
+      ],
+      0,
+      'mock-wus-1-2',
+    ),
+    explanation: '"Fast" and "bored" have no numbers or observable behavior attached — there\'s no way to verify this is satisfied.',
+  },
+  {
+    id: 'mock-wus-1-3',
+    quizType: 'IDENTIFY_WEAK_USER_STORIES',
+    level: 1,
+    questionText: 'Which of these user stories is the weakest?',
+    answerOptions: options(
+      [
+        'As a student, I want a nice looking app, so that I like it.',
+        'As a student, I want to pick one answer per question and submit it, so that my choice is recorded and scored.',
+        'As a student, I want to see the explanation for my chosen answer, so that I understand why it was right or wrong.',
+        'As an instructor, I want to see how many students completed an activity, so that I can gauge participation.',
+      ],
+      0,
+      'mock-wus-1-3',
+    ),
+    explanation: '"Nice looking" and "like it" are subjective with no acceptance test possible — this story can\'t be verified as done.',
+  },
+  {
+    id: 'mock-wus-2-1',
+    quizType: 'IDENTIFY_WEAK_USER_STORIES',
+    level: 2,
+    questionText: 'Which of these user stories is the weakest?',
+    answerOptions: options(
+      [
+        'As a student, I want to abandon an in-progress activity, so that I can start fresh.',
+        'As a student, I want better feedback on my answers, so that I learn more effectively.',
+        'As a student and instructor, I want to view activity results, so that we can both track progress.',
+        'As a student, I want my cumulative score to update after each completed activity, so that my profile always reflects my effort.',
+      ],
+      1,
+      'mock-wus-2-1',
+    ),
+    explanation: '"Better feedback" and "more effectively" aren\'t defined — better than what, and how would you measure "more effectively"?',
+  },
+  {
+    id: 'mock-wus-2-2',
+    quizType: 'IDENTIFY_WEAK_USER_STORIES',
+    level: 2,
+    questionText: 'Which of these user stories is the weakest?',
+    answerOptions: options(
+      [
+        'As a student, I want the navigation bar to be intuitive, so that I can find things easily.',
+        'As a student, I want a list of prior attempts with date and score, so that I can track my history.',
+        'As a student, I want the app to remember my last activity across my phone, laptop, and a shared lab computer.',
+        'As an instructor, I want to filter activity results by difficulty level, so that I can see how students perform at each level.',
+      ],
+      0,
+      'mock-wus-2-2',
+    ),
+    explanation: '"Intuitive" and "easily" aren\'t observable — you can\'t write a pass/fail check for either one.',
+  },
+  {
+    id: 'mock-wus-3-1',
+    quizType: 'IDENTIFY_WEAK_USER_STORIES',
+    level: 3,
+    questionText: 'Which of these user stories is the weakest?',
+    answerOptions: options(
+      [
+        'As a student retaking a failed level, I want a newly selected set of random questions, so that I can\'t just memorize answers.',
+        'As a student, I want the system to be fair when selecting my next questions, so that I\'m evaluated accurately.',
+        'As a student, I want each question to show its difficulty level, so that I understand why I\'m seeing it.',
+        'As an instructor, I want to see the average score per difficulty level across my class, so that I can judge whether a level is too hard.',
+      ],
+      1,
+      'mock-wus-3-1',
+    ),
+    explanation: '"Fair" and "accurate" define no rule a developer could implement or test.',
+  },
+  {
+    id: 'mock-wac-1-1',
+    quizType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+    level: 1,
+    questionText:
+      'User story: "As a student, I want to submit my answer to a question, so that it counts toward my score." Which acceptance criterion is weakest?',
+    answerOptions: options(
+      [
+        'Given the student has selected one option, when they click Submit, then the system records that option as their answer.',
+        'The submission process should work properly.',
+        'Given no option is selected, when they click Submit, then the button remains disabled and no answer is recorded.',
+        'Given an answer has been submitted, when the student tries to submit again, then the system ignores the second submission.',
+      ],
+      1,
+      'mock-wac-1-1',
+    ),
+    explanation: '"Work properly" defines no observable behavior — there\'s no way to test whether this criterion passes or fails.',
+  },
+  {
+    id: 'mock-wac-1-2',
+    quizType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+    level: 1,
+    questionText:
+      'User story: "As a student, I want to see feedback after answering, so that I understand my mistake." Which acceptance criterion is weakest?',
+    answerOptions: options(
+      [
+        'Given the selected option is incorrect, when feedback is shown, then explanations for the selected and correct option are both displayed.',
+        'The feedback should be helpful and easy to understand.',
+        'Given the selected option is correct, when feedback is shown, then only the explanation for the correct option is displayed.',
+        'Given feedback is displayed, when the student clicks Next, then the next unanswered question appears.',
+      ],
+      1,
+      'mock-wac-1-2',
+    ),
+    explanation: '"Helpful" and "easy to understand" are subjective — no test could confirm or deny this criterion is met.',
+  },
+  {
+    id: 'mock-wac-1-3',
+    quizType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+    level: 1,
+    questionText:
+      'User story: "As a student, I want to resume an abandoned activity, so that I don\'t lose progress." Which acceptance criterion is weakest?',
+    answerOptions: options(
+      [
+        'Given an in-progress session exists, when the student opens the activity, then they are offered Resume or Abandon.',
+        'Resuming should feel seamless.',
+        'Given the student selects Resume, then the next unanswered question is shown, not a previously answered one.',
+        'Given the student selects Abandon and confirms, then the session status is set to abandoned and cannot be resumed.',
+      ],
+      1,
+      'mock-wac-1-3',
+    ),
+    explanation: '"Feel seamless" describes an impression with no defined, checkable behavior — this criterion cannot be verified.',
+  },
+  {
+    id: 'mock-wac-2-1',
+    quizType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+    level: 2,
+    questionText:
+      'User story: "As a student, I want the activity to advance in difficulty when I do well, so that I\'m challenged appropriately." Which acceptance criterion is weakest?',
+    answerOptions: options(
+      [
+        'Given a completed session scores 80% or higher, then the next attempt uses level+1 questions.',
+        'Given a completed session scores below 80%, then the next attempt repeats the same level with a new random set.',
+        'The difficulty should progress at a reasonable pace for the student.',
+        'Given a student passes level 3, then they are informed they\'ve completed this activity\'s skill track.',
+      ],
+      2,
+      'mock-wac-2-1',
+    ),
+    explanation: '"Reasonable pace" defines no rule or threshold — compare to the other options, which state the exact rule this criterion is trying to describe.',
+  },
+  {
+    id: 'mock-wac-2-2',
+    quizType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+    level: 2,
+    questionText:
+      'User story: "As a student, I want to know when I\'ve earned a new title, so that I notice my progress." Which acceptance criterion is weakest?',
+    answerOptions: options(
+      [
+        'Given a student passes a difficulty level for the first time, then a notification names the new title and its activity type.',
+        'Given a student has no passed sessions, then that activity\'s title reads "Not yet started."',
+        'New titles should be exciting for students to receive.',
+        'Given a student re-passes an already-passed level, then no duplicate new-title notification is shown.',
+      ],
+      2,
+      'mock-wac-2-2',
+    ),
+    explanation: '"Exciting" is an emotional reaction with no defined, testable behavior attached to it.',
+  },
+  {
+    id: 'mock-wac-3-1',
+    quizType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+    level: 3,
+    questionText:
+      'User story: "As a student, I want a session to resume exactly where I left off, so that switching devices doesn\'t cost me progress." Which acceptance criterion is weakest?',
+    answerOptions: options(
+      [
+        'Given a session has 2 of 4 questions answered, when resumed on any device, then question 3 is presented first.',
+        'Given a session is resumed, the cumulative score continues from its stored value rather than resetting.',
+        'Given a session is resumed, when the page loads, it should load quickly enough that the student doesn\'t get frustrated.',
+        'Given a session was marked abandoned, when the student tries to resume it, the system does not offer a resume option.',
+      ],
+      2,
+      'mock-wac-3-1',
+    ),
+    explanation: '"Quickly enough" and "doesn\'t get frustrated" have no number or observable condition attached.',
+  },
+];

--- a/lib/quizQuestionTypes.ts
+++ b/lib/quizQuestionTypes.ts
@@ -1,0 +1,26 @@
+import type { ActivityType } from './activityTypes';
+
+export type QuizAnswerOption = {
+  id: string;
+  text: string;
+  isCorrect: boolean;
+};
+
+/**
+ * One question as the Instructor's "Add Question" form (GitHub #120) creates it. Deliberately
+ * its own shape rather than lib/activityContent.ts's Question/AnswerOption (built for the
+ * legacy student-facing mock, with a fixed 25-point maxScore and a per-option explanation baked
+ * in) — this one is designed to be what a real "create a question" endpoint would accept and
+ * return, so lib/mockQuestions.ts is the only thing that needs replacing once that endpoint
+ * exists; AddQuestionModal, AnswerOptionField and app/instructor/questions/page.tsx don't change.
+ */
+export type QuizQuestion = {
+  id: string;
+  quizType: ActivityType;
+  level: 1 | 2 | 3;
+  questionText: string;
+  /** Exactly one entry has isCorrect: true — single-choice, per REQ-PL-6.4. */
+  answerOptions: QuizAnswerOption[];
+  /** Shown to the student when they answer incorrectly. */
+  explanation: string;
+};


### PR DESCRIPTION

<img width="1242" height="1496" alt="image" src="https://github.com/user-attachments/assets/d51f95a1-29d5-4376-a97d-84bb081b4ff7" />


Add "create question" UI for instructors (GitHub #120)

Adds a popup form on the Question Bank page for adding a question and
its answer options to an existing quiz — quiz/level pickers, prompt
and explanation textareas, single-choice correct-answer selection,
inline validation, success toast, and a brief highlight on the newly
added card. Frontend only: saves into local React state seeded from
a new MOCK_QUESTIONS array, no backend wiring.

New: lib/quizQuestionTypes.ts (QuizQuestion/QuizAnswerOption),
lib/mockQuestions.ts, components/AddQuestionModal.tsx (focus trap,
Escape-to-close, returns focus on close), components/AnswerOptionField.tsx.
Changed: app/instructor/questions/page.tsx now sources its question
list from MOCK_QUESTIONS instead of lib/activityContent.ts.
