### PR TITLE
Added llm provider factories to rate acceptance criteria 

### DIFF
--- a/__tests__/lib/llmFactory.test.ts
+++ b/__tests__/lib/llmFactory.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getLLMProvider } from '../../lib/llm/factory';
+import { ClaudeProvider } from '../../lib/llm/providers/claudeProvider';
+import { ChatGptProvider } from '../../lib/llm/providers/chatGptProvider';
+import { GeminiProvider } from '../../lib/llm/providers/geminiProvider';
+
+describe('getLLMProvider', () => {
+  it('returns null when apiKey is empty, mirroring getSupabaseClient()', () => {
+    expect(getLLMProvider('CLAUDE', '')).toBeNull();
+    expect(getLLMProvider('CHATGPT', '')).toBeNull();
+    expect(getLLMProvider('GEMINI', '')).toBeNull();
+  });
+
+  it('does not throw when apiKey is missing', () => {
+    expect(() => getLLMProvider('CLAUDE', '')).not.toThrow();
+  });
+
+  it('instantiates a ClaudeProvider for CLAUDE', () => {
+    expect(getLLMProvider('CLAUDE', 'test-key')).toBeInstanceOf(ClaudeProvider);
+  });
+
+  it('instantiates a ChatGptProvider for CHATGPT', () => {
+    expect(getLLMProvider('CHATGPT', 'test-key')).toBeInstanceOf(ChatGptProvider);
+  });
+
+  it('instantiates a GeminiProvider for GEMINI', () => {
+    expect(getLLMProvider('GEMINI', 'test-key')).toBeInstanceOf(GeminiProvider);
+  });
+
+  it('every instantiated provider implements rateAcceptanceCriteria', () => {
+    const providers = [
+      getLLMProvider('CLAUDE', 'test-key'),
+      getLLMProvider('CHATGPT', 'test-key'),
+      getLLMProvider('GEMINI', 'test-key'),
+    ];
+
+    for (const provider of providers) {
+      expect(provider).not.toBeNull();
+      expect(typeof provider!.rateAcceptanceCriteria).toBe('function');
+    }
+  });
+
+  it('returns a different provider instance on each call (not a singleton)', () => {
+    const first = getLLMProvider('CLAUDE', 'test-key');
+    const second = getLLMProvider('CLAUDE', 'test-key');
+    expect(first).not.toBe(second);
+  });
+});

--- a/lib/llm/factory.ts
+++ b/lib/llm/factory.ts
@@ -1,0 +1,23 @@
+import type { LLMProvider } from './provider';
+import { ClaudeProvider } from './providers/claudeProvider';
+import { ChatGptProvider } from './providers/chatGptProvider';
+import { GeminiProvider } from './providers/geminiProvider';
+
+/**
+ * Instantiates the configured LLM provider, or null if apiKey is missing —
+ * mirrors getSupabaseClient()'s null-on-missing-config pattern (lib/supabase.ts).
+ */
+export function getLLMProvider(provider: 'CLAUDE' | 'CHATGPT' | 'GEMINI', apiKey: string): LLMProvider | null {
+  if (!apiKey) {
+    return null;
+  }
+
+  switch (provider) {
+    case 'CLAUDE':
+      return new ClaudeProvider(apiKey);
+    case 'CHATGPT':
+      return new ChatGptProvider(apiKey);
+    case 'GEMINI':
+      return new GeminiProvider(apiKey);
+  }
+}

--- a/lib/llm/promptUtils.ts
+++ b/lib/llm/promptUtils.ts
@@ -1,0 +1,33 @@
+import type { LLMRatingResult } from './provider';
+
+// REQ-FU-2 (Write Acceptance Criteria): evaluate whether the acceptance criteria
+// are clear, testable, and connected to the user story, then give feedback to
+// help the student improve them. Full score is 100 points (requirements.md).
+export function buildRatingPrompt(userStory: string, submittedText: string): string {
+  return [
+    'You are grading a student\'s submitted acceptance criteria for a user story.',
+    'Evaluate whether the acceptance criteria are clear, testable, and connected to the user story.',
+    'Give a score from 0 to 100 and feedback that helps the student improve the acceptance criteria.',
+    '',
+    `User story: ${userStory}`,
+    `Submitted acceptance criteria: ${submittedText}`,
+  ].join('\n');
+}
+
+export const RATING_JSON_SCHEMA = {
+  type: 'object',
+  properties: {
+    score: { type: 'integer' },
+    feedback: { type: 'string' },
+  },
+  required: ['score', 'feedback'],
+  additionalProperties: false,
+} as const;
+
+/** Parses a provider's raw JSON text into an LLMRatingResult, clamping score to [0, 100]. */
+export function parseRatingResponse(rawText: string): LLMRatingResult {
+  const parsed = JSON.parse(rawText);
+  const score = Math.min(100, Math.max(0, Math.round(Number(parsed.score))));
+  const feedback = String(parsed.feedback);
+  return { score, feedback };
+}

--- a/lib/llm/provider.ts
+++ b/lib/llm/provider.ts
@@ -1,0 +1,8 @@
+export type LLMRatingResult = {
+  score: number;
+  feedback: string;
+};
+
+export interface LLMProvider {
+  rateAcceptanceCriteria(userStory: string, submittedText: string): Promise<LLMRatingResult>;
+}

--- a/lib/llm/providers/chatGptProvider.ts
+++ b/lib/llm/providers/chatGptProvider.ts
@@ -1,0 +1,34 @@
+import type { LLMProvider, LLMRatingResult } from '../provider';
+import { buildRatingPrompt, parseRatingResponse, RATING_JSON_SCHEMA } from '../promptUtils';
+
+const MODEL = 'gpt-4o-mini';
+
+export class ChatGptProvider implements LLMProvider {
+  constructor(private readonly apiKey: string) {}
+
+  async rateAcceptanceCriteria(userStory: string, submittedText: string): Promise<LLMRatingResult> {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        messages: [{ role: 'user', content: buildRatingPrompt(userStory, submittedText) }],
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'acceptance_criteria_rating', schema: RATING_JSON_SCHEMA },
+        },
+      }),
+    });
+
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(body?.error?.message ?? `ChatGPT request failed with status ${response.status}`);
+    }
+
+    const rawText = body?.choices?.[0]?.message?.content ?? '';
+    return parseRatingResponse(rawText);
+  }
+}

--- a/lib/llm/providers/claudeProvider.ts
+++ b/lib/llm/providers/claudeProvider.ts
@@ -1,0 +1,26 @@
+import Anthropic from '@anthropic-ai/sdk';
+import type { LLMProvider, LLMRatingResult } from '../provider';
+import { buildRatingPrompt, parseRatingResponse, RATING_JSON_SCHEMA } from '../promptUtils';
+
+const MODEL = 'claude-opus-5';
+
+export class ClaudeProvider implements LLMProvider {
+  private readonly client: Anthropic;
+
+  constructor(apiKey: string) {
+    this.client = new Anthropic({ apiKey });
+  }
+
+  async rateAcceptanceCriteria(userStory: string, submittedText: string): Promise<LLMRatingResult> {
+    const response = await this.client.messages.create({
+      model: MODEL,
+      max_tokens: 1024,
+      thinking: { type: 'disabled' },
+      output_config: { effort: 'low', format: { type: 'json_schema', schema: RATING_JSON_SCHEMA } },
+      messages: [{ role: 'user', content: buildRatingPrompt(userStory, submittedText) }],
+    });
+
+    const textBlock = response.content.find((block) => block.type === 'text');
+    return parseRatingResponse(textBlock?.text ?? '');
+  }
+}

--- a/lib/llm/providers/geminiProvider.ts
+++ b/lib/llm/providers/geminiProvider.ts
@@ -1,0 +1,31 @@
+import type { LLMProvider, LLMRatingResult } from '../provider';
+import { buildRatingPrompt, parseRatingResponse, RATING_JSON_SCHEMA } from '../promptUtils';
+
+const MODEL = 'gemini-2.0-flash';
+
+export class GeminiProvider implements LLMProvider {
+  constructor(private readonly apiKey: string) {}
+
+  async rateAcceptanceCriteria(userStory: string, submittedText: string): Promise<LLMRatingResult> {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${MODEL}:generateContent?key=${this.apiKey}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: buildRatingPrompt(userStory, submittedText) }] }],
+        generationConfig: {
+          responseMimeType: 'application/json',
+          responseSchema: RATING_JSON_SCHEMA,
+        },
+      }),
+    });
+
+    const body = await response.json();
+    if (!response.ok) {
+      throw new Error(body?.error?.message ?? `Gemini request failed with status ${response.status}`);
+    }
+
+    const rawText = body?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    return parseRatingResponse(rawText);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ssu-starter-app-v2",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.115.0",
         "@supabase/supabase-js": "^2.45.4",
         "next": "14.2.15",
         "react": "18.3.1",
@@ -34,6 +35,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.115.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.115.0.tgz",
+      "integrity": "sha512-BJrFIVyjNuU8lfDyIJTvlRYzgQg+zEl78BxE7fq8esULsGz9IRQvGtW5spq3tydmtjQb/GFdooKGdGsetpx+lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -939,6 +970,12 @@
         "win32"
       ]
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.107.0",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.107.0.tgz",
@@ -1624,6 +1661,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1788,6 +1831,19 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -2390,6 +2446,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -2648,6 +2714,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.115.0",
     "@supabase/supabase-js": "^2.45.4",
     "next": "14.2.15",
     "react": "18.3.1",


### PR DESCRIPTION
Add pluggable LLM provider factory (Claude/ChatGPT/Gemini) with tests

- lib/llm/provider.ts: LLMProvider interface (rateAcceptanceCriteria) and
  LLMRatingResult type — the one contract every provider implements.
- lib/llm/factory.ts: getLLMProvider(provider, apiKey) dispatches to the
  right implementation; returns null (never throws) when apiKey is empty,
  mirroring lib/supabase.ts's getSupabaseClient() null-fallback pattern.
  No provider-specific logic lives here, only the dispatch.
- lib/llm/promptUtils.ts: shared helper used by all three providers —
  builds the acceptance-criteria rating prompt (REQ-FU-2: clear, testable,
  connected to the user story) and parses/clamps a provider's raw JSON
  response into { score, feedback } (score clamped to 0-100).
- lib/llm/providers/claudeProvider.ts: implements LLMProvider via the
  official @anthropic-ai/sdk (newly added dependency). Uses claude-opus-5
  with thinking disabled at low effort (safe here since no tools are
  declared) and output_config.format for structured JSON output.
- lib/llm/providers/chatGptProvider.ts and geminiProvider.ts: implement
  LLMProvider via plain fetch, mirroring lib/authClient.ts's postJson
  convention, since no SDK exists for these providers in this repo and
  none is required.
- __tests__/lib/llmFactory.test.ts: 7 tests covering null-on-missing-key,
  no-throw behavior, correct class instantiated per provider string,
  interface compliance (rateAcceptanceCriteria present on every
  instance), and non-singleton instantiation.

resolve #137 
resolve #138 
resolve #139 
resolve #140