### PR TITLE
Await cache refresh before navigating after quiz completion GitHub #130

### DIFF
--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -176,18 +176,23 @@ export default function PlayActivityPage({
     });
   }
 
-  function handleContinue() {
+  async function handleContinue() {
     if (!outcome) return;
     if (outcome.completed) {
       if (token && profile?.user_id) {
-        void loadStudentScore(token, profile.user_id, { forceRefresh: true });
-        void loadSessions(token, "completed", {
-          studentId: profile.user_id,
-          forceRefresh: true,
-        });
-        void loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
-          forceRefresh: true,
-        });
+        // Await the completed-attempts refresh before navigating so the activity
+        // page's cache is already up to date when it mounts — without this the
+        // "previous attempts" table still shows the stale list (GitHub #130).
+        await Promise.all([
+          loadStudentScore(token, profile.user_id, { forceRefresh: true }),
+          loadSessions(token, "completed", {
+            studentId: profile.user_id,
+            forceRefresh: true,
+          }),
+          loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
+            forceRefresh: true,
+          }),
+        ]);
       }
       router.push(`/activities/${activity!.slug}`);
       return;


### PR DESCRIPTION
After completing a quiz, the previous attempts table was showing stale data because the cache refresh calls were fired without waiting for them to finish before navigating back to the activity page. Fixed by awaiting all three refresh calls (completed attempts, sessions, and student score) before navigating, so the cache is up to date when the activity page mounts.

resolve #130