### PR TITLE
Instructor pages go through sessionClient, shared row type (#173)

### DIFF
--- a/__tests__/lib/sessionClient.test.ts
+++ b/__tests__/lib/sessionClient.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadInstructorActivities } from '../../lib/sessionClient';
+import type { InstructorActivityEntry } from '../../lib/sessionTypes';
+
+// No vi.mock('../../lib/supabase') here, the same way __tests__/lib/instructorAuth.test.ts does
+// without one: this is the client side of the wire, so the only collaborator to fake is fetch.
+// lib/sessionClient.ts carries 'use client' but is plain TypeScript, and loadInstructorActivities
+// touches none of the localStorage caches the other loaders use, so it imports cleanly under
+// vitest's node environment.
+
+const TOKEN = 'instructor-token';
+
+function stubFetch(impl: (url: string, init: RequestInit) => Promise<Response> | Promise<never>) {
+  const spy = vi.fn(impl);
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+function jsonResponse(body: unknown, status: number) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status }));
+}
+
+const SESSION: InstructorActivityEntry = {
+  session_id: 'session-1',
+  user_id: 'student-1',
+  activity_type: 'weak-user-stories',
+  difficulty_level: 1,
+  started_at: '2026-01-01T10:00:00.000Z',
+  ended_at: '2026-01-01T10:05:00.000Z',
+  status: 'completed',
+  cumulative_score: 4,
+  max_score: 4,
+  passed: true,
+  badge_id: null,
+  questionCount: 4,
+  answeredCount: 4,
+  studentId: 'student-1',
+  studentName: 'Ada Lovelace',
+  nextPosition: null,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('loadInstructorActivities', () => {
+  it('returns the class-wide sessions and sends the bearer token', async () => {
+    const fetchSpy = stubFetch(() => jsonResponse({ sessions: [SESSION] }, 200));
+
+    const result = await loadInstructorActivities(TOKEN);
+
+    expect(result).toEqual({ ok: true, data: { sessions: [SESSION] } });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('/api/instructor/activities');
+    expect(init.method).toBe('GET');
+    // The point of routing instructor pages through this module: no page assembles this header.
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('reports a non-2xx response as a failed result instead of throwing', async () => {
+    stubFetch(() => jsonResponse({ error: 'Something went wrong.' }, 500));
+
+    await expect(loadInstructorActivities(TOKEN)).resolves.toEqual({
+      ok: false,
+      status: 500,
+      error: 'Something went wrong.',
+    });
+  });
+
+  it('keeps the status even when the error response has no body to read', async () => {
+    // requireInstructor's 403 answers with no body at all (GitHub #169), so there is no
+    // { error } to pick apart — the caller still has to get 403 rather than an exception.
+    stubFetch(() => Promise.resolve(new Response(null, { status: 403 })));
+
+    const result = await loadInstructorActivities(TOKEN);
+
+    expect(result.ok).toBe(false);
+    expect(result).toMatchObject({ status: 403 });
+  });
+
+  it('reports a request that never reached the server as status 0', async () => {
+    stubFetch(() => Promise.reject(new TypeError('Failed to fetch')));
+
+    // Status 0 is what lets the page say "server unreachable" instead of blaming the server
+    // for an error it never got the chance to send.
+    await expect(loadInstructorActivities(TOKEN)).resolves.toEqual({
+      ok: false,
+      status: 0,
+      error: 'Could not reach the server. Please try again.',
+    });
+  });
+});

--- a/app/api/instructor/activities/route.ts
+++ b/app/api/instructor/activities/route.ts
@@ -1,6 +1,7 @@
 import { getSupabaseClient } from '../../../../lib/supabase';
 import { requireInstructor } from '../../../../lib/instructorAuth';
 import { loadAllStudentActivity } from '../../../../lib/sessionQueries';
+import type { InstructorActivityEntry } from '../../../../lib/sessionTypes';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -41,5 +42,10 @@ export async function GET(request: Request) {
   const { activities, error } = await loadAllStudentActivity(supabase);
   if (error) return Response.json({ error: error.message }, { status: 500 });
 
-  return Response.json({ sessions: activities }, { status: 200 });
+  // Annotated with the shared row type (GitHub #173) rather than left to inference, so this
+  // route and lib/sessionClient.ts's loadInstructorActivities are checked against the same
+  // declaration instead of agreeing by accident.
+  const payload: { sessions: InstructorActivityEntry[] } = { sessions: activities };
+
+  return Response.json(payload, { status: 200 });
 }

--- a/app/instructor/page.tsx
+++ b/app/instructor/page.tsx
@@ -14,7 +14,7 @@ import {
 } from '../../components/InstructorFilters';
 import { InstructorRoster } from '../../components/InstructorRoster';
 import { summarizeStudents, toStudentActivitySummary, type StudentActivitySummary } from '../../lib/activityLogTypes';
-import { loadInstructorActivities } from '../../lib/sessionClient';
+import { loadInstructorActivities, type InstructorActivityEntry } from '../../lib/sessionClient';
 import { useRequireRole } from '../../lib/useRequireRole';
 
 const PAGE_SIZE = 10;
@@ -52,8 +52,13 @@ function InstructorDashboardContent() {
 
     loadInstructorActivities(token).then((result) => {
       if (cancelled) return;
-      if (result.ok) setEntries(result.data.sessions.map(toStudentActivitySummary));
-      else setError(result.error);
+      if (result.ok) {
+        setEntries(result.data.sessions.map((session: InstructorActivityEntry) => toStudentActivitySummary(session)));
+      } else {
+        // result.error already distinguishes "server said no" from "never reached the server"
+        // (status 0) — see the request helper in lib/sessionClient.ts.
+        setError(result.error);
+      }
     });
 
     return () => {

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -11,7 +11,7 @@ import {
   type StudentActivitySummary,
   type StudentAggregate,
 } from '../../../lib/activityLogTypes';
-import { loadInstructorActivities } from '../../../lib/sessionClient';
+import { loadInstructorActivities, type InstructorActivityEntry } from '../../../lib/sessionClient';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
 const PAGE_SIZE = 9;
@@ -54,8 +54,11 @@ export default function AllStudentsPage() {
 
     loadInstructorActivities(token).then((result) => {
       if (cancelled) return;
-      if (result.ok) setEntries(result.data.sessions.map(toStudentActivitySummary));
-      else setError(result.error);
+      if (result.ok) {
+        setEntries(result.data.sessions.map((session: InstructorActivityEntry) => toStudentActivitySummary(session)));
+      } else {
+        setError(result.error);
+      }
     });
 
     return () => {

--- a/lib/activityLogTypes.ts
+++ b/lib/activityLogTypes.ts
@@ -1,6 +1,6 @@
 import { getActivityByType } from './activityContent';
 import type { ActivityType } from './activityTypes';
-import type { InstructorSessionEntry, SessionListEntry } from './sessionClient';
+import type { InstructorActivityEntry, SessionListEntry } from './sessionClient';
 
 export type ActivityLogStatus = 'completed' | 'in-progress' | 'abandoned';
 
@@ -113,7 +113,7 @@ export function summarizeStudents(entries: StudentActivitySummary[]): StudentAgg
  * say whose attempt it was. Built on toActivityLogEntry rather than beside it, so the student
  * log and the class-wide table cannot drift apart in how they read a session.
  */
-export function toStudentActivitySummary(session: InstructorSessionEntry): StudentActivitySummary {
+export function toStudentActivitySummary(session: InstructorActivityEntry): StudentActivitySummary {
   return {
     ...toActivityLogEntry(session),
     studentId: session.studentId,

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -9,24 +9,16 @@
 // from the feedback route, and only after the answer has been committed.
 
 import type { ActivityType } from './activityTypes';
+import type { InstructorActivityEntry, SessionListEntry, SessionRecord } from './sessionTypes';
 import { getCachedCompletedAttempts, setCachedCompletedAttempts } from './completedAttemptsStore';
 import { getCachedActivityLog, setCachedActivityLog } from './activityLogStore';
 import { getCachedCompletedSessions, setCachedCompletedSessions } from './completedSessionsStore';
 import { getCachedScore, setCachedScore } from './scoreStore';
 
-export type SessionRecord = {
-  session_id: string;
-  user_id: string;
-  activity_type: string;
-  difficulty_level: number;
-  started_at: string;
-  ended_at: string | null;
-  status: string;
-  cumulative_score: number;
-  max_score: number;
-  passed: boolean;
-  badge_id: string | null;
-};
+// The row shapes themselves live in lib/sessionTypes.ts, which imports nothing, so the routes
+// can share them without importing this 'use client' module. Re-exported here so this file
+// stays the one import the UI needs for anything session-related.
+export type { InstructorActivityEntry, SessionListEntry, SessionRecord } from './sessionTypes';
 
 export type SessionQuestionOption = {
   answer_id: string;
@@ -50,23 +42,6 @@ export type SessionAnswer = {
   submitted_at: string;
   correct: boolean | null;
   explanation: string | null;
-};
-
-/** A session as the list endpoint returns it: the record plus how far it got. */
-export type SessionListEntry = SessionRecord & {
-  questionCount: number;
-  answeredCount: number;
-  nextPosition: number | null;
-};
-
-/**
- * The same entry as returned by the class-wide instructor endpoint, plus who it belongs to.
- * studentName is already a display name — the server derives it from first/last name or
- * username, so no caller has to know the profile's shape.
- */
-export type InstructorSessionEntry = SessionListEntry & {
-  studentId: string;
-  studentName: string;
 };
 
 export type StartSessionResult = {
@@ -367,7 +342,7 @@ export function loadActivityLog(
  * an instructor stale results with no invalidation point to fix it.
  */
 export function loadInstructorActivities(token: string) {
-  return request<{ sessions: InstructorSessionEntry[] }>('/api/instructor/activities', { method: 'GET' }, token);
+  return request<{ sessions: InstructorActivityEntry[] }>('/api/instructor/activities', { method: 'GET' }, token);
 }
 
 /**

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -3,6 +3,7 @@
 
 import { getSupabaseClient } from './supabase';
 import { DEFAULT_QUESTION_MAX_SCORE, SESSION_COLUMNS } from './sessionRules';
+import type { InstructorActivityEntry, SessionListEntry } from './sessionTypes';
 import { shuffleArray } from './shuffleArray';
 
 export type SupabaseClient = NonNullable<ReturnType<typeof getSupabaseClient>>;
@@ -241,28 +242,16 @@ export type SessionProgress = {
 };
 
 /**
- * A session plus its progress, exactly the shape lib/sessionClient.ts's SessionListEntry
- * describes for the UI — this is the server-side counterpart, kept as its own type rather than
- * imported from that 'use client' module. Not to be confused with lib/activityLogTypes.ts's
- * ActivityLogEntry, the display shape the profile/dashboard log UI (GitHub #48) actually renders
- * — that one is derived from this one client-side (see toActivityLogEntry in app/dashboard/page.tsx).
+ * A session plus its progress — the server-side name for lib/sessionTypes.ts's SessionListEntry,
+ * which is the one declaration of this shape (GitHub #173). It used to be a hand-kept copy so
+ * that nothing here imported from the 'use client' lib/sessionClient.ts; sessionTypes.ts imports
+ * nothing at all, so both sides can now share it without that risk.
+ *
+ * Not to be confused with lib/activityLogTypes.ts's ActivityLogEntry, the display shape the
+ * profile/dashboard log UI (GitHub #48) actually renders — that one is derived from this one
+ * client-side (see toActivityLogEntry in lib/activityLogTypes.ts).
  */
-export type ActivityLogRow = {
-  session_id: string;
-  user_id: string;
-  activity_type: string;
-  difficulty_level: number;
-  started_at: string;
-  ended_at: string | null;
-  status: string;
-  cumulative_score: number;
-  max_score: number;
-  passed: boolean;
-  badge_id: string | null;
-  questionCount: number;
-  answeredCount: number;
-  nextPosition: number | null;
-};
+export type ActivityLogRow = SessionListEntry;
 
 /**
  * Every session the student has ever started, across every activity type and status — the full
@@ -310,12 +299,6 @@ export async function loadActivityLog(supabase: SupabaseClient, userId: string) 
 
   return { activities, error: null };
 }
-
-/** One attempt as the Instructor Dashboard needs it: the session plus who it belongs to. */
-export type StudentActivityRow = ActivityLogRow & {
-  studentId: string;
-  studentName: string;
-};
 
 /**
  * The "user" row joined onto a session, only for deriving a display name and for filtering
@@ -387,7 +370,7 @@ export async function loadAllStudentActivity(supabase: SupabaseClient) {
 
   // The embed is destructured off rather than spread along: it carries role and username,
   // which are inputs to this query, not part of what the endpoint discloses.
-  const activities: StudentActivityRow[] = rows.map(({ student, ...session }) => {
+  const activities: InstructorActivityEntry[] = rows.map(({ student, ...session }) => {
     const sessionProgress = progress!.get(session.session_id);
 
     return {

--- a/lib/sessionTypes.ts
+++ b/lib/sessionTypes.ts
@@ -1,0 +1,42 @@
+// The shapes a session travels in over the wire, and the one place they are declared.
+//
+// This file deliberately imports nothing. That is what lets both sides of the app read from
+// it: lib/sessionClient.ts ('use client') re-exports these for the UI, while lib/sessionQueries.ts
+// and app/api/instructor/activities/route.ts build them on the server. A shared module that
+// imported anything could drag server code — and with it the service-role key — into the browser
+// bundle; one with no imports at all cannot.
+//
+// Not to be confused with lib/activityLogTypes.ts's ActivityLogEntry: that is the *display*
+// shape the log UI renders, derived from these client-side by toActivityLogEntry.
+
+/** One row of session_log, exactly as the routes disclose it. */
+export type SessionRecord = {
+  session_id: string;
+  user_id: string;
+  activity_type: string;
+  difficulty_level: number;
+  started_at: string;
+  ended_at: string | null;
+  status: string;
+  cumulative_score: number;
+  max_score: number;
+  passed: boolean;
+  badge_id: string | null;
+};
+
+/** A session as the list endpoints return it: the record plus how far it got. */
+export type SessionListEntry = SessionRecord & {
+  questionCount: number;
+  answeredCount: number;
+  nextPosition: number | null;
+};
+
+/**
+ * The same entry as returned by the class-wide instructor endpoint, plus who it belongs to
+ * (GitHub #173). studentName is already a display name — the server derives it from first/last
+ * name or username, so no caller has to know the profile's shape.
+ */
+export type InstructorActivityEntry = SessionListEntry & {
+  studentId: string;
+  studentName: string;
+};


### PR DESCRIPTION
resolve #173.

`loadInstructorActivities(token)` already existed after #171 and goes through the same
private `request<T>` helper as `loadActivityLog`/`loadStudentScore`, so it already returns
`ApiResult<T>` and reports an unreachable server as `status: 0` / NETWORK_ERROR. Neither
instructor page calls `fetch` directly.

What was left was the row type: it was declared twice, as `InstructorSessionEntry`
(lib/sessionClient.ts) and `StudentActivityRow` (lib/sessionQueries.ts).

- New `lib/sessionTypes.ts` holds `SessionRecord`, `SessionListEntry` and
  `InstructorActivityEntry`. It imports nothing, so the server can share it without
  importing the `'use client'` module — the reason the copies existed in the first place.
- `sessionClient` re-exports them, so no existing importer changes.
- `sessionQueries`: `ActivityLogRow` is now an alias, `StudentActivityRow` is gone.
- The route annotates its response with the shared type; both instructor pages import it.

Tests: added `__tests__/lib/sessionClient.test.ts` (200 + bearer header, 500 → ok:false,
403 with no body, fetch reject → status 0). `npm test` 207 passing, `npm run build` clean.