### PR TITLE
Add route to get all sessions of students of the current prof

### DIFF
--- a/__tests__/api/instructor-sessions.test.ts
+++ b/__tests__/api/instructor-sessions.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Same harness as __tests__/api/instructor-activities.test.ts: eq() and order() are recorded,
+// not no-ops, since "only role student, newest first" are acceptance criteria here and an
+// ignored filter would let a wrong one pass unnoticed.
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    filters: [] as { table: string; column: string; value: unknown }[],
+    orders: [] as { table: string; column: string; ascending: boolean }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
+      order: (column: string, opts?: { ascending?: boolean }) => {
+        state.orders.push({ table, column, ascending: opts?.ascending ?? true });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly.
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+/** Queues the result the next `from(table)` chain resolves to. */
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/instructor/sessions/route';
+
+/** requireInstructor's own lookup: the caller's role, read from "user" first. */
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function sessionRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    session_id: 'session-1',
+    user_id: 'student-1',
+    activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+    difficulty_level: 1,
+    started_at: '2026-08-01T10:00:00.000Z',
+    ended_at: '2026-08-01T10:20:00.000Z',
+    status: 'completed',
+    cumulative_score: 75,
+    max_score: 100,
+    passed: false,
+    badge_id: null,
+    student: { first_name: 'Alex', last_name: 'Chen', username: 'achen', role: 'student' },
+    ...overrides,
+  };
+}
+
+function request(token?: string) {
+  return new Request('http://localhost/api/instructor/sessions', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.filters = [];
+  h.state.orders = [];
+});
+
+describe('GET /api/instructor/sessions', () => {
+  it('answers 401 without a token', async () => {
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('answers 401 for an invalid token', async () => {
+    const response = await GET(request('bad-token'));
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a student with 403 and an empty body, before reading any session', async () => {
+    queueRole('student');
+    queue('session_log', { data: [sessionRow()], error: null });
+
+    const response = await GET(request('valid-token'));
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+    expect(h.state.tables).not.toContain('session_log');
+  });
+
+  it('rejects an account without a profile row, which has never been confirmed as an instructor', async () => {
+    queue('user', { data: null, error: null });
+
+    const response = await GET(request('valid-token'));
+
+    expect(response.status).toBe(403);
+    expect(h.state.tables).not.toContain('session_log');
+  });
+
+  it('returns every session with the student and record fields the AC asks for', async () => {
+    queueRole('instructor');
+    queue('session_log', {
+      data: [
+        sessionRow(),
+        sessionRow({
+          session_id: 'session-2',
+          user_id: 'student-2',
+          status: 'in-progress',
+          ended_at: null,
+          cumulative_score: 25,
+          student: { first_name: 'Jordan', last_name: 'Smith', username: 'jsmith', role: 'student' },
+        }),
+      ],
+      error: null,
+    });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.sessions).toHaveLength(2);
+    expect(body.sessions[0]).toEqual({
+      session_id: 'session-1',
+      user_id: 'student-1',
+      activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+      difficulty_level: 1,
+      started_at: '2026-08-01T10:00:00.000Z',
+      ended_at: '2026-08-01T10:20:00.000Z',
+      status: 'completed',
+      cumulative_score: 75,
+      max_score: 100,
+      passed: false,
+      badge_id: null,
+      studentId: 'student-1',
+      studentName: 'Alex Chen',
+    });
+  });
+
+  it('does not leak the joined "user" row, or fetch progress, into the response', async () => {
+    queueRole('instructor');
+    queue('session_log', { data: [sessionRow()], error: null });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(body.sessions[0]).not.toHaveProperty('student');
+    expect(body.sessions[0]).not.toHaveProperty('questionCount');
+    expect(JSON.stringify(body)).not.toContain('achen');
+    // No progress lookup — this endpoint's AC never asks how far into the session it got.
+    expect(h.state.tables).not.toContain('session_to_question');
+    expect(h.state.tables).not.toContain('answered_question_log');
+  });
+
+  it('filters to role student, so an instructor’s own sessions stay out', async () => {
+    queueRole('instructor');
+    queue('session_log', { data: [], error: null });
+
+    const response = await GET(request('valid-token'));
+
+    expect(response.status).toBe(404);
+    expect(h.state.filters).toContainEqual({ table: 'session_log', column: 'student.role', value: 'student' });
+  });
+
+  it('orders newest first by started_at', async () => {
+    queueRole('instructor');
+    queue('session_log', { data: [sessionRow()], error: null });
+
+    await GET(request('valid-token'));
+
+    expect(h.state.orders).toContainEqual({ table: 'session_log', column: 'started_at', ascending: false });
+  });
+
+  it('falls back to the username when the profile has no first/last name', async () => {
+    queueRole('instructor');
+    queue('session_log', {
+      data: [sessionRow({ student: { first_name: null, last_name: null, username: 'quiet-owl', role: 'student' } })],
+      error: null,
+    });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(body.sessions[0].studentName).toBe('quiet-owl');
+  });
+
+  it('returns 404 when there are no session_log records at all', async () => {
+    queueRole('instructor');
+    queue('session_log', { data: [], error: null });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toMatch(/no sessions/i);
+  });
+
+  it('returns 500 when the session query fails', async () => {
+    queueRole('instructor');
+    queue('session_log', { data: null, error: { message: 'boom' } });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('boom');
+  });
+});

--- a/app/api/instructor/sessions/route.ts
+++ b/app/api/instructor/sessions/route.ts
@@ -1,0 +1,51 @@
+import { getSupabaseClient } from '../../../../lib/supabase';
+import { requireInstructor } from '../../../../lib/instructorAuth';
+import { loadAllStudentSessions } from '../../../../lib/sessionQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/instructor/sessions — every session_log record belonging to a student, for an
+ * instructor (GitHub #115).
+ *
+ * Deliberately a separate route from GET /api/instructor/activities (#171), not a variant of
+ * it: that route answers 200 with an empty list for a class that has not started anything, by
+ * design (see its docstring) — #115's AC explicitly asks for 404 in that same case, and
+ * changing #171's behavior to match would break the instructor dashboard that already depends
+ * on it.
+ *
+ * "Students of the current prof" is, today, every account with role 'student' — the same scope
+ * #171 already uses. There is no professor-to-student assignment (class/section) anywhere in
+ * the schema, so a real per-professor scope is not something this route can add on its own;
+ * every instructor account currently sees every student, same as #171.
+ */
+export async function GET(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    // 403 answers with no body at all (GitHub #169's acceptance criteria); 401 and 500 keep
+    // the { error } shape every other route uses.
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { sessions, error } = await loadAllStudentSessions(supabase);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  // AC: 404 when no session_log records exist — unlike #171, which treats this as a normal,
+  // empty class overview.
+  if (!sessions || sessions.length === 0) {
+    return Response.json({ error: 'No sessions found.' }, { status: 404 });
+  }
+
+  return Response.json({ sessions }, { status: 200 });
+}

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -3,7 +3,7 @@
 
 import { getSupabaseClient } from './supabase';
 import { DEFAULT_QUESTION_MAX_SCORE, SESSION_COLUMNS } from './sessionRules';
-import type { InstructorActivityEntry, SessionListEntry } from './sessionTypes';
+import type { InstructorActivityEntry, InstructorSessionEntry, SessionListEntry, SessionRecord } from './sessionTypes';
 import { shuffleArray } from './shuffleArray';
 
 export type SupabaseClient = NonNullable<ReturnType<typeof getSupabaseClient>>;
@@ -384,6 +384,44 @@ export async function loadAllStudentActivity(supabase: SupabaseClient) {
   });
 
   return { activities, error: null };
+}
+
+/**
+ * Every session_log record belonging to a student, class-wide (GitHub #115) — the leaner
+ * counterpart to loadAllStudentActivity (#171): same STUDENT_EMBED join and role = 'student'
+ * scope, but no loadProgressForSessions call, since this endpoint's AC (student, activity,
+ * level, start date, score, result) never asks how far into the session the student got.
+ *
+ * "Students of the current prof" is, today, every account with role 'student' — there is no
+ * professor-to-student assignment (class/section) anywhere in the schema, so this is the same
+ * scope #171 already uses. A real per-professor scope would need that relationship to exist
+ * first.
+ *
+ * Newest first by started_at — the AC does not specify an order, but every other listing in
+ * this codebase defaults to newest-first, and "Start date" is the one date this endpoint has.
+ */
+export async function loadAllStudentSessions(supabase: SupabaseClient) {
+  const { data, error } = await supabase
+    .from('session_log')
+    .select(`${SESSION_COLUMNS}, ${STUDENT_EMBED}`)
+    .eq('student.role', 'student')
+    .order('started_at', { ascending: false });
+
+  if (error) return { sessions: null, error };
+
+  type SessionRow = SessionRecord & { student: EmbeddedStudent };
+
+  // The embed is destructured off rather than spread along: it carries role and username,
+  // which are inputs to this query, not part of what the endpoint discloses.
+  const sessions: InstructorSessionEntry[] = ((data ?? []) as unknown as SessionRow[]).map(
+    ({ student, ...session }) => ({
+      ...session,
+      studentId: session.user_id,
+      studentName: studentDisplayName(student),
+    }),
+  );
+
+  return { sessions, error: null };
 }
 
 /**

--- a/lib/sessionTypes.ts
+++ b/lib/sessionTypes.ts
@@ -40,3 +40,13 @@ export type InstructorActivityEntry = SessionListEntry & {
   studentId: string;
   studentName: string;
 };
+
+/**
+ * One session_log record plus who it belongs to, without progress (GitHub #115) — the leaner
+ * counterpart to InstructorActivityEntry, for the route that only needs the record itself
+ * (student, activity, level, start date, score, result), not how far in it the student got.
+ */
+export type InstructorSessionEntry = SessionRecord & {
+  studentId: string;
+  studentName: string;
+};


### PR DESCRIPTION
The route should return all session_log records of students who attempted a quiz of the current prof. It should return following information:

    The student
    Activity name
    Level
    Start date
    Score
    Result
Revise #115 