### PR TITLE
Added route to retreive random user story and corresponding test

### DIFF
--- a/__tests__/api/write-acceptance-criteria-user-story.test.ts
+++ b/__tests__/api/write-acceptance-criteria-user-story.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'user-123' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/activities/write-acceptance-criteria/user-story/route';
+
+function req(token: string | null = 'valid-token') {
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return new Request('http://localhost/api/activities/write-acceptance-criteria/user-story', { headers });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+});
+
+describe('GET /api/activities/write-acceptance-criteria/user-story', () => {
+  it('returns 401 when no token is supplied', async () => {
+    const res = await GET(req(null));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when the token is invalid', async () => {
+    const res = await GET(req('bad-token'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns a random story mapped to { userStoryId, description }', async () => {
+    queue('user_story', {
+      data: [{ user_story_id: 'story-1', story_text: 'As a student, I want to log in.' }],
+      error: null,
+    });
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ userStoryId: 'story-1', description: 'As a student, I want to log in.' });
+  });
+
+  it('does not always return the same story (random draw)', async () => {
+    const seed = [
+      { user_story_id: 'story-1', story_text: 'Story one' },
+      { user_story_id: 'story-2', story_text: 'Story two' },
+      { user_story_id: 'story-3', story_text: 'Story three' },
+    ];
+
+    const seen = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      queue('user_story', { data: seed, error: null });
+      const res = await GET(req());
+      const body = await res.json();
+      seen.add(body.userStoryId as string);
+    }
+
+    expect(seen.size).toBeGreaterThan(1);
+  });
+
+  it('returns 500 when the query fails', async () => {
+    queue('user_story', { data: null, error: { message: 'DB error' } });
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+  });
+
+  it('returns 500 when user_story has no rows', async () => {
+    queue('user_story', { data: [], error: null });
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toMatch(/no user stories/i);
+  });
+});

--- a/app/api/activities/write-acceptance-criteria/user-story/route.ts
+++ b/app/api/activities/write-acceptance-criteria/user-story/route.ts
@@ -1,0 +1,52 @@
+import { getSupabaseClient } from '../../../../../lib/supabase';
+import { shuffleArray } from '../../../../../lib/shuffleArray';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/activities/write-acceptance-criteria/user-story
+ *
+ * Returns one random user story for the student to write acceptance criteria against
+ * (REQ-FU-2). Nothing is persisted here — like the MCQ session's current question
+ * (lib/sessionQueries.ts's nextUnansweredPosition), "current story" is derived fresh on
+ * every call rather than stored; the submission route is what pins a later answer to the
+ * story shown.
+ *
+ * user_story has no title/description columns yet, only story_text — the response maps
+ * story_text to `description` and omits `title` until the schema grows one.
+ *
+ * AC summary:
+ *  - 401 if the bearer token is missing or invalid
+ *  - 500 if Supabase is not configured, the query fails, or user_story has no rows
+ *  - 200 with { userStoryId, description }
+ */
+export async function GET(request: Request) {
+  const token = getToken(request);
+  if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
+
+  const { data: stories, error } = await supabase
+    .from('user_story')
+    .select('user_story_id, story_text');
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  if (!stories || stories.length === 0) {
+    return Response.json({ error: 'No user stories available.' }, { status: 500 });
+  }
+
+  const [story] = shuffleArray(stories as { user_story_id: string; story_text: string }[]);
+
+  return Response.json(
+    { userStoryId: story.user_story_id, description: story.story_text },
+    { status: 200 },
+  );
+}


### PR DESCRIPTION
Added a new endpoint for the "Write Acceptance Criteria" activity that serves a random user story for the student to write acceptance criteria against.

New route: GET /api/activities/write-acceptance-criteria/user-story ([app/api/activities/write-acceptance-criteria/user-story/route.ts](vscode-webview://0mmu0vit11vsqn63b3959pk46vdhakd0hqottqr7r9r6umqnmeeo/app/api/activities/write-acceptance-criteria/user-story/route.ts))

Requires a valid bearer token (401 if missing/invalid)
Picks one random row from user_story, no user_story_id accepted from the client
Returns { userStoryId, description } (200)
Returns 500 if Supabase isn't configured, the query fails, or user_story has no rows
Nothing is persisted — the story is derived fresh on each call, same as the MCQ flow's current-question logic
Note on response shape: the acceptance criteria called for { userStoryId, title, description }, but user_story only has a story_text column (no title/description). Per direction, story_text is mapped to description and title is omitted rather than migrating the schema.

New tests: [tests/api/write-acceptance-criteria-user-story.test.ts](vscode-webview://0mmu0vit11vsqn63b3959pk46vdhakd0hqottqr7r9r6umqnmeeo/__tests__/api/write-acceptance-criteria-user-story.test.ts) — covers missing/invalid token, happy path, empty-table 500, query-error 500, and a randomness regression check. Full suite passes (235/235 tests).

resolve #141 