### PR TITLE
resolve issue #174

### DIFF
--- a/app/instructor/page.tsx
+++ b/app/instructor/page.tsx
@@ -12,6 +12,7 @@ import {
   type LevelFilterValue,
   type StudentFilterValue,
 } from '../../components/InstructorFilters';
+import { InstructorDashboardSkeleton } from '../../components/InstructorDashboardSkeleton';
 import { InstructorRoster } from '../../components/InstructorRoster';
 import { summarizeStudents, toStudentActivitySummary, type StudentActivitySummary } from '../../lib/activityLogTypes';
 import { loadInstructorActivities, type InstructorActivityEntry } from '../../lib/sessionClient';
@@ -68,14 +69,19 @@ function InstructorDashboardContent() {
 
   const roster = useMemo(() => summarizeStudents(entries ?? []), [entries]);
 
-  const students = useMemo(() => {
-    const byId = new Map((entries ?? []).map((entry) => [entry.studentId, entry.studentName]));
-    return [...byId.entries()].map(([id, name]) => ({ id, name })).sort((a, b) => a.name.localeCompare(b.name));
-  }, [entries]);
-
+  // Keyed by studentId, not by the attempt's own id (GitHub #174): a returning student owns many
+  // rows, and every one of them has to resolve to the same name from a single entry.
   const studentNameById = useMemo(
-    () => new Map((entries ?? []).map((entry) => [entry.id, entry.studentName])),
+    () => new Map((entries ?? []).map((entry) => [entry.studentId, entry.studentName])),
     [entries],
+  );
+
+  const students = useMemo(
+    () =>
+      [...studentNameById.entries()]
+        .map(([id, name]) => ({ id, name }))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [studentNameById],
   );
 
   // Lets app/instructor/students/page.tsx link straight into a filtered table
@@ -130,7 +136,18 @@ function InstructorDashboardContent() {
             {error}
           </p>
         ) : entries === null ? (
-          <p className="mb-6 text-sm font-semibold text-gray-500">Loading…</p>
+          <InstructorDashboardSkeleton />
+        ) : entries.length === 0 ? (
+          // GET /api/instructor/activities answers 200 [] for a class that has not started
+          // anything (by design — see its docstring). Rendering the full dashboard here would
+          // show empty stat tiles and the table's "No attempts match these filters." message,
+          // which blames filters the instructor never set (GitHub #174).
+          <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-10 text-center">
+            <p className="text-sm font-extrabold text-brand-navy">No activity yet</p>
+            <p className="mx-auto mt-1.5 max-w-md text-sm font-semibold text-gray-500">
+              Once students start an activity, their attempts show up here.
+            </p>
+          </div>
         ) : (
           <>
             <InstructorActivityStats entries={entries} />
@@ -153,7 +170,7 @@ function InstructorDashboardContent() {
               onSortChange={setSort}
             />
 
-            <ActivityLogTable entries={pageEntries} getStudentName={(entry) => studentNameById.get(entry.id) ?? ''} />
+            <ActivityLogTable entries={pageEntries} getStudentName={(entry) => studentNameById.get(entry.studentId) ?? ''} />
 
             <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
               <span className="text-xs font-semibold text-gray-500">

--- a/components/ActivityLogTable.tsx
+++ b/components/ActivityLogTable.tsx
@@ -7,13 +7,18 @@ const COLUMNS = ['Activity', 'Level', 'Date & time', 'Score', 'Result'];
  * getStudentName is how the Instructor Dashboard (GitHub #82) reuses this same table for
  * StudentActivitySummary[] — a plain ActivityLogEntry[] just omits it and gets the original
  * student-less table back.
+ *
+ * Generic in the row type so that callback sees the caller's row, not the narrowed base type:
+ * the instructor dashboard looks a student up by entry.studentId (GitHub #174), which only
+ * exists on StudentActivitySummary. Callers that omit getStudentName infer T = ActivityLogEntry
+ * and are unaffected (app/dashboard/log/page.tsx).
  */
-export function ActivityLogTable({
+export function ActivityLogTable<T extends ActivityLogEntry>({
   entries,
   getStudentName,
 }: {
-  entries: ActivityLogEntry[];
-  getStudentName?: (entry: ActivityLogEntry) => string;
+  entries: T[];
+  getStudentName?: (entry: T) => string;
 }) {
   const columns = getStudentName ? ['Student', ...COLUMNS] : COLUMNS;
 

--- a/components/InstructorDashboardSkeleton.tsx
+++ b/components/InstructorDashboardSkeleton.tsx
@@ -1,0 +1,129 @@
+/**
+ * Loading placeholder for the Instructor Dashboard (GitHub #174) — mirrors the real layout
+ * (stat tiles, roster grid, filter row, attempts table) so the page doesn't jump when
+ * loadInstructorActivities resolves, same idea as ActivityCardSkeleton (GitHub #108) on
+ * /activities.
+ *
+ * Two block variants on purpose: this page renders inside AppShell's white <main>, unlike
+ * ActivityCardSkeleton and AcceptanceCriteriaWritingScreenSkeleton, which sit on dark surfaces
+ * and shimmer in white. A white shimmer is invisible on gray-50 tiles, so everything above the
+ * table uses .skeleton-block (dark-on-light) and only the table — brand-navy header,
+ * brand-navy-2 rows, see ActivityLogRow — uses .skeleton-block-dark (light-on-dark).
+ *
+ * The <style jsx> block is duplicated rather than shared because styled-jsx is scoped per
+ * component; AcceptanceCriteriaWritingScreenSkeleton duplicates it for the same reason.
+ */
+
+const ROSTER_CARD_COUNT = 6; // matches InstructorRoster's INITIAL_VISIBLE_COUNT
+const TABLE_ROW_COUNT = 5;
+
+export function InstructorDashboardSkeleton() {
+  return (
+    <div role="status" aria-label="Loading class activity">
+      {/* InstructorActivityStats: one tile per activity in ACTIVITIES */}
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {[0, 1].map((tile) => (
+          <div key={tile} className="rounded-brand-lg border border-gray-100 bg-gray-50 p-5">
+            <span className="skeleton-block block h-4 w-40 rounded-full" />
+            <div className="mt-3 flex gap-8">
+              <div>
+                <span className="skeleton-block block h-6 w-14 rounded-full" />
+                <span className="skeleton-block mt-1.5 block h-3 w-24 rounded-full" />
+              </div>
+              <div>
+                <span className="skeleton-block block h-6 w-14 rounded-full" />
+                <span className="skeleton-block mt-1.5 block h-3 w-20 rounded-full" />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* "Students" heading + "View all students →" link */}
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <span className="skeleton-block block h-3 w-20 rounded-full" />
+        <span className="skeleton-block block h-3 w-28 rounded-full" />
+      </div>
+
+      {/* InstructorRoster */}
+      <div className="mb-6 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: ROSTER_CARD_COUNT }, (_, index) => (
+          <div key={index} className="rounded-brand-lg border border-gray-100 bg-gray-50 p-4">
+            <span className="skeleton-block block h-4 w-32 rounded-full" />
+            <span className="skeleton-block mt-2 block h-3 w-40 rounded-full" />
+            <span className="skeleton-block mt-1.5 block h-3 w-28 rounded-full" />
+          </div>
+        ))}
+      </div>
+
+      {/* InstructorFilters: student select, level pills, sort select */}
+      <div className="mb-5 flex flex-wrap items-end justify-between gap-4">
+        <div className="flex flex-wrap items-end gap-4">
+          <div>
+            <span className="skeleton-block block h-3 w-14 rounded-full" />
+            <span className="skeleton-block mt-1 block h-9 w-36 rounded-brand-md" />
+          </div>
+          <div>
+            <span className="skeleton-block block h-3 w-10 rounded-full" />
+            <div className="mt-1 flex gap-1.5">
+              {[0, 1, 2, 3].map((pill) => (
+                <span key={pill} className="skeleton-block block h-7 w-16 rounded-full" />
+              ))}
+            </div>
+          </div>
+        </div>
+        <div>
+          <span className="skeleton-block block h-3 w-10 rounded-full" />
+          <span className="skeleton-block mt-1 block h-9 w-40 rounded-brand-md" />
+        </div>
+      </div>
+
+      {/* ActivityLogTable — the one dark surface on this page */}
+      <div className="overflow-hidden rounded-brand-lg border border-brand-navy-border">
+        <div className="bg-brand-navy px-4 py-3.5">
+          <span className="skeleton-block-dark block h-3 w-28 rounded-full" />
+        </div>
+        {Array.from({ length: TABLE_ROW_COUNT }, (_, index) => (
+          <div key={index} className="flex items-center gap-6 border-t border-brand-navy-border bg-brand-navy-2 px-4 py-4">
+            <span className="skeleton-block-dark block h-3.5 w-28 rounded-full" />
+            <span className="skeleton-block-dark block h-3.5 w-32 rounded-full" />
+            <span className="skeleton-block-dark hidden h-3.5 w-16 rounded-full sm:block" />
+            <span className="skeleton-block-dark hidden h-3.5 w-24 rounded-full sm:block" />
+            <span className="skeleton-block-dark ml-auto block h-3.5 w-16 rounded-full" />
+          </div>
+        ))}
+      </div>
+
+      <style jsx>{`
+        .skeleton-block {
+          background: linear-gradient(90deg, rgba(0, 0, 0, 0.06) 25%, rgba(0, 0, 0, 0.12) 37%, rgba(0, 0, 0, 0.06) 63%);
+          background-size: 400% 100%;
+          animation: skeleton-shimmer 1.6s ease-in-out infinite;
+        }
+        .skeleton-block-dark {
+          background: linear-gradient(90deg, rgba(255, 255, 255, 0.06) 25%, rgba(255, 255, 255, 0.16) 37%, rgba(255, 255, 255, 0.06) 63%);
+          background-size: 400% 100%;
+          animation: skeleton-shimmer 1.6s ease-in-out infinite;
+        }
+        @keyframes skeleton-shimmer {
+          0% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .skeleton-block {
+            animation: none;
+            background: rgba(0, 0, 0, 0.08);
+          }
+          .skeleton-block-dark {
+            animation: none;
+            background: rgba(255, 255, 255, 0.08);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
resolve #174.

app/instructor/page.tsx already fetched through loadInstructorActivities on mount after
#173, with the memos, filters, sorting and pagination running over that state and
InstructorActivityStats getting the unfiltered list. MOCK_STUDENT_ACTIVITY is imported
nowhere — lib/mockStudentActivity.ts was deleted in #173.

What was left was the two UI states around the fetch, plus the lookup the story called out.

    studentNameById was keyed by the attempt id. No row ever showed a wrong name —
    session_id is unique — but the map held one entry per attempt instead of one per
    student. It now keys on studentId, and the students dropdown derives from it.
    ActivityLogTable is generic over its row type so the callback sees studentId; prop
    names and count are unchanged, and app/dashboard/log is unaffected.

    New components/InstructorDashboardSkeleton.tsx replaces the "Loading…" line so the page
    no longer jumps. ActivityCardSkeleton's shimmer could not be copied: it sits on a dark
    surface, this page renders inside AppShell's white <main>, so only the table keeps the
    light-on-dark block.

    A class with no attempts (200 []) rendered the full dashboard, including the table's
    "No attempts match these filters." — blaming filters nobody set. It gets its own branch
    now; the filter message stays for the case it describes.

Tests: none added