### PR TITLE
Added route to add new llm configuration and model attribute to table instructor_llm_config

### DIFF
--- a/__tests__/api/instructor-llm-config.test.ts
+++ b/__tests__/api/instructor-llm-config.test.ts
@@ -1,0 +1,256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    inserts: [] as { table: string; payload: unknown }[],
+    updates: [] as { table: string; payload: unknown }[],
+    filters: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      update: (payload: unknown) => {
+        state.updates.push({ table, payload });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly
+      // (the deactivate UPDATE never calls .single()).
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+/** The guard's own lookup: requireInstructor reads the caller's role from "user" first. */
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { POST } from '../../app/api/instructor/llm-config/route';
+
+function req(body: unknown, token: string | null = 'valid-token') {
+  return new Request('http://localhost/api/instructor/llm-config', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function configRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    instructor_llm_config_id: 'config-1',
+    provider: 'CLAUDE',
+    model: 'claude-opus-5',
+    is_active: false,
+    updated_at: '2026-08-06T10:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.inserts = [];
+  h.state.updates = [];
+  h.state.filters = [];
+});
+
+describe('POST /api/instructor/llm-config', () => {
+  it('saves a config and never echoes the api key back', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: configRow(), error: null });
+
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.config).toEqual(configRow());
+    expect(JSON.stringify(body)).not.toContain('sk-secret');
+
+    expect(h.state.inserts).toHaveLength(1);
+    expect(h.state.inserts[0].payload).toMatchObject({
+      user_id: 'instructor-1',
+      provider: 'CLAUDE',
+      model: 'claude-opus-5',
+      api_key: 'sk-secret',
+      is_active: false,
+    });
+  });
+
+  it('deactivates any previously active row when setActive is true', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: [], error: null }); // the deactivate UPDATE
+    queue('instructor_llm_config', { data: configRow({ is_active: true }), error: null }); // the INSERT
+
+    const res = await POST(req({ provider: 'GEMINI', apiKey: 'sk-secret', model: 'gemini-2.0-flash', setActive: true }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.config.is_active).toBe(true);
+
+    expect(h.state.updates).toHaveLength(1);
+    expect(h.state.updates[0]).toEqual({ table: 'instructor_llm_config', payload: { is_active: false } });
+    expect(h.state.filters).toContainEqual({ table: 'instructor_llm_config', column: 'is_active', value: true });
+  });
+
+  it('does not deactivate anything when setActive is false or omitted', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: configRow(), error: null });
+
+    await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }));
+
+    expect(h.state.updates).toHaveLength(0);
+  });
+
+  it('retries the deactivate+insert pair once on a unique-index race', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: [], error: null }); // first deactivate
+    queue('instructor_llm_config', { data: null, error: { code: '23505', message: 'duplicate' } }); // racing insert
+    queue('instructor_llm_config', { data: [], error: null }); // retry deactivate
+    queue('instructor_llm_config', { data: configRow({ is_active: true }), error: null }); // retry insert
+
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5', setActive: true }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.config.is_active).toBe(true);
+    expect(h.state.updates).toHaveLength(2);
+  });
+
+  it('rejects an unknown provider with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(req({ provider: 'LLAMA', apiKey: 'sk-secret', model: 'llama-4' }));
+
+    expect(res.status).toBe(400);
+    expect(h.state.tables).not.toContain('instructor_llm_config');
+  });
+
+  it('rejects a missing provider with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(req({ apiKey: 'sk-secret', model: 'claude-opus-5' }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an empty api key with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: '  ', model: 'claude-opus-5' }));
+
+    expect(res.status).toBe(400);
+    expect(h.state.tables).not.toContain('instructor_llm_config');
+  });
+
+  it('rejects a missing api key with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(req({ provider: 'CLAUDE', model: 'claude-opus-5' }));
+
+    expect(res.status).toBe(400);
+  });
+
+  it('answers 401 without a token', async () => {
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }, null));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('answers 401 for an invalid token', async () => {
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }, 'bad-token'));
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a student with 403 and an empty body, before touching the config table', async () => {
+    queueRole('student');
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }));
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('instructor_llm_config');
+  });
+
+  it('rejects an account without a profile row', async () => {
+    queue('user', { data: null, error: null });
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }));
+
+    expect(res.status).toBe(403);
+  });
+
+  it('answers 500 when the insert fails', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: null, error: { message: 'boom' } });
+
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('boom');
+  });
+
+  it('answers 500 when the deactivate query fails', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: null, error: { message: 'deactivate failed' } });
+
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5', setActive: true }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('deactivate failed');
+  });
+
+  it('answers 400 for invalid JSON', async () => {
+    queueRole('instructor');
+    const res = await POST(
+      new Request('http://localhost/api/instructor/llm-config', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token' },
+        body: '{not json',
+      }),
+    );
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/instructor/llm-config/route.ts
+++ b/app/api/instructor/llm-config/route.ts
@@ -1,0 +1,114 @@
+import { getSupabaseClient } from '../../../../lib/supabase';
+import { requireInstructor } from '../../../../lib/instructorAuth';
+import { isLLMProviderName } from '../../../../lib/llm/provider';
+
+const UNIQUE_VIOLATION = '23505';
+
+// api_key is deliberately excluded — write-only from the client's perspective, matching the
+// schema comment on instructor_llm_config ("only a service-role route can read or write
+// api_key, and that route is responsible for masking it before it reaches the client").
+const CONFIG_COLUMNS = 'instructor_llm_config_id, provider, model, is_active, updated_at';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * POST /api/instructor/llm-config — an instructor saves an LLM provider + model + API key used
+ * to grade free-text submissions (instructor_llm_config).
+ *
+ * Instructor-only: requireInstructor runs before any row is touched, the same guard every other
+ * /api/instructor/* route uses.
+ *
+ * uq_instructor_llm_config_one_active is a *global* partial unique index (supabase/schema.sql) —
+ * at most one row across every instructor, not just this caller, can have is_active = true.
+ * setActive: true therefore deactivates whichever row currently holds that flag before the new
+ * row is inserted. supabase-js has no multi-statement transaction here, so the deactivate and
+ * the insert aren't atomic — a concurrent activation can still land in between and trip the
+ * unique index; on that 23505 the pair is retried once, the same bounded-retry idea POST
+ * /api/sessions uses for uq_session_log_one_active.
+ *
+ * AC summary:
+ *  - 401 if the bearer token is missing or invalid
+ *  - 403 if the caller isn't an instructor (no body, matching requireInstructor's convention)
+ *  - 400 if provider isn't one of CLAUDE/CHATGPT/GEMINI, or apiKey is empty
+ *  - 200 with the saved row — api_key never included
+ *  - 500 if Supabase isn't configured or a query fails
+ */
+export async function POST(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { provider, apiKey, model, setActive } = (body ?? {}) as {
+    provider?: unknown;
+    apiKey?: unknown;
+    model?: unknown;
+    setActive?: unknown;
+  };
+
+  if (!isLLMProviderName(provider)) {
+    return Response.json({ error: 'provider must be one of CLAUDE, CHATGPT, GEMINI.' }, { status: 400 });
+  }
+
+  if (typeof apiKey !== 'string' || apiKey.trim() === '') {
+    return Response.json({ error: 'apiKey is required.' }, { status: 400 });
+  }
+
+  const isActive = Boolean(setActive);
+
+  const deactivateExisting = () =>
+    supabase.from('instructor_llm_config').update({ is_active: false }).eq('is_active', true);
+
+  const insertRow = () =>
+    supabase
+      .from('instructor_llm_config')
+      .insert({
+        instructor_llm_config_id: crypto.randomUUID(),
+        user_id: guard.user_id,
+        provider,
+        model,
+        api_key: apiKey,
+        is_active: isActive,
+      })
+      .select(CONFIG_COLUMNS)
+      .single();
+
+  if (isActive) {
+    const { error: deactivateError } = await deactivateExisting();
+    if (deactivateError) return Response.json({ error: deactivateError.message }, { status: 500 });
+  }
+
+  let { data: config, error: insertError } = await insertRow();
+
+  // Narrow race window between the deactivate above and this insert — retry the pair once
+  // rather than failing a legitimate save.
+  if (insertError?.code === UNIQUE_VIOLATION && isActive) {
+    const { error: retryDeactivateError } = await deactivateExisting();
+    if (retryDeactivateError) return Response.json({ error: retryDeactivateError.message }, { status: 500 });
+    ({ data: config, error: insertError } = await insertRow());
+  }
+
+  if (insertError || !config) {
+    return Response.json({ error: insertError?.message ?? 'Could not save LLM config.' }, { status: 500 });
+  }
+
+  return Response.json({ config }, { status: 200 });
+}

--- a/lib/llm/factory.ts
+++ b/lib/llm/factory.ts
@@ -1,4 +1,4 @@
-import type { LLMProvider } from './provider';
+import type { LLMProvider, LLMProviderName } from './provider';
 import { ClaudeProvider } from './providers/claudeProvider';
 import { ChatGptProvider } from './providers/chatGptProvider';
 import { GeminiProvider } from './providers/geminiProvider';
@@ -7,7 +7,7 @@ import { GeminiProvider } from './providers/geminiProvider';
  * Instantiates the configured LLM provider, or null if apiKey is missing —
  * mirrors getSupabaseClient()'s null-on-missing-config pattern (lib/supabase.ts).
  */
-export function getLLMProvider(provider: 'CLAUDE' | 'CHATGPT' | 'GEMINI', apiKey: string): LLMProvider | null {
+export function getLLMProvider(provider: LLMProviderName, apiKey: string): LLMProvider | null {
   if (!apiKey) {
     return null;
   }

--- a/lib/llm/provider.ts
+++ b/lib/llm/provider.ts
@@ -6,3 +6,14 @@ export type LLMRatingResult = {
 export interface LLMProvider {
   rateAcceptanceCriteria(userStory: string, submittedText: string): Promise<LLMRatingResult>;
 }
+
+// The set of providers an instructor can configure (instructor_llm_config.provider). Kept in one
+// place, same reasoning as lib/activityTypes.ts's ACTIVITY_TYPES, so getLLMProvider and any route
+// validating a provider string never drift apart.
+export const LLM_PROVIDERS = ['CLAUDE', 'CHATGPT', 'GEMINI'] as const;
+
+export type LLMProviderName = (typeof LLM_PROVIDERS)[number];
+
+export function isLLMProviderName(value: unknown): value is LLMProviderName {
+  return typeof value === 'string' && (LLM_PROVIDERS as readonly string[]).includes(value);
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -125,7 +125,7 @@ CREATE TABLE submission (
 -- ---------------------------------------------------------------------
 -- Instructor LLM Config
 --
--- Stores the LLM provider + API key an instructor has configured for
+-- Stores the LLM provider + model + API key an instructor has configured for
 -- grading free-text submissions (submission.llm_provider). RLS-enabled
 -- with no client policies, same as question/answer/user_story — only a
 -- service-role route can read or write api_key, and that route is
@@ -135,6 +135,7 @@ CREATE TABLE instructor_llm_config (
     instructor_llm_config_id uuid      NOT NULL,
     user_id                  uuid      NOT NULL,
     provider                 text      NOT NULL,
+    model                    text      NOT NULL,
     api_key                  text      NOT NULL,
     is_active                bool      NOT NULL DEFAULT false,
     updated_at               timestamp NOT NULL DEFAULT now(),
@@ -467,3 +468,11 @@ CREATE POLICY own_submissions_insert ON submission
 -- requires "user" to already exist. uq_instructor_llm_config_one_active is a global partial
 -- unique index (not scoped by user_id) — at most one row across the whole table can have
 -- is_active = true at a time.
+
+-- LLM model selection: if your instructor_llm_config table already exists from an earlier run
+-- of this script, add the new column instead of recreating the table. model is NOT NULL with no
+-- DEFAULT (no single model is a sensible fallback across CLAUDE/CHATGPT/GEMINI) — safe today
+-- because nothing writes to this table yet, so it has no rows in any real deployment; if that
+-- stops being true before this runs, backfill a value before adding the constraint:
+--
+--   ALTER TABLE instructor_llm_config ADD COLUMN IF NOT EXISTS model text NOT NULL;


### PR DESCRIPTION
Adds instructor-side support for configuring which LLM grades free-text submissions.

- Schema: instructor_llm_config gets a new model column (NOT NULL, no default) alongside the existing provider/api_key, plus a migration-notes entry for existing databases.
- POST /api/instructor/llm-config: lets an instructor save a provider, model, and API key. Instructor-only (requireInstructor), validates provider against the allowed set, rejects an empty apiKey, and never echoes api_key back in the response. setActive: true deactivates the single global active row (uq_instructor_llm_config_one_active) before inserting the new one, with a bounded retry on the rare unique-index race.
- lib/llm: promotes the provider allow-list ('CLAUDE' | 'CHATGPT' | 'GEMINI') out of an inline type in factory.ts into an exported LLM_PROVIDERS / isLLMProviderName guard, so the new route (and any future one) can validate a request body against it instead of redeclaring the list.

Covered by 15 new tests in __tests__/api/instructor-llm-config.test.ts (auth/role rejections, validation, save + redaction, deactivation, and the race retry); full suite is green and npm run build is clean.

resolve #195 
resolve #143 