### PR TITLE
Add user_id to question table

### DIFF
--- a/__tests__/api/instructor-statistics.test.ts
+++ b/__tests__/api/instructor-statistics.test.ts
@@ -1,0 +1,206 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    filters: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly.
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+/** Queues the result the next `from(table)` chain resolves to. */
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/instructor/statistics/route';
+
+/** requireInstructor's own lookup: the caller's role, read from "user" first. */
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function queueActivityTypes(rows: { activity_type: string }[]) {
+  queue('activity_type', { data: rows, error: null });
+}
+
+function completedSession(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+    cumulative_score: 100,
+    max_score: 100,
+    passed: true,
+    ...overrides,
+  };
+}
+
+function request(token?: string) {
+  return new Request('http://localhost/api/instructor/statistics', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.filters = [];
+});
+
+describe('GET /api/instructor/statistics', () => {
+  it('answers 401 without a token', async () => {
+    const response = await GET(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('answers 401 for an invalid token', async () => {
+    const response = await GET(request('bad-token'));
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a student with 403 and an empty body, before reading any data', async () => {
+    queueRole('student');
+
+    const response = await GET(request('valid-token'));
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+    expect(h.state.tables).not.toContain('activity_type');
+    expect(h.state.tables).not.toContain('session_log');
+  });
+
+  it('rejects an account without a profile row, which has never been confirmed as an instructor', async () => {
+    queue('user', { data: null, error: null });
+
+    const response = await GET(request('valid-token'));
+
+    expect(response.status).toBe(403);
+    expect(h.state.tables).not.toContain('activity_type');
+  });
+
+  it('returns 404 when there are no quizzes at all', async () => {
+    queueRole('instructor');
+    queueActivityTypes([]);
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toMatch(/no quizzes/i);
+  });
+
+  it('computes class average as the mean of each attempt\'s own percentage, and pass rate as the passed share', async () => {
+    queueRole('instructor');
+    queueActivityTypes([{ activity_type: 'IDENTIFY_WEAK_USER_STORIES' }]);
+    queue('session_log', {
+      data: [
+        completedSession({ cumulative_score: 100, max_score: 100, passed: true }),
+        completedSession({ cumulative_score: 50, max_score: 100, passed: false }),
+        completedSession({ cumulative_score: 75, max_score: 100, passed: false }),
+      ],
+      error: null,
+    });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.statistics).toEqual([
+      { activityType: 'IDENTIFY_WEAK_USER_STORIES', classAverage: 75, passRate: 33 },
+    ]);
+  });
+
+  it('reports 0%/0% for a quiz with no completed attempts, rather than omitting it or dividing by zero', async () => {
+    queueRole('instructor');
+    queueActivityTypes([
+      { activity_type: 'IDENTIFY_WEAK_USER_STORIES' },
+      { activity_type: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA' },
+    ]);
+    queue('session_log', {
+      data: [completedSession({ activity_type: 'IDENTIFY_WEAK_USER_STORIES' })],
+      error: null,
+    });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.statistics).toContainEqual({
+      activityType: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA',
+      classAverage: 0,
+      passRate: 0,
+    });
+  });
+
+  it('only counts completed sessions', async () => {
+    queueRole('instructor');
+    queueActivityTypes([{ activity_type: 'IDENTIFY_WEAK_USER_STORIES' }]);
+    queue('session_log', { data: [], error: null });
+
+    await GET(request('valid-token'));
+
+    expect(h.state.filters).toContainEqual({ table: 'session_log', column: 'status', value: 'completed' });
+  });
+
+  it('returns 500 when the activity_type query fails', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: null, error: { message: 'boom' } });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('boom');
+  });
+
+  it('returns 500 when the session_log query fails', async () => {
+    queueRole('instructor');
+    queueActivityTypes([{ activity_type: 'IDENTIFY_WEAK_USER_STORIES' }]);
+    queue('session_log', { data: null, error: { message: 'boom' } });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('boom');
+  });
+});

--- a/app/api/instructor/statistics/route.ts
+++ b/app/api/instructor/statistics/route.ts
@@ -1,0 +1,45 @@
+import { getSupabaseClient } from '../../../../lib/supabase';
+import { requireInstructor } from '../../../../lib/instructorAuth';
+import { computeQuizStatistics } from '../../../../lib/quizStatisticsQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/instructor/statistics — class average and pass rate for each quiz, for an
+ * instructor (GitHub #114).
+ *
+ * "Each quiz of a professor" is, today, every row in the activity_type table (#122) — there is
+ * no professor-to-quiz ownership anywhere in the schema, the same gap already flagged for
+ * GitHub #115's "students of the current prof". Every instructor account sees the same
+ * statistics, class-wide.
+ */
+export async function GET(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    // 403 answers with no body at all (GitHub #169's acceptance criteria); 401 and 500 keep
+    // the { error } shape every other route uses.
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { statistics, error } = await computeQuizStatistics(supabase);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  // AC: 404 when there are no quizzes at all — not to be confused with a quiz that simply has
+  // no completed attempts yet, which still gets an entry (at 0%/0%).
+  if (!statistics || statistics.length === 0) {
+    return Response.json({ error: 'No quizzes found for this professor.' }, { status: 404 });
+  }
+
+  return Response.json({ statistics }, { status: 200 });
+}

--- a/lib/quizStatisticsQueries.ts
+++ b/lib/quizStatisticsQueries.ts
@@ -1,0 +1,74 @@
+// Shared logic for computing class average and pass rate per quiz (REQ-PL-3.2's instructor
+// review, GitHub #114), so the statistics route cannot drift from how these numbers are defined.
+
+import type { SupabaseClient } from './sessionQueries';
+
+export type QuizStatistics = {
+  activityType: string;
+  classAverage: number;
+  passRate: number;
+};
+
+type SessionRow = { activity_type: string; cumulative_score: number; max_score: number; passed: boolean };
+type ActivityTypeRow = { activity_type: string };
+
+/**
+ * Class average score and pass rate for every quiz (activity type), across every student's
+ * completed attempts. "Every quiz of the current professor" is, today, every row in the
+ * activity_type table (#122) — there is no professor-to-quiz ownership anywhere in the schema,
+ * the same gap noted for GitHub #115's "students of the current prof".
+ *
+ * classAverage is the mean of each completed session's own percentage (cumulative_score /
+ * max_score), not sum(cumulative_score) / sum(max_score) — so a quiz whose max_score happens to
+ * vary across sessions isn't skewed toward whichever attempts were worth more points. passRate
+ * is the share of a quiz's completed sessions with passed = true. A quiz with no completed
+ * sessions yet still gets an entry, at 0% for both, rather than being divided by zero.
+ *
+ * An empty activity_type table — no quizzes exist at all — is the only case that reports
+ * nothing; the caller turns that into the AC's 404.
+ */
+export async function computeQuizStatistics(supabase: SupabaseClient) {
+  const [{ data: activityRows, error: activityError }, { data: sessionRows, error: sessionError }] =
+    await Promise.all([
+      supabase.from('activity_type').select('activity_type'),
+      supabase
+        .from('session_log')
+        .select('activity_type, cumulative_score, max_score, passed')
+        .eq('status', 'completed'),
+    ]);
+
+  const error = activityError ?? sessionError ?? null;
+  if (error) return { statistics: null, error };
+
+  const activityTypes = (activityRows ?? []) as ActivityTypeRow[];
+  if (activityTypes.length === 0) return { statistics: [], error: null };
+
+  const byActivity = new Map<string, SessionRow[]>();
+  for (const row of (sessionRows ?? []) as SessionRow[]) {
+    const attempts = byActivity.get(row.activity_type) ?? [];
+    attempts.push(row);
+    byActivity.set(row.activity_type, attempts);
+  }
+
+  const statistics: QuizStatistics[] = activityTypes.map(({ activity_type: activityType }) => {
+    const attempts = byActivity.get(activityType) ?? [];
+
+    if (attempts.length === 0) {
+      return { activityType, classAverage: 0, passRate: 0 };
+    }
+
+    const totalPercent = attempts.reduce((sum, row) => {
+      return sum + (row.max_score > 0 ? (row.cumulative_score / row.max_score) * 100 : 0);
+    }, 0);
+
+    const passCount = attempts.filter((row) => row.passed).length;
+
+    return {
+      activityType,
+      classAverage: Math.round(totalPercent / attempts.length),
+      passRate: Math.round((passCount / attempts.length) * 100),
+    };
+  });
+
+  return { statistics, error: null };
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -62,6 +62,11 @@ CREATE TABLE question (
     activity_type varchar(50) NOT NULL,
     order_number int4 NOT NULL,
     max_score int4,
+    -- GitHub #201: the instructor who created the question, so #116 can scope "my quiz's
+    -- questions" to one professor. Nullable — the seeded question bank (supabase/seed.sql) has
+    -- no real "user" row to point at when it runs, and a question without a specific creator is
+    -- a legitimate state, not a data error.
+    user_id uuid,
     PRIMARY KEY (question_id));
 
 -- ---------------------------------------------------------------------
@@ -233,6 +238,11 @@ ALTER TABLE "user" ADD CONSTRAINT fk_user_auth_users FOREIGN KEY (user_id) REFER
 -- from #122, instead of being free text (question, session_log) or a hardcoded CHECK
 -- (title_definition, see the constraint removed below).
 ALTER TABLE question ADD CONSTRAINT fk_question_activity_type FOREIGN KEY (activity_type) REFERENCES activity_type (activity_type);
+
+-- GitHub #201: which instructor created the question. No ON DELETE clause on purpose — a
+-- deleted instructor account should not silently orphan or cascade-delete their questions;
+-- that decision is left for whoever eventually handles account deletion.
+ALTER TABLE question ADD CONSTRAINT fk_question_user FOREIGN KEY (user_id) REFERENCES "user" (user_id);
 
 ALTER TABLE question_to_answer ADD CONSTRAINT fk_question_to_answer_question FOREIGN KEY (question_id) REFERENCES question (question_id);
 ALTER TABLE question_to_answer ADD CONSTRAINT fk_question_to_answer_answer FOREIGN KEY (answer_id) REFERENCES answer (answer_id);
@@ -452,6 +462,14 @@ CREATE POLICY own_submissions_insert ON submission
 --   ALTER TABLE title_definition DROP CONSTRAINT IF EXISTS ck_title_definition_activity_type;
 --   ALTER TABLE title_definition ADD CONSTRAINT fk_title_definition_activity_type
 --     FOREIGN KEY (activity_type) REFERENCES activity_type (activity_type);
+
+-- GitHub #201 (question.user_id — which instructor created the question, for #116): if your
+-- "question" table predates this column, add it and its FK; existing rows get NULL, meaning
+-- no specific creator, same as a fresh run of this script gives the seeded question bank —
+--
+--   ALTER TABLE question ADD COLUMN IF NOT EXISTS user_id uuid;
+--   ALTER TABLE question ADD CONSTRAINT fk_question_user FOREIGN KEY (user_id) REFERENCES "user" (user_id);
+
 -- User Story bank (new table, no rename path — it has no starter-template or prior-schema
 -- predecessor): if your database already has everything above and you only need this table,
 -- run just its CREATE TABLE, CHECK constraint, index, fk_user_story_user, and RLS statements


### PR DESCRIPTION
In order to connect a question to a instructor, the table "question" gets the column "user_id" containing the user_id of the instructor who created the question.

The story is done when:

    The column user_id was added to the question table
    A foreign key constrain on the user_id was created
    All related api routes still work without conflicts
    The changes are live on the supabase
Resolve #201 