### PR TITLE
Wire instructor LLM config to the UI

### DIFF
--- a/__tests__/api/instructor-llm-config.test.ts
+++ b/__tests__/api/instructor-llm-config.test.ts
@@ -18,6 +18,8 @@ const h = vi.hoisted(() => {
         state.filters.push({ table, column, value });
         return builder;
       },
+      order: () => builder,
+      limit: () => builder,
       insert: (payload: unknown) => {
         state.inserts.push({ table, payload });
         return builder;
@@ -64,7 +66,7 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
-import { POST } from '../../app/api/instructor/llm-config/route';
+import { GET, POST } from '../../app/api/instructor/llm-config/route';
 
 function req(body: unknown, token: string | null = 'valid-token') {
   return new Request('http://localhost/api/instructor/llm-config', {
@@ -74,6 +76,13 @@ function req(body: unknown, token: string | null = 'valid-token') {
       ...(token ? { Authorization: `Bearer ${token}` } : {}),
     },
     body: JSON.stringify(body),
+  });
+}
+
+function getReq(token: string | null = 'valid-token') {
+  return new Request('http://localhost/api/instructor/llm-config', {
+    method: 'GET',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
 }
 
@@ -252,5 +261,78 @@ describe('POST /api/instructor/llm-config', () => {
     );
 
     expect(res.status).toBe(400);
+  });
+});
+
+describe('GET /api/instructor/llm-config', () => {
+  it("returns the caller's own most recent config, api key never included", async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: configRow(), error: null });
+
+    const res = await GET(getReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.config).toEqual(configRow());
+    expect(JSON.stringify(body)).not.toContain('api_key');
+
+    expect(h.state.filters).toContainEqual({
+      table: 'instructor_llm_config',
+      column: 'user_id',
+      value: 'instructor-1',
+    });
+  });
+
+  it('returns { config: null } when the instructor has never saved one', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: null, error: null });
+
+    const res = await GET(getReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ config: null });
+  });
+
+  it('answers 401 without a token', async () => {
+    const res = await GET(getReq(null));
+    const body = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(body.error).toBe('Unauthorized');
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('answers 401 for an invalid token', async () => {
+    const res = await GET(getReq('bad-token'));
+
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects a student with 403 and an empty body', async () => {
+    queueRole('student');
+    const res = await GET(getReq());
+
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('instructor_llm_config');
+  });
+
+  it('rejects an account without a profile row', async () => {
+    queue('user', { data: null, error: null });
+    const res = await GET(getReq());
+
+    expect(res.status).toBe(403);
+  });
+
+  it('answers 500 when the query fails', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: null, error: { message: 'boom' } });
+
+    const res = await GET(getReq());
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('boom');
   });
 });

--- a/__tests__/api/instructor-llm-config.test.ts
+++ b/__tests__/api/instructor-llm-config.test.ts
@@ -79,8 +79,8 @@ function req(body: unknown, token: string | null = 'valid-token') {
   });
 }
 
-function getReq(token: string | null = 'valid-token') {
-  return new Request('http://localhost/api/instructor/llm-config', {
+function getReq(token: string | null = 'valid-token', query = '') {
+  return new Request(`http://localhost/api/instructor/llm-config${query}`, {
     method: 'GET',
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
@@ -323,6 +323,59 @@ describe('GET /api/instructor/llm-config', () => {
     const res = await GET(getReq());
 
     expect(res.status).toBe(403);
+  });
+
+  it('filters by both provider and model when given', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: configRow({ provider: 'GEMINI', model: 'gemini-3.6-flash' }), error: null });
+
+    const res = await GET(getReq('valid-token', '?provider=GEMINI&model=gemini-3.6-flash'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.config).toEqual(configRow({ provider: 'GEMINI', model: 'gemini-3.6-flash' }));
+
+    expect(h.state.filters).toContainEqual({ table: 'instructor_llm_config', column: 'provider', value: 'GEMINI' });
+    expect(h.state.filters).toContainEqual({
+      table: 'instructor_llm_config',
+      column: 'model',
+      value: 'gemini-3.6-flash',
+    });
+  });
+
+  it('returns { config: null } for a valid pair the instructor never saved', async () => {
+    queueRole('instructor');
+    queue('instructor_llm_config', { data: null, error: null });
+
+    const res = await GET(getReq('valid-token', '?provider=CLAUDE&model=claude-sonnet-5'));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ config: null });
+  });
+
+  it('rejects an invalid provider in the filter with 400', async () => {
+    queueRole('instructor');
+    const res = await GET(getReq('valid-token', '?provider=LLAMA&model=llama-4'));
+
+    expect(res.status).toBe(400);
+    expect(h.state.tables).not.toContain('instructor_llm_config');
+  });
+
+  it('rejects provider without model with 400', async () => {
+    queueRole('instructor');
+    const res = await GET(getReq('valid-token', '?provider=CLAUDE'));
+
+    expect(res.status).toBe(400);
+    expect(h.state.tables).not.toContain('instructor_llm_config');
+  });
+
+  it('rejects model without provider with 400', async () => {
+    queueRole('instructor');
+    const res = await GET(getReq('valid-token', '?model=claude-opus-5'));
+
+    expect(res.status).toBe(400);
+    expect(h.state.tables).not.toContain('instructor_llm_config');
   });
 
   it('answers 500 when the query fails', async () => {

--- a/__tests__/lib/instructorLlmConfigClient.test.ts
+++ b/__tests__/lib/instructorLlmConfigClient.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadLlmConfig, saveLlmConfig } from '../../lib/instructorLlmConfigClient';
+
+// Client-side-of-the-wire test, same reasoning as __tests__/lib/sessionClient.test.ts's
+// stubFetch: the only collaborator to fake is fetch.
+
+const TOKEN = 'instructor-token';
+
+function stubFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
+  const spy = vi.fn(impl);
+  vi.stubGlobal('fetch', spy);
+  return spy;
+}
+
+function jsonResponse(body: unknown, status: number) {
+  return Promise.resolve(new Response(JSON.stringify(body), { status }));
+}
+
+const ROW = {
+  instructor_llm_config_id: 'config-1',
+  provider: 'CLAUDE',
+  model: 'claude-opus-5',
+  is_active: false,
+  updated_at: '2026-08-07T10:00:00.000Z',
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('loadLlmConfig', () => {
+  it('translates a returned row into hasApiKey: true, sends the bearer token', async () => {
+    const spy = stubFetch(() => jsonResponse({ config: ROW }, 200));
+
+    const result = await loadLlmConfig(TOKEN);
+
+    expect(result).toEqual({
+      ok: true,
+      data: { config: { provider: 'CLAUDE', model: 'claude-opus-5', hasApiKey: true, updatedAt: ROW.updated_at } },
+    });
+
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe('/api/instructor/llm-config');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('returns config: null when the instructor has no saved config', async () => {
+    stubFetch(() => jsonResponse({ config: null }, 200));
+
+    const result = await loadLlmConfig(TOKEN);
+
+    expect(result).toEqual({ ok: true, data: { config: null } });
+  });
+
+  it('propagates a non-ok response as ok: false', async () => {
+    stubFetch(() => jsonResponse({ error: 'Unauthorized' }, 401));
+
+    const result = await loadLlmConfig(TOKEN);
+
+    expect(result).toEqual({ ok: false, status: 401, error: 'Unauthorized' });
+  });
+});
+
+describe('saveLlmConfig', () => {
+  it('sends provider, model, and apiKey with the bearer token, translates the response', async () => {
+    const spy = stubFetch(() => jsonResponse({ config: ROW }, 200));
+
+    const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', 'sk-secret');
+
+    expect(result).toEqual({
+      ok: true,
+      data: { config: { provider: 'CLAUDE', model: 'claude-opus-5', hasApiKey: true, updatedAt: ROW.updated_at } },
+    });
+
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe('/api/instructor/llm-config');
+    expect(init.method).toBe('POST');
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+    expect(JSON.parse(init.body as string)).toEqual({
+      provider: 'CLAUDE',
+      model: 'claude-opus-5',
+      apiKey: 'sk-secret',
+    });
+  });
+
+  it('propagates a non-ok response as ok: false', async () => {
+    stubFetch(() => jsonResponse({ error: 'apiKey is required.' }, 400));
+
+    const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', '');
+
+    expect(result).toEqual({ ok: false, status: 400, error: 'apiKey is required.' });
+  });
+});

--- a/__tests__/lib/instructorLlmConfigClient.test.ts
+++ b/__tests__/lib/instructorLlmConfigClient.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { loadLlmConfig, saveLlmConfig } from '../../lib/instructorLlmConfigClient';
+import { checkLlmConfigForSelection, loadLlmConfig, saveLlmConfig } from '../../lib/instructorLlmConfigClient';
 
 // Client-side-of-the-wire test, same reasoning as __tests__/lib/sessionClient.test.ts's
 // stubFetch: the only collaborator to fake is fetch.
@@ -90,5 +90,39 @@ describe('saveLlmConfig', () => {
     const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', '');
 
     expect(result).toEqual({ ok: false, status: 400, error: 'apiKey is required.' });
+  });
+});
+
+describe('checkLlmConfigForSelection', () => {
+  it('sends provider and model as a query string, translates a returned row', async () => {
+    const spy = stubFetch(() => jsonResponse({ config: ROW }, 200));
+
+    const result = await checkLlmConfigForSelection(TOKEN, 'CLAUDE', 'claude-opus-5');
+
+    expect(result).toEqual({
+      ok: true,
+      data: { config: { provider: 'CLAUDE', model: 'claude-opus-5', hasApiKey: true, updatedAt: ROW.updated_at } },
+    });
+
+    const [url, init] = spy.mock.calls[0];
+    expect(url).toBe('/api/instructor/llm-config?provider=CLAUDE&model=claude-opus-5');
+    expect(init.method).toBe('GET');
+    expect((init.headers as Record<string, string>).Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('returns config: null for a pair with no saved key', async () => {
+    stubFetch(() => jsonResponse({ config: null }, 200));
+
+    const result = await checkLlmConfigForSelection(TOKEN, 'GEMINI', 'gemini-3.6-flash');
+
+    expect(result).toEqual({ ok: true, data: { config: null } });
+  });
+
+  it('propagates a non-ok response as ok: false', async () => {
+    stubFetch(() => jsonResponse({ error: 'provider must be one of CLAUDE, CHATGPT, GEMINI.' }, 400));
+
+    const result = await checkLlmConfigForSelection(TOKEN, 'CLAUDE', 'claude-opus-5');
+
+    expect(result).toEqual({ ok: false, status: 400, error: 'provider must be one of CLAUDE, CHATGPT, GEMINI.' });
   });
 });

--- a/__tests__/lib/instructorLlmConfigClient.test.ts
+++ b/__tests__/lib/instructorLlmConfigClient.test.ts
@@ -5,6 +5,7 @@ import { checkLlmConfigForSelection, loadLlmConfig, saveLlmConfig } from '../../
 // stubFetch: the only collaborator to fake is fetch.
 
 const TOKEN = 'instructor-token';
+const USER_ID = 'instructor-1';
 
 function stubFetch(impl: (url: string, init: RequestInit) => Promise<Response>) {
   const spy = vi.fn(impl);
@@ -32,7 +33,7 @@ describe('loadLlmConfig', () => {
   it('translates a returned row into hasApiKey: true, sends the bearer token', async () => {
     const spy = stubFetch(() => jsonResponse({ config: ROW }, 200));
 
-    const result = await loadLlmConfig(TOKEN);
+    const result = await loadLlmConfig(TOKEN, { userId: USER_ID });
 
     expect(result).toEqual({
       ok: true,
@@ -48,7 +49,7 @@ describe('loadLlmConfig', () => {
   it('returns config: null when the instructor has no saved config', async () => {
     stubFetch(() => jsonResponse({ config: null }, 200));
 
-    const result = await loadLlmConfig(TOKEN);
+    const result = await loadLlmConfig(TOKEN, { userId: USER_ID });
 
     expect(result).toEqual({ ok: true, data: { config: null } });
   });
@@ -56,7 +57,7 @@ describe('loadLlmConfig', () => {
   it('propagates a non-ok response as ok: false', async () => {
     stubFetch(() => jsonResponse({ error: 'Unauthorized' }, 401));
 
-    const result = await loadLlmConfig(TOKEN);
+    const result = await loadLlmConfig(TOKEN, { userId: USER_ID });
 
     expect(result).toEqual({ ok: false, status: 401, error: 'Unauthorized' });
   });
@@ -66,7 +67,7 @@ describe('saveLlmConfig', () => {
   it('sends provider, model, and apiKey with the bearer token, translates the response', async () => {
     const spy = stubFetch(() => jsonResponse({ config: ROW }, 200));
 
-    const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', 'sk-secret');
+    const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', 'sk-secret', { userId: USER_ID });
 
     expect(result).toEqual({
       ok: true,
@@ -87,7 +88,7 @@ describe('saveLlmConfig', () => {
   it('propagates a non-ok response as ok: false', async () => {
     stubFetch(() => jsonResponse({ error: 'apiKey is required.' }, 400));
 
-    const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', '');
+    const result = await saveLlmConfig(TOKEN, 'CLAUDE', 'claude-opus-5', '', { userId: USER_ID });
 
     expect(result).toEqual({ ok: false, status: 400, error: 'apiKey is required.' });
   });
@@ -97,7 +98,7 @@ describe('checkLlmConfigForSelection', () => {
   it('sends provider and model as a query string, translates a returned row', async () => {
     const spy = stubFetch(() => jsonResponse({ config: ROW }, 200));
 
-    const result = await checkLlmConfigForSelection(TOKEN, 'CLAUDE', 'claude-opus-5');
+    const result = await checkLlmConfigForSelection(TOKEN, 'CLAUDE', 'claude-opus-5', { userId: USER_ID });
 
     expect(result).toEqual({
       ok: true,
@@ -113,7 +114,7 @@ describe('checkLlmConfigForSelection', () => {
   it('returns config: null for a pair with no saved key', async () => {
     stubFetch(() => jsonResponse({ config: null }, 200));
 
-    const result = await checkLlmConfigForSelection(TOKEN, 'GEMINI', 'gemini-3.6-flash');
+    const result = await checkLlmConfigForSelection(TOKEN, 'GEMINI', 'gemini-3.6-flash', { userId: USER_ID });
 
     expect(result).toEqual({ ok: true, data: { config: null } });
   });
@@ -121,7 +122,7 @@ describe('checkLlmConfigForSelection', () => {
   it('propagates a non-ok response as ok: false', async () => {
     stubFetch(() => jsonResponse({ error: 'provider must be one of CLAUDE, CHATGPT, GEMINI.' }, 400));
 
-    const result = await checkLlmConfigForSelection(TOKEN, 'CLAUDE', 'claude-opus-5');
+    const result = await checkLlmConfigForSelection(TOKEN, 'CLAUDE', 'claude-opus-5', { userId: USER_ID });
 
     expect(result).toEqual({ ok: false, status: 400, error: 'provider must be one of CLAUDE, CHATGPT, GEMINI.' });
   });

--- a/app/api/instructor/llm-config/route.ts
+++ b/app/api/instructor/llm-config/route.ts
@@ -38,10 +38,15 @@ function getToken(request: Request): string | null {
  *
  * GET AC summary:
  *  - Same 401/403 as POST.
- *  - 200 with the caller's own most recently saved row (POST always inserts, never updates in
- *    place, so a caller can have several rows over time — this is the same "most recent row
- *    for this user_id" precedent the grading route uses for the story's creator), or
- *    `{ config: null }` if they've never saved one — a normal state, not a 404.
+ *  - No ?provider=&model= given: 200 with the caller's own most recently saved row (POST
+ *    always inserts, never updates in place, so a caller can have several rows over time —
+ *    this is the same "most recent row for this user_id" precedent the grading route uses for
+ *    the story's creator), or `{ config: null }` if they've never saved one — a normal state,
+ *    not a 404.
+ *  - ?provider=&model= given together: 200 with the most recent row for that *exact* pair, or
+ *    `{ config: null }` if the caller has never saved one for it, even if a different pair is
+ *    now their most recent save. 400 if provider isn't one of CLAUDE/CHATGPT/GEMINI, or only
+ *    one of the two query params is given.
  *  - 500 if Supabase isn't configured or the query fails.
  */
 export async function GET(request: Request) {
@@ -58,13 +63,26 @@ export async function GET(request: Request) {
         );
   }
 
-  const { data: config, error } = await supabase
-    .from('instructor_llm_config')
-    .select(CONFIG_COLUMNS)
-    .eq('user_id', guard.user_id)
-    .order('updated_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
+  const { searchParams } = new URL(request.url);
+  const providerParam = searchParams.get('provider');
+  const modelParam = searchParams.get('model');
+  const hasFilter = providerParam !== null || modelParam !== null;
+
+  if (hasFilter) {
+    if (!isLLMProviderName(providerParam)) {
+      return Response.json({ error: 'provider must be one of CLAUDE, CHATGPT, GEMINI.' }, { status: 400 });
+    }
+    if (!modelParam || modelParam.trim() === '') {
+      return Response.json({ error: 'model is required when filtering by provider.' }, { status: 400 });
+    }
+  }
+
+  let query = supabase.from('instructor_llm_config').select(CONFIG_COLUMNS).eq('user_id', guard.user_id);
+  if (hasFilter) {
+    query = query.eq('provider', providerParam).eq('model', modelParam);
+  }
+
+  const { data: config, error } = await query.order('updated_at', { ascending: false }).limit(1).maybeSingle();
 
   if (error) return Response.json({ error: error.message }, { status: 500 });
 

--- a/app/api/instructor/llm-config/route.ts
+++ b/app/api/instructor/llm-config/route.ts
@@ -15,8 +15,8 @@ function getToken(request: Request): string | null {
 }
 
 /**
- * POST /api/instructor/llm-config — an instructor saves an LLM provider + model + API key used
- * to grade free-text submissions (instructor_llm_config).
+ * GET/POST /api/instructor/llm-config — an instructor's LLM provider + model + API key used to
+ * grade free-text submissions (instructor_llm_config).
  *
  * Instructor-only: requireInstructor runs before any row is touched, the same guard every other
  * /api/instructor/* route uses.
@@ -29,13 +29,48 @@ function getToken(request: Request): string | null {
  * unique index; on that 23505 the pair is retried once, the same bounded-retry idea POST
  * /api/sessions uses for uq_session_log_one_active.
  *
- * AC summary:
+ * POST AC summary:
  *  - 401 if the bearer token is missing or invalid
  *  - 403 if the caller isn't an instructor (no body, matching requireInstructor's convention)
  *  - 400 if provider isn't one of CLAUDE/CHATGPT/GEMINI, or apiKey is empty
  *  - 200 with the saved row — api_key never included
  *  - 500 if Supabase isn't configured or a query fails
+ *
+ * GET AC summary:
+ *  - Same 401/403 as POST.
+ *  - 200 with the caller's own most recently saved row (POST always inserts, never updates in
+ *    place, so a caller can have several rows over time — this is the same "most recent row
+ *    for this user_id" precedent the grading route uses for the story's creator), or
+ *    `{ config: null }` if they've never saved one — a normal state, not a 404.
+ *  - 500 if Supabase isn't configured or the query fails.
  */
+export async function GET(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { data: config, error } = await supabase
+    .from('instructor_llm_config')
+    .select(CONFIG_COLUMNS)
+    .eq('user_id', guard.user_id)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ config: config ?? null }, { status: 200 });
+}
+
 export async function POST(request: Request) {
   const supabase = getSupabaseClient();
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });

--- a/components/LLMProviderSettingsForm.tsx
+++ b/components/LLMProviderSettingsForm.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { PasswordField } from './PasswordField';
-import { loadLlmConfig, saveLlmConfig } from '../lib/instructorLlmConfigClient';
+import { checkLlmConfigForSelection, loadLlmConfig, saveLlmConfig } from '../lib/instructorLlmConfigClient';
 import { LLM_MODELS_BY_PROVIDER, LLM_PROVIDERS, type InstructorLlmConfig, type LLMProviderId } from '../lib/instructorLlmConfigTypes';
 
 const PILL_BASE = 'rounded-full border px-3.5 py-1.5 text-xs font-bold transition';
@@ -22,7 +22,12 @@ const PILL_INACTIVE = 'border-gray-300 bg-white text-gray-600 hover:border-brand
  * default true, since nothing else on that page renders a title for it.
  */
 export function LLMProviderSettingsForm({ token, showHeading = true }: { token: string; showHeading?: boolean }) {
-  const [config, setConfig] = useState<InstructorLlmConfig | null>(null);
+  // Always represents "is there a saved key for the *currently selected* provider+model pair" —
+  // refreshed via checkSelection() on every change, not derived by comparing against a single
+  // cached value. POST never updates a row in place, so an earlier pair can still have a saved
+  // key even once a different pair becomes the instructor's most recent save; only the backend
+  // can answer "does this exact pair have one."
+  const [selectionConfig, setSelectionConfig] = useState<InstructorLlmConfig | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
 
@@ -34,6 +39,10 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
   const [submitting, setSubmitting] = useState(false);
   const [saveError, setSaveError] = useState('');
   const [saveSuccess, setSaveSuccess] = useState(false);
+
+  // Tracks the most recently requested pair, so a slower response to an earlier change can't
+  // clobber a newer one if the instructor clicks through providers/models quickly.
+  const latestSelectionRef = useRef({ provider, model });
 
   useEffect(() => {
     let cancelled = false;
@@ -47,10 +56,13 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
         return;
       }
 
+      // The unfiltered fetch already returns the row for whichever pair it is — no extra
+      // per-pair check call needed to know the answer for this initial selection.
       if (result.data.config) {
-        setConfig(result.data.config);
+        setSelectionConfig(result.data.config);
         setProvider(result.data.config.provider);
         setModel(result.data.config.model);
+        latestSelectionRef.current = { provider: result.data.config.provider, model: result.data.config.model };
       }
       setIsLoading(false);
     });
@@ -60,23 +72,43 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
     };
   }, [token]);
 
+  async function checkSelection(nextProvider: LLMProviderId, nextModel: string) {
+    latestSelectionRef.current = { provider: nextProvider, model: nextModel };
+    // Clear immediately so the previous pair's "already saved" text doesn't flash for the new
+    // pair while the check is in flight.
+    setSelectionConfig(null);
+
+    const result = await checkLlmConfigForSelection(token, nextProvider, nextModel);
+    const stillCurrent =
+      latestSelectionRef.current.provider === nextProvider && latestSelectionRef.current.model === nextModel;
+    if (!stillCurrent) return; // superseded by a newer selection before this resolved
+
+    // A failed check is swallowed — this is a secondary UX nicety, not worth a hard error
+    // state; the indicator just won't show "already saved" until the next successful check.
+    if (result.ok) setSelectionConfig(result.data.config);
+  }
+
   // Switching provider invalidates the previous model choice — each provider's model list is
   // disjoint — so this lands on that provider's first model, same as how the provider pills
-  // themselves always have a selected default rather than an empty state.
+  // themselves always have a selected default rather than an empty state. A provider change is
+  // a pair change too, so it needs the same live check as a plain model change.
   function handleProviderChange(nextProvider: LLMProviderId) {
+    const nextModel = LLM_MODELS_BY_PROVIDER[nextProvider][0].id;
     setProvider(nextProvider);
-    setModel(LLM_MODELS_BY_PROVIDER[nextProvider][0].id);
+    setModel(nextModel);
+    checkSelection(nextProvider, nextModel);
+  }
+
+  function handleModelChange(nextModel: string) {
+    setModel(nextModel);
+    checkSelection(provider, nextModel);
   }
 
   const modelOptions = LLM_MODELS_BY_PROVIDER[provider];
   // Provider/model always have a default value (never actually blank), so in practice this
   // gates on the one field that starts empty: the API key.
   const canSave = Boolean(provider && model && apiKeyInput.trim());
-  // The API only ever returns the instructor's single most-recently-saved row (one config
-  // total, not one per provider/model), so "already saved" is only true when the currently
-  // selected provider AND model are the exact pair that row was saved for — otherwise the
-  // saved key belongs to a different combination and doesn't cover this one.
-  const hasSavedKeyForSelection = Boolean(config?.hasApiKey && config.provider === provider && config.model === model);
+  const hasSavedKeyForSelection = Boolean(selectionConfig?.hasApiKey);
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -96,8 +128,9 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
 
     // Refresh local state straight from the response — the form reflects the new saved config
     // immediately, no refetch/reload needed — and clear the typed key so it never lingers in
-    // state once it's been sent.
-    setConfig(result.data.config);
+    // state once it's been sent. The response is the row for the pair just submitted, so it's
+    // exactly what selectionConfig should hold now.
+    setSelectionConfig(result.data.config);
     setApiKeyInput('');
     setSaveSuccess(true);
   }
@@ -148,7 +181,7 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
             Model
             <select
               value={model}
-              onChange={(event) => setModel(event.target.value)}
+              onChange={(event) => handleModelChange(event.target.value)}
               className="mt-1.5 block w-full rounded-brand-md border border-gray-300 bg-white px-3.5 py-2.5 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
             >
               {modelOptions.map((option) => (

--- a/components/LLMProviderSettingsForm.tsx
+++ b/components/LLMProviderSettingsForm.tsx
@@ -72,6 +72,11 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
   // Provider/model always have a default value (never actually blank), so in practice this
   // gates on the one field that starts empty: the API key.
   const canSave = Boolean(provider && model && apiKeyInput.trim());
+  // The API only ever returns the instructor's single most-recently-saved row (one config
+  // total, not one per provider/model), so "already saved" is only true when the currently
+  // selected provider AND model are the exact pair that row was saved for — otherwise the
+  // saved key belongs to a different combination and doesn't cover this one.
+  const hasSavedKeyForSelection = Boolean(config?.hasApiKey && config.provider === provider && config.model === model);
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
@@ -158,13 +163,14 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
             label="API Key"
             value={apiKeyInput}
             onChange={setApiKeyInput}
-            placeholder={config?.hasApiKey ? '•••• already saved' : 'Paste your API key'}
+            placeholder={hasSavedKeyForSelection ? '•••• already saved' : 'Paste your API key'}
             autoComplete="off"
             variant="light"
           />
-          {config?.hasApiKey ? (
+          {hasSavedKeyForSelection ? (
             <p className="mt-1.5 text-xs font-semibold text-gray-500">
-              A key for {LLM_PROVIDERS.find((p) => p.id === config.provider)?.label} is already saved.
+              A key for {LLM_PROVIDERS.find((p) => p.id === provider)?.label} (
+              {modelOptions.find((m) => m.id === model)?.label}) is already saved.
             </p>
           ) : null}
 

--- a/components/LLMProviderSettingsForm.tsx
+++ b/components/LLMProviderSettingsForm.tsx
@@ -164,7 +164,7 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
           />
           {config?.hasApiKey ? (
             <p className="mt-1.5 text-xs font-semibold text-gray-500">
-              A key for {LLM_PROVIDERS.find((p) => p.id === config.provider)?.label} is already saved. Enter a new key to replace it.
+              A key for {LLM_PROVIDERS.find((p) => p.id === config.provider)?.label} is already saved.
             </p>
           ) : null}
 

--- a/components/LLMProviderSettingsForm.tsx
+++ b/components/LLMProviderSettingsForm.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { PasswordField } from './PasswordField';
+import { useUser } from './UserProvider';
 import { checkLlmConfigForSelection, loadLlmConfig, saveLlmConfig } from '../lib/instructorLlmConfigClient';
 import { LLM_MODELS_BY_PROVIDER, LLM_PROVIDERS, type InstructorLlmConfig, type LLMProviderId } from '../lib/instructorLlmConfigTypes';
 
@@ -22,6 +23,12 @@ const PILL_INACTIVE = 'border-gray-300 bg-white text-gray-600 hover:border-brand
  * default true, since nothing else on that page renders a title for it.
  */
 export function LLMProviderSettingsForm({ token, showHeading = true }: { token: string; showHeading?: boolean }) {
+  // Only used to key the local cache (lib/instructorLlmConfigStore.ts) per instructor, the same
+  // way components/AppShell.tsx already reads profile.user_id off this hook — not threaded in
+  // as a prop, since neither of this component's two hosts otherwise needs it.
+  const { profile } = useUser();
+  const userId = profile?.user_id;
+
   // Always represents "is there a saved key for the *currently selected* provider+model pair" —
   // refreshed via checkSelection() on every change, not derived by comparing against a single
   // cached value. POST never updates a row in place, so an earlier pair can still have a saved
@@ -47,7 +54,7 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
   useEffect(() => {
     let cancelled = false;
 
-    loadLlmConfig(token).then((result) => {
+    loadLlmConfig(token, { userId }).then((result) => {
       if (cancelled) return;
 
       if (!result.ok) {
@@ -78,7 +85,7 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
     // pair while the check is in flight.
     setSelectionConfig(null);
 
-    const result = await checkLlmConfigForSelection(token, nextProvider, nextModel);
+    const result = await checkLlmConfigForSelection(token, nextProvider, nextModel, { userId });
     const stillCurrent =
       latestSelectionRef.current.provider === nextProvider && latestSelectionRef.current.model === nextModel;
     if (!stillCurrent) return; // superseded by a newer selection before this resolved
@@ -118,7 +125,7 @@ export function LLMProviderSettingsForm({ token, showHeading = true }: { token: 
     setSaveSuccess(false);
     setSubmitting(true);
 
-    const result = await saveLlmConfig(token, provider, model, apiKeyInput);
+    const result = await saveLlmConfig(token, provider, model, apiKeyInput, { userId });
     setSubmitting(false);
 
     if (!result.ok) {

--- a/lib/instructorLlmConfigClient.ts
+++ b/lib/instructorLlmConfigClient.ts
@@ -64,6 +64,27 @@ export async function loadLlmConfig(token: string): Promise<ApiResult<{ config: 
 }
 
 /**
+ * GET .../llm-config?provider=&model=: does the instructor have a previously saved key for
+ * this *exact* provider/model pair? Distinct from loadLlmConfig's unfiltered "most recent
+ * config overall" — POST never updates in place, so an earlier pair can still have a saved key
+ * even once a different pair becomes the most recent save.
+ */
+export async function checkLlmConfigForSelection(
+  token: string,
+  provider: LLMProviderId,
+  model: string,
+): Promise<ApiResult<{ config: InstructorLlmConfig | null }>> {
+  const params = new URLSearchParams({ provider, model });
+  const result = await request<{ config: ConfigRow | null }>(
+    `/api/instructor/llm-config?${params.toString()}`,
+    { method: 'GET' },
+    token,
+  );
+  if (!result.ok) return result;
+  return { ok: true, data: { config: toInstructorLlmConfig(result.data.config) } };
+}
+
+/**
  * POST .../llm-config: saves provider, model, and key together. All three are required —
  * LLMProviderSettingsForm only calls this once its own canSave check (provider + model + a
  * non-blank key) passes, but the route validates independently regardless.

--- a/lib/instructorLlmConfigClient.ts
+++ b/lib/instructorLlmConfigClient.ts
@@ -1,59 +1,76 @@
 'use client';
 
-// GitHub #150: client for the instructor LLM provider settings page.
-//
-// No real backend route exists for this yet (nothing under app/api/instructor/llm-config or
-// similar — searched before writing this). supabase/schema.sql's instructor_llm_config table
-// and lib/llm/factory.ts's getLLMProvider already exist for real, so the shapes below are
-// modeled on that table's columns (see lib/instructorLlmConfigTypes.ts) rather than invented.
-//
-// Still missing for a real, secure backend integration:
-//   - GET  /api/instructor/llm-config  → requireInstructor() (lib/instructorAuth.ts), then
-//     read the caller's own instructor_llm_config row and return { provider, model, hasApiKey,
-//     updatedAt } — never api_key itself.
-//   - POST /api/instructor/llm-config  → requireInstructor(), validate provider is one
-//     getLLMProvider recognizes, upsert the row keyed by user_id. api_key must never be logged
-//     (no console.log/error of the request body or the row), and should be encrypted at rest,
-//     not stored as plain text the way the current schema.sql column does — that's a schema
-//     change (e.g. pgsodium/pgcrypto) beyond what this UI issue covers.
-//   - instructor_llm_config has no `model` column at all yet, and every *Provider.ts class
-//     (lib/llm/providers/) hardcodes a single MODEL constant instead of accepting one — a real
-//     integration needs both a schema column and each provider class/getLLMProvider threading
-//     the chosen model through to its API call.
-//   - uq_instructor_llm_config_one_active is a *global* partial unique index — only one row in
-//     the whole table can have is_active = true at a time (grading has no per-instructor/course
-//     scoping yet). This mock has no is_active concept at all; a real route needs to decide how
-//     "Save" here relates to activating a config for the whole app, which isn't specified by
-//     this issue's acceptance criteria.
-//   - Rate limiting / key format validation per provider, so a typo'd key fails fast instead of
-//     surfacing as a confusing grading-time error later.
+// GitHub #150: client for the instructor LLM provider settings page. Same role as
+// lib/acceptanceCriteriaClient.ts for the write-acceptance-criteria flow: the one place the UI
+// talks to GET/POST /api/instructor/llm-config, so no component hand-rolls the Authorization
+// header or picks apart an error body.
 
 import type { InstructorLlmConfig, LLMProviderId } from './instructorLlmConfigTypes';
 
 export type ApiResult<T> = { ok: true; data: T } | { ok: false; status: number; error: string };
 
-const MOCK_DELAY_MS = 500;
+const NETWORK_ERROR = 'Could not reach the server. Please try again.';
 
-function delay(ms: number) {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+async function request<T>(url: string, init: RequestInit, token: string): Promise<ApiResult<T>> {
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      ...init,
+      headers: { ...init.headers, Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    // status 0 marks "never reached the server", so callers can tell it apart from a 500.
+    return { ok: false, status: 0, error: NETWORK_ERROR };
+  }
+
+  const body = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    return { ok: false, status: response.status, error: body?.error || 'Something went wrong.' };
+  }
+
+  return { ok: true, data: body as T };
 }
 
-// Module-level "server" — resets on a hard reload, same as every other not-yet-backed mock in
-// this codebase (lib/mockQuestions.ts, lib/mockUserStories.ts). Deliberately not localStorage:
-// even mocked, an API key has no business sitting in the browser's persistent storage.
-let mockConfig: InstructorLlmConfig | null = null;
+// The raw row app/api/instructor/llm-config/route.ts returns (its CONFIG_COLUMNS) — never
+// includes api_key.
+type ConfigRow = {
+  instructor_llm_config_id: string;
+  provider: string;
+  model: string;
+  is_active: boolean;
+  updated_at: string;
+};
 
-/** Mocks GET .../llm-config: the signed-in instructor's current provider + whether a key is saved. */
+// is_active is a global "which config grading currently defaults to" flag, unrelated to
+// whether *this* row has a key — POST 400s on a blank apiKey, so every row the API ever
+// returns has one by construction. "A row exists" is exactly "a key is saved".
+function toInstructorLlmConfig(row: ConfigRow | null): InstructorLlmConfig | null {
+  if (!row) return null;
+  return {
+    provider: row.provider as LLMProviderId,
+    model: row.model,
+    hasApiKey: true,
+    updatedAt: row.updated_at,
+  };
+}
+
+/** GET .../llm-config: the signed-in instructor's own most recently saved config, if any. */
 export async function loadLlmConfig(token: string): Promise<ApiResult<{ config: InstructorLlmConfig | null }>> {
-  void token;
-  await delay(MOCK_DELAY_MS);
-  return { ok: true, data: { config: mockConfig } };
+  const result = await request<{ config: ConfigRow | null }>('/api/instructor/llm-config', { method: 'GET' }, token);
+  if (!result.ok) return result;
+  return { ok: true, data: { config: toInstructorLlmConfig(result.data.config) } };
 }
 
 /**
- * Mocks POST .../llm-config: saves provider, model, and key together. All three are required —
+ * POST .../llm-config: saves provider, model, and key together. All three are required —
  * LLMProviderSettingsForm only calls this once its own canSave check (provider + model + a
- * non-blank key) passes, so an empty apiKey here would mean that check was bypassed.
+ * non-blank key) passes, but the route validates independently regardless.
+ *
+ * setActive is intentionally omitted: the settings form has no control for it, and grading
+ * (app/api/activities/write-acceptance-criteria/submissions/route.ts) scopes by the story's
+ * creator_id, not by the global is_active flag, so there's nothing here for it to affect.
  */
 export async function saveLlmConfig(
   token: string,
@@ -61,13 +78,16 @@ export async function saveLlmConfig(
   model: string,
   apiKey: string,
 ): Promise<ApiResult<{ config: InstructorLlmConfig }>> {
-  void token;
-  await delay(MOCK_DELAY_MS);
+  const result = await request<{ config: ConfigRow }>(
+    '/api/instructor/llm-config',
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ provider, model, apiKey }),
+    },
+    token,
+  );
 
-  if (!apiKey.trim()) {
-    return { ok: false, status: 400, error: 'API key is required.' };
-  }
-
-  mockConfig = { provider, model, hasApiKey: true, updatedAt: new Date().toISOString() };
-  return { ok: true, data: { config: mockConfig } };
+  if (!result.ok) return result;
+  return { ok: true, data: { config: toInstructorLlmConfig(result.data.config)! } };
 }

--- a/lib/instructorLlmConfigClient.ts
+++ b/lib/instructorLlmConfigClient.ts
@@ -5,6 +5,12 @@
 // talks to GET/POST /api/instructor/llm-config, so no component hand-rolls the Authorization
 // header or picks apart an error body.
 
+import {
+  getCachedLlmConfig,
+  getCachedLlmConfigForSelection,
+  setCachedLlmConfig,
+  setCachedLlmConfigForSelection,
+} from './instructorLlmConfigStore';
 import type { InstructorLlmConfig, LLMProviderId } from './instructorLlmConfigTypes';
 
 export type ApiResult<T> = { ok: true; data: T } | { ok: false; status: number; error: string };
@@ -56,11 +62,30 @@ function toInstructorLlmConfig(row: ConfigRow | null): InstructorLlmConfig | nul
   };
 }
 
-/** GET .../llm-config: the signed-in instructor's own most recently saved config, if any. */
-export async function loadLlmConfig(token: string): Promise<ApiResult<{ config: InstructorLlmConfig | null }>> {
+/**
+ * GET .../llm-config: the signed-in instructor's own most recently saved config, if any.
+ *
+ * Cached in localStorage (lib/instructorLlmConfigStore.ts) when userId is given — the same
+ * "optional key opts into the cache" shape as lib/sessionClient.ts's loadSessions, since userId
+ * (from useUser()'s profile) may not have loaded yet when this is first called. A plain call is
+ * served from the cache when present; pass forceRefresh to bypass it and re-cache the server's
+ * answer.
+ */
+export async function loadLlmConfig(
+  token: string,
+  options: { userId?: string; forceRefresh?: boolean } = {},
+): Promise<ApiResult<{ config: InstructorLlmConfig | null }>> {
+  if (options.userId && !options.forceRefresh) {
+    const cached = getCachedLlmConfig(options.userId);
+    if (cached !== null) return { ok: true, data: cached };
+  }
+
   const result = await request<{ config: ConfigRow | null }>('/api/instructor/llm-config', { method: 'GET' }, token);
   if (!result.ok) return result;
-  return { ok: true, data: { config: toInstructorLlmConfig(result.data.config) } };
+
+  const data = { config: toInstructorLlmConfig(result.data.config) };
+  if (options.userId) setCachedLlmConfig(options.userId, data);
+  return { ok: true, data };
 }
 
 /**
@@ -68,12 +93,20 @@ export async function loadLlmConfig(token: string): Promise<ApiResult<{ config: 
  * this *exact* provider/model pair? Distinct from loadLlmConfig's unfiltered "most recent
  * config overall" — POST never updates in place, so an earlier pair can still have a saved key
  * even once a different pair becomes the most recent save.
+ *
+ * Same cache shape as loadLlmConfig, keyed additionally by provider+model.
  */
 export async function checkLlmConfigForSelection(
   token: string,
   provider: LLMProviderId,
   model: string,
+  options: { userId?: string; forceRefresh?: boolean } = {},
 ): Promise<ApiResult<{ config: InstructorLlmConfig | null }>> {
+  if (options.userId && !options.forceRefresh) {
+    const cached = getCachedLlmConfigForSelection(options.userId, provider, model);
+    if (cached !== null) return { ok: true, data: cached };
+  }
+
   const params = new URLSearchParams({ provider, model });
   const result = await request<{ config: ConfigRow | null }>(
     `/api/instructor/llm-config?${params.toString()}`,
@@ -81,7 +114,10 @@ export async function checkLlmConfigForSelection(
     token,
   );
   if (!result.ok) return result;
-  return { ok: true, data: { config: toInstructorLlmConfig(result.data.config) } };
+
+  const data = { config: toInstructorLlmConfig(result.data.config) };
+  if (options.userId) setCachedLlmConfigForSelection(options.userId, provider, model, data);
+  return { ok: true, data };
 }
 
 /**
@@ -92,12 +128,17 @@ export async function checkLlmConfigForSelection(
  * setActive is intentionally omitted: the settings form has no control for it, and grading
  * (app/api/activities/write-acceptance-criteria/submissions/route.ts) scopes by the story's
  * creator_id, not by the global is_active flag, so there's nothing here for it to affect.
+ *
+ * On success, writes through to both caches — the pair just saved, and the "most recent
+ * overall" slot, since a fresh save *is* now the most recent — no extra round trip needed, the
+ * response here is already the authoritative new state.
  */
 export async function saveLlmConfig(
   token: string,
   provider: LLMProviderId,
   model: string,
   apiKey: string,
+  options: { userId?: string } = {},
 ): Promise<ApiResult<{ config: InstructorLlmConfig }>> {
   const result = await request<{ config: ConfigRow }>(
     '/api/instructor/llm-config',
@@ -110,5 +151,11 @@ export async function saveLlmConfig(
   );
 
   if (!result.ok) return result;
-  return { ok: true, data: { config: toInstructorLlmConfig(result.data.config)! } };
+
+  const data = { config: toInstructorLlmConfig(result.data.config)! };
+  if (options.userId) {
+    setCachedLlmConfigForSelection(options.userId, provider, model, data);
+    setCachedLlmConfig(options.userId, data);
+  }
+  return { ok: true, data };
 }

--- a/lib/instructorLlmConfigStore.ts
+++ b/lib/instructorLlmConfigStore.ts
@@ -1,0 +1,72 @@
+// Local cache for the instructor's LLM provider config (GET /api/instructor/llm-config), so the
+// settings screen doesn't have to hit the network on every mount or every provider/model
+// switch. Same shape as lib/completedAttemptsStore.ts: a versioned key, an SSR-guarded
+// read/write pair, and only typed getter/setter functions exported — never the raw store.
+//
+// Two independent slots per instructor: the "most recent overall" config (single key, like
+// lib/scoreStore.ts) used to prefill the form on mount, and one entry per (provider, model)
+// pair actually checked (compound key, like lib/completedAttemptsStore.ts) used by the live
+// per-selection check. Both cache { config: InstructorLlmConfig | null } — the wrapper object,
+// not the bare config — so a confirmed "no key for this pair" (config: null) is distinguishable
+// from "never checked" (no entry at all); a bare null value couldn't tell those apart once read
+// back through `store[key] ?? null`.
+import type { InstructorLlmConfig, LLMProviderId } from './instructorLlmConfigTypes';
+
+const STORAGE_KEY = 'rc_instructor_llm_config_v1';
+
+type CachedConfig = { config: InstructorLlmConfig | null };
+type Store = Partial<Record<string, CachedConfig>>;
+
+function latestKey(userId: string): string {
+  return `${userId}:latest`;
+}
+
+function selectionKey(userId: string, provider: LLMProviderId, model: string): string {
+  return `${userId}:${provider}:${model}`;
+}
+
+function readStore(): Store {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as Store) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: Store) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedLlmConfig(userId: string): CachedConfig | null {
+  const store = readStore();
+  return store[latestKey(userId)] ?? null;
+}
+
+export function setCachedLlmConfig(userId: string, data: CachedConfig): void {
+  const store = readStore();
+  store[latestKey(userId)] = data;
+  writeStore(store);
+}
+
+export function getCachedLlmConfigForSelection(
+  userId: string,
+  provider: LLMProviderId,
+  model: string,
+): CachedConfig | null {
+  const store = readStore();
+  return store[selectionKey(userId, provider, model)] ?? null;
+}
+
+export function setCachedLlmConfigForSelection(
+  userId: string,
+  provider: LLMProviderId,
+  model: string,
+  data: CachedConfig,
+): void {
+  const store = readStore();
+  store[selectionKey(userId, provider, model)] = data;
+  writeStore(store);
+}


### PR DESCRIPTION
- **New GET /api/instructor/llm-config route** — returns the signed-in instructor's saved config (provider, model, whether a key is set — the raw key itself is never returned), with optional ?provider=&model= query params to check a specific pair rather than just the most recent save.
- **Connected LLMProviderSettingsForm.tsx to the real API** — the form now loads the saved config on mount, saves through the real POST route, and re-checks the backend live whenever the instructor changes the provider or model dropdown (so the "already saved" indicator reflects that exact pair, not just the last-saved one). Previously this all lived only in a local mock.
- **Added a local cache** (lib/instructorLlmConfigStore.ts) in front of both reads, so reopening the settings form or switching back to an already-checked provider/model pair is served instantly instead of round-tripping to the API. Writes (saves) update the cache directly, so it's never stale after a save.

resolve #144 
resolve #147 
resolve #208 
resolve #209 