### PR TITLE
Add POST /api/activities/types to create a new activity type

### DIFF
--- a/__tests__/api/activity-types.test.ts
+++ b/__tests__/api/activity-types.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    inserts: [] as { table: string; payload: unknown }[],
+    user: { id: 'instructor-1' } as { id: string } | null,
+    role: 'instructor' as string,
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let insertPayload: unknown = null;
+    const builder: Record<string, unknown> = {
+      insert: (payload: unknown) => {
+        insertPayload = payload;
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      select: () => builder,
+      eq: () => builder,
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    from: (table: string) => {
+      const queued = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, queued);
+    },
+    auth: {
+      getUser: async () => ({
+        data: { user: h.state.user },
+        error: null,
+      }),
+    },
+  }),
+}));
+
+import { POST } from '../../app/api/activities/types/route';
+
+function makeRequest(body: unknown) {
+  return new Request('http://localhost/api/activities/types', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: 'Bearer test-token' },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.inserts = [];
+  h.state.user = { id: 'instructor-1' };
+  h.state.role = 'instructor';
+});
+
+describe('POST /api/activities/types', () => {
+  it('returns 401 when no token is provided', async () => {
+    h.state.user = null;
+    const req = new Request('http://localhost/api/activities/types', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ activityType: 'NEW_ACTIVITY' }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the user is not an instructor', async () => {
+    h.state.queues['user'] = [{ data: { role: 'student' }, error: null }];
+    const res = await POST(makeRequest({ activityType: 'NEW_ACTIVITY' }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when activityType is missing', async () => {
+    h.state.queues['user'] = [{ data: { role: 'instructor' }, error: null }];
+    const res = await POST(makeRequest({}));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/activityType/i);
+  });
+
+  it('returns 400 when activityType is empty', async () => {
+    h.state.queues['user'] = [{ data: { role: 'instructor' }, error: null }];
+    const res = await POST(makeRequest({ activityType: '  ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when activityType exceeds 50 characters', async () => {
+    h.state.queues['user'] = [{ data: { role: 'instructor' }, error: null }];
+    const res = await POST(makeRequest({ activityType: 'A'.repeat(51) }));
+    expect(res.status).toBe(400);
+  });
+
+  it('creates the activity type and returns 201 with the activity_type', async () => {
+    h.state.queues['user'] = [{ data: { role: 'instructor' }, error: null }];
+    h.state.queues['activity_type'] = [{ data: { activity_type: 'NEW_ACTIVITY' }, error: null }];
+
+    const res = await POST(makeRequest({ activityType: 'NEW_ACTIVITY' }));
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.activity_type).toBe('NEW_ACTIVITY');
+  });
+
+  it('returns 409 when the activity type already exists', async () => {
+    h.state.queues['user'] = [{ data: { role: 'instructor' }, error: null }];
+    h.state.queues['activity_type'] = [{ data: null, error: { code: '23505', message: 'duplicate key' } }];
+
+    const res = await POST(makeRequest({ activityType: 'EXISTING_ACTIVITY' }));
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/already exists/i);
+  });
+
+  it('returns 500 when the database returns an error', async () => {
+    h.state.queues['user'] = [{ data: { role: 'instructor' }, error: null }];
+    h.state.queues['activity_type'] = [{ data: null, error: { code: '99999', message: 'DB error' } }];
+
+    const res = await POST(makeRequest({ activityType: 'NEW_ACTIVITY' }));
+    expect(res.status).toBe(500);
+  });
+});

--- a/app/api/activities/types/route.ts
+++ b/app/api/activities/types/route.ts
@@ -1,0 +1,61 @@
+import { getSupabaseClient } from '../../../../lib/supabase';
+import { requireInstructor } from '../../../../lib/instructorAuth';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * POST /api/activities/types
+ *
+ * Creates a new activity type in the activity_type lookup table.
+ * Only instructors can create activity types.
+ *
+ * Body: { activityType: string }
+ * Returns: { activity_type: string }
+ */
+export async function POST(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json({ error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' }, { status: guard.status });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { activityType } = (body ?? {}) as { activityType?: unknown };
+
+  if (typeof activityType !== 'string' || activityType.trim() === '') {
+    return Response.json({ error: 'activityType is required.' }, { status: 400 });
+  }
+
+  const trimmed = activityType.trim();
+  if (trimmed.length > 50) {
+    return Response.json({ error: 'activityType must be 50 characters or fewer.' }, { status: 400 });
+  }
+
+  const { data, error } = await supabase
+    .from('activity_type')
+    .insert({ activity_type: trimmed })
+    .select('activity_type')
+    .maybeSingle();
+
+  if (error) {
+    if (error.code === '23505') {
+      return Response.json({ error: 'Activity type already exists.' }, { status: 409 });
+    }
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json({ activity_type: (data as { activity_type: string }).activity_type }, { status: 201 });
+}


### PR DESCRIPTION
Adds a new route that allows instructors to create a new activity type in the database. Previously, activity types had to be inserted manually via Supabase.

resolve #126
