### PR TITLE
Add GET /api/instructor/students route with instructor guard

### DIFF
--- a/__tests__/api/instructor-students.test.ts
+++ b/__tests__/api/instructor-students.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    filters: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/instructor/students/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function makeRequest(token?: string) {
+  return new Request('http://localhost/api/instructor/students', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe('GET /api/instructor/students', () => {
+  beforeEach(() => {
+    h.state.queues = {};
+    h.state.filters = [];
+  });
+
+  it('returns 401 when no token is provided', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when the token is invalid', async () => {
+    const res = await GET(makeRequest('bad-token'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when the caller is a student', async () => {
+    queueRole('student');
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('returns 200 with the student list', async () => {
+    queueRole('instructor');
+    queue('user', {
+      data: [
+        { user_id: 'u1', username: 'alice', first_name: 'Alice', last_name: 'Smith' },
+        { user_id: 'u2', username: 'bob', first_name: 'Bob', last_name: 'Jones' },
+      ],
+      error: null,
+    });
+
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.students).toHaveLength(2);
+    expect(body.students[0]).toEqual({
+      userId: 'u1',
+      username: 'alice',
+      firstName: 'Alice',
+      lastName: 'Smith',
+    });
+    expect(body.students[1]).toEqual({
+      userId: 'u2',
+      username: 'bob',
+      firstName: 'Bob',
+      lastName: 'Jones',
+    });
+  });
+
+  it('returns 200 with empty list when no students exist', async () => {
+    queueRole('instructor');
+    queue('user', { data: [], error: null });
+
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.students).toEqual([]);
+  });
+
+  it('filters the user table by role = student', async () => {
+    queueRole('instructor');
+    queue('user', { data: [], error: null });
+
+    await GET(makeRequest('valid-token'));
+
+    const studentFilter = h.state.filters.find(
+      (f) => f.table === 'user' && f.column === 'role' && f.value === 'student',
+    );
+    expect(studentFilter).toBeDefined();
+  });
+
+  it('returns 500 when the database returns an error', async () => {
+    queueRole('instructor');
+    queue('user', { data: null, error: { message: 'DB failure' } });
+
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('DB failure');
+  });
+});

--- a/app/api/instructor/students/route.ts
+++ b/app/api/instructor/students/route.ts
@@ -1,0 +1,58 @@
+import { getSupabaseClient } from '../../../../lib/supabase';
+import { requireInstructor } from '../../../../lib/instructorAuth';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+type StudentRow = {
+  user_id: string;
+  username: string;
+  first_name: string;
+  last_name: string;
+};
+
+/**
+ * GET /api/instructor/students — every student in the system (GitHub #145).
+ *
+ * Not scoped per-professor: the course has one instructor seat and one shared roster, so
+ * filtering by who is asking would return the same list every time and just add a join.
+ * This is a documented simplification captured in the issue.
+ *
+ * An empty list is a 200, not a 404 — a class with no students yet is a normal state.
+ *
+ * getSupabaseClient() is the service-role client and bypasses RLS entirely, which is why
+ * requireInstructor must run before any data is read. That guard, not the database, is what
+ * stops a student from pulling the full roster.
+ */
+export async function GET(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { data, error } = await supabase
+    .from('user')
+    .select('user_id, username, first_name, last_name')
+    .eq('role', 'student');
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  const students = ((data ?? []) as StudentRow[]).map((row) => ({
+    userId: row.user_id,
+    username: row.username,
+    firstName: row.first_name,
+    lastName: row.last_name,
+  }));
+
+  return Response.json({ students }, { status: 200 });
+}


### PR DESCRIPTION
- Adds GET /api/instructor/students — returns every student as { userId, username, firstName, lastName }
- Protected by requireInstructor: 401, 403 for non-instructors, 200 for empty list, 500 on DB error
- 7 unit tests covering all status codes and the role=student filter

Resolves #145