### PR TITLE
Add GET /api/instructor/acceptance-criteria/statistics route

### DIFF
--- a/__tests__/api/instructor-ac-statistics.test.ts
+++ b/__tests__/api/instructor-ac-statistics.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = { queues: {} as Record<string, Result[]> };
+
+  function makeBuilder(result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      const result = h.state.queues[table]?.shift() ?? { data: [], error: null };
+      return h.makeBuilder(result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/instructor/acceptance-criteria/statistics/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function makeRequest(token?: string) {
+  return new Request('http://localhost/api/instructor/acceptance-criteria/statistics', {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+describe('GET /api/instructor/acceptance-criteria/statistics', () => {
+  beforeEach(() => {
+    h.state.queues = {};
+  });
+
+  it('returns 401 when no token is provided', async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 when the token is invalid', async () => {
+    const res = await GET(makeRequest('bad-token'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with empty body when caller is a student', async () => {
+    queueRole('student');
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('returns 200 with zeroed stats when no submissions exist', async () => {
+    queueRole('instructor');
+    queue('submission', { data: [], error: null });
+    queue('user_story', { data: [], error: null });
+
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(200);
+
+    const { statistics } = await res.json();
+    expect(statistics.totalSubmissions).toBe(0);
+    expect(statistics.gradedSubmissions).toBe(0);
+    expect(statistics.averageScore).toBeNull();
+    expect(statistics.studentsAttempted).toBe(0);
+    expect(statistics.byUserStory).toEqual([]);
+  });
+
+  it('returns correct aggregates for mixed graded and ungraded submissions', async () => {
+    queueRole('instructor');
+    queue('submission', {
+      data: [
+        { user_id: 'u1', user_story_id: 'us1', llm_score: 8 },
+        { user_id: 'u2', user_story_id: 'us1', llm_score: 6 },
+        { user_id: 'u1', user_story_id: 'us2', llm_score: null },
+      ],
+      error: null,
+    });
+    queue('user_story', {
+      data: [
+        { user_story_id: 'us1', story_text: 'Story A' },
+        { user_story_id: 'us2', story_text: 'Story B' },
+      ],
+      error: null,
+    });
+
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(200);
+
+    const { statistics } = await res.json();
+    expect(statistics.totalSubmissions).toBe(3);
+    expect(statistics.gradedSubmissions).toBe(2);
+    expect(statistics.averageScore).toBe(7);
+    expect(statistics.studentsAttempted).toBe(2);
+  });
+
+  it('includes user stories with no submissions in byUserStory', async () => {
+    queueRole('instructor');
+    queue('submission', {
+      data: [{ user_id: 'u1', user_story_id: 'us1', llm_score: 5 }],
+      error: null,
+    });
+    queue('user_story', {
+      data: [
+        { user_story_id: 'us1', story_text: 'Story A' },
+        { user_story_id: 'us2', story_text: 'Story B — never attempted' },
+      ],
+      error: null,
+    });
+
+    const res = await GET(makeRequest('valid-token'));
+    const { statistics } = await res.json();
+
+    const storyB = statistics.byUserStory.find((s: { userStoryId: string }) => s.userStoryId === 'us2');
+    expect(storyB).toBeDefined();
+    expect(storyB.submissionCount).toBe(0);
+    expect(storyB.averageScore).toBeNull();
+  });
+
+  it('sorts byUserStory lowest-average-first with null-average rows last', async () => {
+    queueRole('instructor');
+    queue('submission', {
+      data: [
+        { user_id: 'u1', user_story_id: 'us1', llm_score: 9 },
+        { user_id: 'u2', user_story_id: 'us2', llm_score: 4 },
+      ],
+      error: null,
+    });
+    queue('user_story', {
+      data: [
+        { user_story_id: 'us1', story_text: 'High avg' },
+        { user_story_id: 'us2', story_text: 'Low avg' },
+        { user_story_id: 'us3', story_text: 'No submissions' },
+      ],
+      error: null,
+    });
+
+    const res = await GET(makeRequest('valid-token'));
+    const { statistics } = await res.json();
+    const ids = statistics.byUserStory.map((s: { userStoryId: string }) => s.userStoryId);
+
+    expect(ids).toEqual(['us2', 'us1', 'us3']);
+  });
+
+  it('computes scoreDistribution correctly', async () => {
+    queueRole('instructor');
+    queue('submission', {
+      data: [
+        { user_id: 'u1', user_story_id: 'us1', llm_score: 7 },
+        { user_id: 'u2', user_story_id: 'us1', llm_score: 7 },
+        { user_id: 'u3', user_story_id: 'us1', llm_score: 9 },
+      ],
+      error: null,
+    });
+    queue('user_story', { data: [{ user_story_id: 'us1', story_text: 'Story A' }], error: null });
+
+    const res = await GET(makeRequest('valid-token'));
+    const { statistics } = await res.json();
+
+    const bucket7 = statistics.scoreDistribution.find((b: { score: number }) => b.score === 7);
+    const bucket9 = statistics.scoreDistribution.find((b: { score: number }) => b.score === 9);
+    const bucket1 = statistics.scoreDistribution.find((b: { score: number }) => b.score === 1);
+    expect(bucket7.count).toBe(2);
+    expect(bucket9.count).toBe(1);
+    expect(bucket1.count).toBe(0);
+  });
+
+  it('returns 500 when submission query fails', async () => {
+    queueRole('instructor');
+    queue('submission', { data: null, error: { message: 'DB error' } });
+    queue('user_story', { data: [], error: null });
+
+    const res = await GET(makeRequest('valid-token'));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('DB error');
+  });
+});

--- a/app/api/instructor/acceptance-criteria/statistics/route.ts
+++ b/app/api/instructor/acceptance-criteria/statistics/route.ts
@@ -1,0 +1,36 @@
+import { getSupabaseClient } from '../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../lib/instructorAuth';
+import { computeAcceptanceCriteriaStatistics } from '../../../../../lib/acceptanceCriteriaStatisticsQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/instructor/acceptance-criteria/statistics — class-wide aggregates for the
+ * write-acceptance-criteria activity (GitHub #152).
+ *
+ * An empty submission table still returns 200 with zeroed stats — no submissions yet is a
+ * normal state, not an error. No per-student data is returned; use the per-student route for
+ * individual review.
+ */
+export async function GET(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { statistics, error } = await computeAcceptanceCriteriaStatistics(supabase);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ statistics }, { status: 200 });
+}

--- a/lib/acceptanceCriteriaStatisticsQueries.ts
+++ b/lib/acceptanceCriteriaStatisticsQueries.ts
@@ -1,0 +1,126 @@
+import type { SupabaseClient } from './sessionQueries';
+
+type SubmissionRow = { user_id: string; user_story_id: string; llm_score: number | null };
+type UserStoryRow = { user_story_id: string; story_text: string };
+
+export type ScoreDistributionEntry = { score: number; count: number };
+
+export type ByUserStoryEntry = {
+  userStoryId: string;
+  storyText: string;
+  submissionCount: number;
+  averageScore: number | null;
+};
+
+export type AcceptanceCriteriaStatistics = {
+  totalSubmissions: number;
+  gradedSubmissions: number;
+  averageScore: number | null;
+  studentsAttempted: number;
+  scoreDistribution: ScoreDistributionEntry[];
+  byUserStory: ByUserStoryEntry[];
+};
+
+/**
+ * Class-wide statistics for the write-acceptance-criteria activity (GitHub #152).
+ *
+ * Pulls only the columns needed for aggregation — user_id, user_story_id, llm_score — rather
+ * than every submission row in full (submitted_text, llm_feedback etc. are irrelevant here and
+ * would bloat the payload). The math is done here, not in the route, so the route stays thin
+ * and the aggregation logic can be tested independently.
+ *
+ * Only graded rows (llm_score IS NOT NULL) feed the numeric averages — an ungraded row
+ * shouldn't count as a zero or drag the average down before the LLM has run.
+ *
+ * byUserStory covers every row in user_story, not just ones that have submissions — a story
+ * nobody has tried yet shows submissionCount: 0 and averageScore: null rather than being
+ * omitted, because "nobody has attempted this" is itself signal.
+ */
+export async function computeAcceptanceCriteriaStatistics(supabase: SupabaseClient): Promise<{
+  statistics: AcceptanceCriteriaStatistics | null;
+  error: { message: string } | null;
+}> {
+  const [
+    { data: submissionRows, error: submissionError },
+    { data: storyRows, error: storyError },
+  ] = await Promise.all([
+    supabase.from('submission').select('user_id, user_story_id, llm_score'),
+    supabase.from('user_story').select('user_story_id, story_text'),
+  ]);
+
+  const error = submissionError ?? storyError ?? null;
+  if (error) return { statistics: null, error };
+
+  const submissions = (submissionRows ?? []) as SubmissionRow[];
+  const stories = (storyRows ?? []) as UserStoryRow[];
+  const graded = submissions.filter((s) => s.llm_score !== null);
+
+  const totalSubmissions = submissions.length;
+  const gradedSubmissions = graded.length;
+
+  const averageScore =
+    gradedSubmissions === 0
+      ? null
+      : Math.round(
+          (graded.reduce((sum, s) => sum + (s.llm_score as number), 0) / gradedSubmissions) * 10,
+        ) / 10;
+
+  const studentsAttempted = new Set(submissions.map((s) => s.user_id)).size;
+
+  const scoreCounts = new Map<number, number>();
+  for (let i = 1; i <= 10; i++) scoreCounts.set(i, 0);
+  for (const s of graded) {
+    const score = s.llm_score as number;
+    if (score >= 1 && score <= 10) scoreCounts.set(score, (scoreCounts.get(score) ?? 0) + 1);
+  }
+  const scoreDistribution: ScoreDistributionEntry[] = Array.from(scoreCounts.entries()).map(
+    ([score, count]) => ({ score, count }),
+  );
+
+  const submissionsByStory = new Map<string, SubmissionRow[]>();
+  for (const s of submissions) {
+    const rows = submissionsByStory.get(s.user_story_id) ?? [];
+    rows.push(s);
+    submissionsByStory.set(s.user_story_id, rows);
+  }
+
+  const byUserStory: ByUserStoryEntry[] = stories.map((story) => {
+    const storySubmissions = submissionsByStory.get(story.user_story_id) ?? [];
+    const storyGraded = storySubmissions.filter((s) => s.llm_score !== null);
+    const storyAvg =
+      storyGraded.length === 0
+        ? null
+        : Math.round(
+            (storyGraded.reduce((sum, s) => sum + (s.llm_score as number), 0) /
+              storyGraded.length) *
+              10,
+          ) / 10;
+
+    return {
+      userStoryId: story.user_story_id,
+      storyText: story.story_text,
+      submissionCount: storySubmissions.length,
+      averageScore: storyAvg,
+    };
+  });
+
+  // Lowest-average-first; null-average rows (no graded submissions) last.
+  byUserStory.sort((a, b) => {
+    if (a.averageScore === null && b.averageScore === null) return 0;
+    if (a.averageScore === null) return 1;
+    if (b.averageScore === null) return -1;
+    return a.averageScore - b.averageScore;
+  });
+
+  return {
+    statistics: {
+      totalSubmissions,
+      gradedSubmissions,
+      averageScore,
+      studentsAttempted,
+      scoreDistribution,
+      byUserStory,
+    },
+    error: null,
+  };
+}


### PR DESCRIPTION
- Adds GET /api/instructor/acceptance-criteria/statistics — class-wide aggregates for the write-acceptance-criteria activity
- Returns totalSubmissions, gradedSubmissions, averageScore (one decimal, graded only), studentsAttempted, scoreDistribution (count per 1–10), byUserStory (every story, sorted lowest-average-first, null-average last)
- Only graded rows (llm_score IS NOT NULL) count toward numeric averages
- Protected by requireInstructor: 401, 403 for non-instructors, 200 for empty table, 500 on DB error
- 9 unit tests covering all status codes, aggregation logic, sorting, and score distribution

Resolves #152
