### PR TITLE
Add local cache for student acceptance-criteria submissions

### DIFF
--- a/lib/acceptanceCriteriaSubmissionsStore.ts
+++ b/lib/acceptanceCriteriaSubmissionsStore.ts
@@ -1,0 +1,39 @@
+// Local cache for a student's acceptance-criteria submission history
+// (GET /api/instructor/students/{id}/acceptance-criteria/submissions, GitHub #153).
+// Same shape as activityLogStore.ts: versioned key, SSR-guarded read/write, only typed
+// getter/setter exported — no raw store object.
+//
+// Keyed by studentId so switching students in the Review page is a cache hit after first visit.
+// No invalidation is needed on the instructor side: grading happens once from the student's
+// submission flow and the row is then read-only until a future "retry grading" story.
+import type { SubmissionEntry } from './sessionClient';
+
+const STORAGE_KEY = 'rc_ac_submissions_v1';
+
+type AcceptanceCriteriaSubmissionsStore = Partial<Record<string, SubmissionEntry[]>>;
+
+function readStore(): AcceptanceCriteriaSubmissionsStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as AcceptanceCriteriaSubmissionsStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: AcceptanceCriteriaSubmissionsStore) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedAcceptanceCriteriaSubmissions(studentId: string): SubmissionEntry[] | null {
+  const store = readStore();
+  return store[studentId] ?? null;
+}
+
+export function setCachedAcceptanceCriteriaSubmissions(studentId: string, submissions: SubmissionEntry[]): void {
+  const store = readStore();
+  store[studentId] = submissions;
+  writeStore(store);
+}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -14,6 +14,10 @@ import { getCachedCompletedAttempts, setCachedCompletedAttempts } from './comple
 import { getCachedActivityLog, setCachedActivityLog } from './activityLogStore';
 import { getCachedCompletedSessions, setCachedCompletedSessions } from './completedSessionsStore';
 import { getCachedScore, setCachedScore } from './scoreStore';
+import {
+  getCachedAcceptanceCriteriaSubmissions,
+  setCachedAcceptanceCriteriaSubmissions,
+} from './acceptanceCriteriaSubmissionsStore';
 
 // The row shapes themselves live in lib/sessionTypes.ts, which imports nothing, so the routes
 // can share them without importing this 'use client' module. Re-exported here so this file
@@ -343,6 +347,53 @@ export function loadActivityLog(
  */
 export function loadInstructorActivities(token: string) {
   return request<{ sessions: InstructorActivityEntry[] }>('/api/instructor/activities', { method: 'GET' }, token);
+}
+
+/** One acceptance-criteria submission row as returned by the submissions API. */
+export type SubmissionEntry = {
+  submissionId: string;
+  userStoryId: string;
+  storyText: string;
+  submittedText: string;
+  llmScore: number | null;
+  llmFeedback: string | null;
+  submittedAt: string;
+  gradedAt: string | null;
+};
+
+/**
+ * A student's acceptance-criteria submission history
+ * (GET /api/instructor/students/{studentId}/acceptance-criteria/submissions, GitHub #153).
+ *
+ * Cache-first: returns the stored list on a hit, calls the network only on a miss or when
+ * forceRefresh is true — same pattern as loadActivityLog. The cache is keyed by studentId so
+ * switching between students in the Review page is a hit after the first visit.
+ */
+export function loadAcceptanceCriteriaSubmissions(
+  token: string,
+  studentId: string,
+  options: { forceRefresh?: boolean } = {},
+) {
+  if (!options.forceRefresh) {
+    const cached = getCachedAcceptanceCriteriaSubmissions(studentId);
+    if (cached !== null) {
+      return Promise.resolve<ApiResult<{ submissions: SubmissionEntry[] }>>({
+        ok: true,
+        data: { submissions: cached },
+      });
+    }
+  }
+
+  return request<{ submissions: SubmissionEntry[] }>(
+    `/api/instructor/students/${encodeURIComponent(studentId)}/acceptance-criteria/submissions`,
+    { method: 'GET' },
+    token,
+  ).then((result) => {
+    if (result.ok) {
+      setCachedAcceptanceCriteriaSubmissions(studentId, result.data.submissions);
+    }
+    return result;
+  });
 }
 
 /**


### PR DESCRIPTION
- Adds lib/acceptanceCriteriaSubmissionsStore.ts — versioned localStorage cache (rc_ac_submissions_v1) keyed by studentId, SSR-guarded, only typed getter/setter exported
- Adds SubmissionEntry type to sessionClient.ts — defined once, shared between store and client
- Adds loadAcceptanceCriteriaSubmissions(token, studentId, { forceRefresh }?) — cache-first wrapper, same pattern as loadActivityLog

Resolves #153
