### PR TITLE
Fix score display to use score/maxScore percentage instead of raw score

### DIFF
--- a/components/ActivityLogRow.tsx
+++ b/components/ActivityLogRow.tsx
@@ -96,12 +96,14 @@ export function ActivityLogRow({
               state === 'passed' ? 'bg-brand-teal' : state === 'in-progress' ? 'bg-brand-purple' : 'bg-brand-danger'
             }`}
             style={{
-              width: state === 'in-progress' ? `${(entry.answeredQuestions / entry.totalQuestions) * 100}%` : `${entry.score}%`,
+              width: state === 'in-progress'
+                ? `${(entry.answeredQuestions / entry.totalQuestions) * 100}%`
+                : `${Math.min(100, Math.max(0, entry.maxScore > 0 ? (entry.score / entry.maxScore) * 100 : 0))}%`,
             }}
           />
         </div>
         <div className="mt-1 whitespace-nowrap text-xs font-semibold text-brand-ink-muted">
-          {state === 'in-progress' || state === 'abandoned' ? `${entry.answeredQuestions} of ${entry.totalQuestions} answered` : `${entry.score}%`}
+          {state === 'in-progress' || state === 'abandoned' ? `${entry.answeredQuestions} of ${entry.totalQuestions} answered` : `${entry.maxScore > 0 ? Math.round((entry.score / entry.maxScore) * 100) : 0}%`}
         </div>
       </td>
       <td className="px-4 py-3.5">

--- a/components/InstructorActivityStats.tsx
+++ b/components/InstructorActivityStats.tsx
@@ -6,9 +6,11 @@ export function InstructorActivityStats({ entries }: { entries: StudentActivityS
   return (
     <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
       {ACTIVITIES.map((activity) => {
-        const completed = entries.filter((entry) => entry.activityType === activity.activityType && entry.status === 'completed');
+        const completed = entries.filter((entry) => entry.activityType === activity.activityType && entry.status === 'completed' && entry.maxScore > 0);
         const average =
-          completed.length === 0 ? null : Math.round(completed.reduce((sum, entry) => sum + entry.score, 0) / completed.length);
+          completed.length === 0
+            ? null
+            : Math.round(completed.reduce((sum, entry) => sum + (entry.score / entry.maxScore) * 100, 0) / completed.length);
         const passRate =
           completed.length === 0 ? null : Math.round((completed.filter((entry) => entry.passed).length / completed.length) * 100);
 

--- a/lib/activityLogTypes.ts
+++ b/lib/activityLogTypes.ts
@@ -81,9 +81,11 @@ export function summarizeStudents(entries: StudentActivitySummary[]): StudentAgg
 
   return [...byStudent.entries()]
     .map(([studentId, list]) => {
-      const completed = list.filter((entry) => entry.status === 'completed');
+      const completed = list.filter((entry) => entry.status === 'completed' && entry.maxScore > 0);
       const averageScore =
-        completed.length === 0 ? null : Math.round(completed.reduce((sum, entry) => sum + entry.score, 0) / completed.length);
+        completed.length === 0
+          ? null
+          : Math.round(completed.reduce((sum, entry) => sum + (entry.score / entry.maxScore) * 100, 0) / completed.length);
       const abandonedCount = list.filter((entry) => entry.status === 'abandoned').length;
 
       return {


### PR DESCRIPTION
- summarizeStudents in lib/activityLogTypes.ts now derives averageScore from score/maxScore per entry; sessions with maxScore <= 0 are excluded to avoid division by zero
- ActivityLogRow progress bar width uses score/maxScore clamped to 0–100 instead of raw score
- ActivityLogRow percentage label computes score/maxScore * 100 rounded
- InstructorActivityStats averages score/maxScore * 100 across completed sessions with maxScore > 0
- LOW_SCORE_THRESHOLD and needsAttention remain expressed against the percentage, unchanged

Resolves #165
