### PR TITLE
Fix mastery titles by reading from API instead of mock localStorage s…

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { ActivityLogRow } from "../../components/ActivityLogRow";
 import { ACTIVITIES, Difficulty } from "../../lib/activityContent";
 import { toActivityLogEntry } from "../../lib/activityLogTypes";
 import { ActivityState, getActivityState } from "../../lib/activityStore";
-import { type SessionListEntry, loadSessions } from "../../lib/sessionClient";
+import { type SessionListEntry, type StudentTitle, loadSessions, loadStudentTitles } from "../../lib/sessionClient";
 import { useRequireRole } from "../../lib/useRequireRole";
 
 const RECENT_LIMIT = 3;
@@ -29,6 +29,7 @@ export default function DashboardPage() {
     ActivityState
   > | null>(null);
   const [recent, setRecent] = useState<SessionListEntry[] | null>(null);
+  const [titles, setTitles] = useState<StudentTitle[] | null>(null);
 
   useEffect(() => {
     if (!token) return;
@@ -53,6 +54,16 @@ export default function DashboardPage() {
     return () => {
       cancelled = true;
     };
+  }, [token, profile?.user_id]);
+
+  useEffect(() => {
+    if (!token || !profile?.user_id) return;
+    let cancelled = false;
+    loadStudentTitles(token, profile.user_id).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setTitles(result.data.titles);
+    });
+    return () => { cancelled = true; };
   }, [token, profile?.user_id]);
 
   // Blank rather than a "logged out" message while useRequireRole's effect redirects — for
@@ -243,13 +254,8 @@ export default function DashboardPage() {
       </h3>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {ACTIVITIES.map((activity) => {
-          const state = statesBySlug?.[activity.slug];
-          const passedLevels =
-            state?.history.filter((h) => h.passed).map((h) => h.level) ?? [];
-          const highest =
-            passedLevels.length > 0
-              ? (Math.max(...passedLevels) as Difficulty)
-              : null;
+          const titleEntry = titles?.find((t) => t.activityType === activity.activityType);
+          const highest = (titleEntry?.difficultyLevel ?? null) as Difficulty | null;
           return (
             <div
               key={activity.slug}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -345,6 +345,29 @@ export function loadInstructorActivities(token: string) {
   return request<{ sessions: InstructorActivityEntry[] }>('/api/instructor/activities', { method: 'GET' }, token);
 }
 
+/** One mastery title entry as returned by GET /api/students/{id}/titles. */
+export type StudentTitle = {
+  activityType: string;
+  difficultyLevel: number | null;
+  title: string | null;
+};
+
+/**
+ * The student's current mastery title per activity type
+ * (GET /api/students/{studentId}/titles, REQ-GAM-BL-1).
+ *
+ * Not cached: titles change whenever a session completes with passed=true, and the dashboard
+ * that shows them re-mounts on every visit — hitting the network once per page load is cheap
+ * enough that a cache would just risk showing a stale title after a student passes a new level.
+ */
+export function loadStudentTitles(token: string, studentId: string) {
+  return request<{ titles: StudentTitle[] }>(
+    `/api/students/${encodeURIComponent(studentId)}/titles`,
+    { method: 'GET' },
+    token,
+  );
+}
+
 /**
  * Commits one answer. The score is decided by the server from the answer bank — it is
  * neither sent nor trusted from here.


### PR DESCRIPTION
- Adds loadStudentTitles(token, studentId) to sessionClient.ts — fetches GET /api/students/{id}/titles
- Dashboard now fetches real mastery title data from the DB on mount instead of reading from the stale mock localStorage store (activityStore.ts)
- After passing level 1, the unlocked title now appears correctly on the dashboard

Resolves #204
