### PR TITLE
Add local cache for instructor student roster with loadInstructorStud…

### DIFF
--- a/app/instructor/page.tsx
+++ b/app/instructor/page.tsx
@@ -15,7 +15,7 @@ import {
 import { InstructorDashboardSkeleton } from '../../components/InstructorDashboardSkeleton';
 import { InstructorRoster } from '../../components/InstructorRoster';
 import { summarizeStudents, toStudentActivitySummary, type StudentActivitySummary } from '../../lib/activityLogTypes';
-import { loadInstructorActivities, type InstructorActivityEntry } from '../../lib/sessionClient';
+import { loadInstructorActivities, loadInstructorStudents, type InstructorActivityEntry, type StudentSummary } from '../../lib/sessionClient';
 import { useRequireRole } from '../../lib/useRequireRole';
 
 const PAGE_SIZE = 10;
@@ -33,10 +33,11 @@ export default function InstructorDashboardPage() {
 function InstructorDashboardContent() {
   // GitHub #82: redirects anyone who isn't a confirmed instructor — see lib/useRequireRole.ts
   // for exactly what "confirmed" means for a profile-less or student account.
-  const { token, loading, authorized } = useRequireRole('instructor');
+  const { token, profile, loading, authorized } = useRequireRole('instructor');
   const searchParams = useSearchParams();
 
   const [entries, setEntries] = useState<StudentActivitySummary[] | null>(null);
+  const [allStudents, setAllStudents] = useState<StudentSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const [studentId, setStudentId] = useState<StudentFilterValue>('all');
@@ -67,10 +68,19 @@ function InstructorDashboardContent() {
     };
   }, [token]);
 
+  useEffect(() => {
+    if (!token || !profile?.user_id) return;
+    let cancelled = false;
+    loadInstructorStudents(token, profile.user_id).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setAllStudents(result.data.students);
+    });
+    return () => { cancelled = true; };
+  }, [token, profile?.user_id]);
+
   const roster = useMemo(() => summarizeStudents(entries ?? []), [entries]);
 
-  // Keyed by studentId, not by the attempt's own id (GitHub #174): a returning student owns many
-  // rows, and every one of them has to resolve to the same name from a single entry.
+  // Used by ActivityLogTable to resolve a student name for each attempt row.
   const studentNameById = useMemo(
     () => new Map((entries ?? []).map((entry) => [entry.studentId, entry.studentName])),
     [entries],
@@ -78,10 +88,10 @@ function InstructorDashboardContent() {
 
   const students = useMemo(
     () =>
-      [...studentNameById.entries()]
-        .map(([id, name]) => ({ id, name }))
+      (allStudents ?? [])
+        .map((s) => ({ id: s.userId, name: `${s.firstName} ${s.lastName}`.trim() || s.username }))
         .sort((a, b) => a.name.localeCompare(b.name)),
-    [studentNameById],
+    [allStudents],
   );
 
   // Lets app/instructor/students/page.tsx link straight into a filtered table

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -11,7 +11,7 @@ import {
   type StudentActivitySummary,
   type StudentAggregate,
 } from '../../../lib/activityLogTypes';
-import { loadInstructorActivities, type InstructorActivityEntry } from '../../../lib/sessionClient';
+import { loadInstructorActivities, loadInstructorStudents, type InstructorActivityEntry } from '../../../lib/sessionClient';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
 const PAGE_SIZE = 9;
@@ -37,7 +37,7 @@ function compareByScore(a: StudentAggregate, b: StudentAggregate, direction: 1 |
  */
 export default function AllStudentsPage() {
   const router = useRouter();
-  const { token, loading, authorized } = useRequireRole('instructor');
+  const { token, profile, loading, authorized } = useRequireRole('instructor');
 
   const [entries, setEntries] = useState<StudentActivitySummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -65,6 +65,16 @@ export default function AllStudentsPage() {
       cancelled = true;
     };
   }, [token]);
+
+  useEffect(() => {
+    if (!token || !profile?.user_id) return;
+    let cancelled = false;
+    loadInstructorStudents(token, profile.user_id).then((result) => {
+      if (cancelled || !result.ok) return;
+      // Warms the cache so repeat visits don't re-fetch the full roster.
+    });
+    return () => { cancelled = true; };
+  }, [token, profile?.user_id]);
 
   const allStudents = useMemo(() => summarizeStudents(entries ?? []), [entries]);
 

--- a/lib/instructorStudentsStore.ts
+++ b/lib/instructorStudentsStore.ts
@@ -1,0 +1,38 @@
+// Local cache for the instructor's student roster (GET /api/instructor/students, GitHub #146).
+// Same shape as activityLogStore/completedSessionsStore: versioned key, SSR-guarded read/write,
+// only typed getter/setter exported — no raw store object.
+//
+// Keyed by instructorId so the cache survives across mounts without re-fetching the full roster.
+// No invalidation is needed: the student list only changes when someone registers, which the
+// instructor's browser never causes — a manual forceRefresh covers the rare case.
+import type { StudentSummary } from './sessionClient';
+
+const STORAGE_KEY = 'rc_instructor_students_v1';
+
+type InstructorStudentsStore = Partial<Record<string, StudentSummary[]>>;
+
+function readStore(): InstructorStudentsStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as InstructorStudentsStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: InstructorStudentsStore) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedInstructorStudents(instructorId: string): StudentSummary[] | null {
+  const store = readStore();
+  return store[instructorId] ?? null;
+}
+
+export function setCachedInstructorStudents(instructorId: string, students: StudentSummary[]): void {
+  const store = readStore();
+  store[instructorId] = students;
+  writeStore(store);
+}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -14,6 +14,10 @@ import { getCachedCompletedAttempts, setCachedCompletedAttempts } from './comple
 import { getCachedActivityLog, setCachedActivityLog } from './activityLogStore';
 import { getCachedCompletedSessions, setCachedCompletedSessions } from './completedSessionsStore';
 import { getCachedScore, setCachedScore } from './scoreStore';
+import {
+  getCachedInstructorStudents,
+  setCachedInstructorStudents,
+} from './instructorStudentsStore';
 
 // The row shapes themselves live in lib/sessionTypes.ts, which imports nothing, so the routes
 // can share them without importing this 'use client' module. Re-exported here so this file
@@ -343,6 +347,48 @@ export function loadActivityLog(
  */
 export function loadInstructorActivities(token: string) {
   return request<{ sessions: InstructorActivityEntry[] }>('/api/instructor/activities', { method: 'GET' }, token);
+}
+
+/** One student row as returned by GET /api/instructor/students. */
+export type StudentSummary = {
+  userId: string;
+  username: string;
+  firstName: string;
+  lastName: string;
+};
+
+/**
+ * Every student in the system (GET /api/instructor/students, GitHub #146).
+ *
+ * Cache-first: returns the stored list on a hit, calls the network only on a miss or when
+ * forceRefresh is true — same pattern as loadActivityLog. Keyed by instructorId so switching
+ * accounts on the same device doesn't serve one instructor's cache to another.
+ */
+export function loadInstructorStudents(
+  token: string,
+  instructorId: string,
+  options: { forceRefresh?: boolean } = {},
+) {
+  if (!options.forceRefresh) {
+    const cached = getCachedInstructorStudents(instructorId);
+    if (cached !== null) {
+      return Promise.resolve<ApiResult<{ students: StudentSummary[] }>>({
+        ok: true,
+        data: { students: cached },
+      });
+    }
+  }
+
+  return request<{ students: StudentSummary[] }>(
+    '/api/instructor/students',
+    { method: 'GET' },
+    token,
+  ).then((result) => {
+    if (result.ok) {
+      setCachedInstructorStudents(instructorId, result.data.students);
+    }
+    return result;
+  });
 }
 
 /**


### PR DESCRIPTION
- Adds lib/instructorStudentsStore.ts — versioned localStorage cache (rc_instructor_students_v1) keyed by instructorId, SSR-guarded, only typed getter/setter exported
- Adds StudentSummary type and loadInstructorStudents(token, instructorId, { forceRefresh }?) to sessionClient.ts — cache-first wrapper calling GET /api/instructor/students
- app/instructor/page.tsx uses loadInstructorStudents to populate the student filter dropdown with all registered students (not just those with activity history)
- app/instructor/students/page.tsx calls loadInstructorStudents to warm the cache on every visit

Resolves #146
