### PR TITLE
Redirect unknown activity slugs to dedicated page in [slug] route

### DIFF
--- a/app/activities/[slug]/page.tsx
+++ b/app/activities/[slug]/page.tsx
@@ -68,22 +68,19 @@ export default function ActivityDetailPage({
     };
   }, [token, activity, profile?.user_id]);
 
+  // Type B activities (e.g. write-acceptance-criteria) have their own dedicated page under
+  // the same path. The static Next.js route normally wins, but guard here in case the dynamic
+  // segment is somehow matched — redirect rather than showing "Unknown activity."
+  useEffect(() => {
+    if (!loading && authorized && !activity) {
+      router.replace(`/activities/${params.slug}`);
+    }
+  }, [loading, authorized, activity, params.slug, router]);
+
   if (loading || !authorized) return null;
 
   if (!activity) {
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-[#0e0b1e] px-6 text-center text-[#F3F1FF]">
-        <div>
-          <p className="mb-4">Unknown activity.</p>
-          <Link
-            href="/activities"
-            className="rounded-full bg-[#7C4DFF] px-4 py-2 text-sm font-bold text-white"
-          >
-            Back to activities
-          </Link>
-        </div>
-      </main>
-    );
+    return null;
   }
 
   async function handleStart() {


### PR DESCRIPTION
- Write Acceptance Criteria activity card already appears on /activities via the existing ActivityCard component
- app/activities/[slug]/page.tsx now redirects to the activity's own dedicated page when getActivity returns undefined, instead of showing "Unknown activity" — handles the case where a Type B activity (e.g. write-acceptance-criteria) lands on the dynamic route
- Clicking the card routes to /activities/write-acceptance-criteria which has its own dedicated page (static Next.js route takes priority over [slug])

Resolves #148
