### PR TITLE
Add instructor AC submissions page with student filter and accordion rows

### DIFF
--- a/app/api/instructor/acceptance-criteria/submissions/route.ts
+++ b/app/api/instructor/acceptance-criteria/submissions/route.ts
@@ -14,7 +14,7 @@ type SubmissionRow = {
   llm_feedback: string | null;
   submitted_at: string;
   graded_at: string | null;
-  student: { first_name: string | null; last_name: string | null; username: string | null; role: string };
+  student: { user_id: string; first_name: string | null; last_name: string | null; username: string | null; role: string };
   story: { story_text: string };
 };
 
@@ -51,7 +51,7 @@ export async function GET(request: Request) {
 
   let query = supabase
     .from('submission')
-    .select('submission_id, user_id, submitted_text, llm_score, llm_feedback, submitted_at, graded_at, student:user!inner(first_name, last_name, username, role), story:user_story!inner(story_text)')
+    .select('submission_id, submitted_text, llm_score, llm_feedback, submitted_at, graded_at, student:user!inner(user_id, first_name, last_name, username, role), story:user_story!inner(story_text)')
     .eq('student.role', 'student')
     .order('submitted_at', { ascending: false });
 
@@ -65,7 +65,7 @@ export async function GET(request: Request) {
     const r = row as unknown as SubmissionRow;
     return {
       submissionId: r.submission_id,
-      studentId: r.user_id,
+      studentId: r.student.user_id,
       studentName: studentDisplayName(r.student),
       userStoryDescription: r.story.story_text,
       submittedText: r.submitted_text,

--- a/app/api/instructor/acceptance-criteria/submissions/route.ts
+++ b/app/api/instructor/acceptance-criteria/submissions/route.ts
@@ -1,0 +1,80 @@
+import { getSupabaseClient } from '../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../lib/instructorAuth';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+type SubmissionRow = {
+  submission_id: string;
+  user_id: string;
+  submitted_text: string;
+  llm_score: number | null;
+  llm_feedback: string | null;
+  submitted_at: string;
+  graded_at: string | null;
+  student: { first_name: string | null; last_name: string | null; username: string | null; role: string };
+  story: { story_text: string };
+};
+
+function studentDisplayName(student: SubmissionRow['student']): string {
+  const fullName = [student.first_name, student.last_name].filter(Boolean).join(' ').trim();
+  return fullName || student.username || 'Unknown student';
+}
+
+/**
+ * GET /api/instructor/acceptance-criteria/submissions — all AC submissions across the class,
+ * optionally filtered to one student via ?studentId= (GitHub #154).
+ *
+ * Gated by requireInstructor; uses the service-role client to bypass RLS. The own_submissions_select
+ * policy restricts students to their own rows, so a student cannot reach this route at all — but
+ * requireInstructor is the explicit gate, not RLS.
+ *
+ * An empty list is a 200.
+ */
+export async function GET(request: Request) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const studentId = new URL(request.url).searchParams.get('studentId');
+
+  let query = supabase
+    .from('submission')
+    .select('submission_id, user_id, submitted_text, llm_score, llm_feedback, submitted_at, graded_at, student:user!inner(first_name, last_name, username, role), story:user_story!inner(story_text)')
+    .eq('student.role', 'student')
+    .order('submitted_at', { ascending: false });
+
+  if (studentId) query = query.eq('user_id', studentId);
+
+  const { data, error } = await query;
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  const submissions = (data ?? []).map((row) => {
+    const r = row as unknown as SubmissionRow;
+    return {
+      submissionId: r.submission_id,
+      studentId: r.user_id,
+      studentName: studentDisplayName(r.student),
+      userStoryDescription: r.story.story_text,
+      submittedText: r.submitted_text,
+      llmScore: r.llm_score,
+      llmFeedback: r.llm_feedback,
+      submittedAt: r.submitted_at,
+      gradedAt: r.graded_at,
+    };
+  });
+
+  return Response.json({ submissions }, { status: 200 });
+}

--- a/app/instructor/acceptance-criteria/page.tsx
+++ b/app/instructor/acceptance-criteria/page.tsx
@@ -25,12 +25,14 @@ function ACSubmissionsContent() {
   const { token, loading, authorized } = useRequireRole('instructor');
   const searchParams = useSearchParams();
 
+  const [allSubmissions, setAllSubmissions] = useState<InstructorACSubmission[] | null>(null);
   const [submissions, setSubmissions] = useState<InstructorACSubmission[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [studentId, setStudentId] = useState<StudentFilterValue>('all');
   const [sort, setSort] = useState<InstructorSortOrder>('newest');
   const [page, setPage] = useState(1);
 
+  // Load all submissions once to populate the student dropdown.
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
@@ -38,6 +40,7 @@ function ACSubmissionsContent() {
     loadInstructorACSubmissions(token).then((result) => {
       if (cancelled) return;
       if (result.ok) {
+        setAllSubmissions(result.data.submissions);
         setSubmissions(result.data.submissions);
       } else {
         setError(result.error);
@@ -49,13 +52,35 @@ function ACSubmissionsContent() {
     };
   }, [token]);
 
+  // Re-fetch from API when student filter changes — server-side filter is reliable.
+  useEffect(() => {
+    if (!token || allSubmissions === null) return;
+    let cancelled = false;
+
+    if (studentId === 'all') {
+      setSubmissions(allSubmissions);
+      return;
+    }
+
+    loadInstructorACSubmissions(token, { studentId }).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setSubmissions(result.data.submissions);
+      else setError(result.error);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, studentId, allSubmissions]);
+
   useEffect(() => {
     const studentParam = searchParams.get('student');
     if (studentParam) setStudentId(studentParam);
   }, [searchParams]);
 
   const students = useMemo(() => {
-    if (!submissions) return [];
+    if (!allSubmissions) return [];
+    const submissions = allSubmissions;
     const seen = new Map<string, string>();
     for (const s of submissions) {
       if (!seen.has(s.studentId)) seen.set(s.studentId, s.studentName);
@@ -66,8 +91,7 @@ function ACSubmissionsContent() {
   }, [submissions]);
 
   const filteredSorted = useMemo(() => {
-    const rows = (submissions ?? []).filter((s) => studentId === 'all' || s.studentId === studentId);
-    return [...rows].sort((a, b) => {
+    return [...(submissions ?? [])].sort((a, b) => {
       if (sort === 'oldest') return new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime();
       if (sort === 'lowest') {
         if (a.llmScore === null) return 1;
@@ -115,36 +139,30 @@ function ACSubmissionsContent() {
           <p className="text-sm font-semibold text-gray-500">Loading…</p>
         ) : (
           <>
-            <div className="mb-5 flex flex-wrap items-end justify-between gap-4">
-              <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
-                Student
-                <select
-                  value={studentId}
-                  onChange={(e) => handleStudentChange(e.target.value)}
-                  className="mt-1 block rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
-                >
-                  <option value="all">All students</option>
-                  {students.map((s) => (
-                    <option key={s.id} value={s.id}>
-                      {s.name}
-                    </option>
-                  ))}
-                </select>
-              </label>
+            <div className="mb-5 flex flex-wrap items-center gap-3">
+              <select
+                value={studentId}
+                onChange={(e) => handleStudentChange(e.target.value)}
+                className="appearance-none rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm outline-none transition hover:border-brand-purple focus:border-brand-purple focus:ring-2 focus:ring-brand-purple/20"
+              >
+                <option value="all">All students</option>
+                {students.map((s) => (
+                  <option key={s.id} value={s.id}>
+                    {s.name}
+                  </option>
+                ))}
+              </select>
 
-              <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
-                Sort
-                <select
-                  value={sort}
-                  onChange={(e) => handleSortChange(e.target.value as InstructorSortOrder)}
-                  className="mt-1 block rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
-                >
-                  <option value="newest">Newest first</option>
-                  <option value="oldest">Oldest first</option>
-                  <option value="lowest">Lowest score first</option>
-                  <option value="highest">Highest score first</option>
-                </select>
-              </label>
+              <select
+                value={sort}
+                onChange={(e) => handleSortChange(e.target.value as InstructorSortOrder)}
+                className="appearance-none rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm outline-none transition hover:border-brand-purple focus:border-brand-purple focus:ring-2 focus:ring-brand-purple/20"
+              >
+                <option value="newest">Newest first</option>
+                <option value="oldest">Oldest first</option>
+                <option value="lowest">Lowest score first</option>
+                <option value="highest">Highest score first</option>
+              </select>
             </div>
 
             {pageRows.length === 0 ? (

--- a/app/instructor/acceptance-criteria/page.tsx
+++ b/app/instructor/acceptance-criteria/page.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { AppShell } from '../../../components/AppShell';
+import { AcceptanceCriteriaSubmissionRow } from '../../../components/AcceptanceCriteriaSubmissionRow';
+import {
+  loadInstructorACSubmissions,
+  type InstructorACSubmission,
+} from '../../../lib/acceptanceCriteriaClient';
+import type { StudentFilterValue, InstructorSortOrder } from '../../../components/InstructorFilters';
+import { useRequireRole } from '../../../lib/useRequireRole';
+
+const PAGE_SIZE = 10;
+
+export default function ACSubmissionsPage() {
+  return (
+    <Suspense fallback={null}>
+      <ACSubmissionsContent />
+    </Suspense>
+  );
+}
+
+function ACSubmissionsContent() {
+  const { token, loading, authorized } = useRequireRole('instructor');
+  const searchParams = useSearchParams();
+
+  const [submissions, setSubmissions] = useState<InstructorACSubmission[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [studentId, setStudentId] = useState<StudentFilterValue>('all');
+  const [sort, setSort] = useState<InstructorSortOrder>('newest');
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+
+    loadInstructorACSubmissions(token).then((result) => {
+      if (cancelled) return;
+      if (result.ok) {
+        setSubmissions(result.data.submissions);
+      } else {
+        setError(result.error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  useEffect(() => {
+    const studentParam = searchParams.get('student');
+    if (studentParam) setStudentId(studentParam);
+  }, [searchParams]);
+
+  const students = useMemo(() => {
+    if (!submissions) return [];
+    const seen = new Map<string, string>();
+    for (const s of submissions) {
+      if (!seen.has(s.studentId)) seen.set(s.studentId, s.studentName);
+    }
+    return [...seen.entries()]
+      .map(([id, name]) => ({ id, name }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [submissions]);
+
+  const filteredSorted = useMemo(() => {
+    const rows = (submissions ?? []).filter((s) => studentId === 'all' || s.studentId === studentId);
+    return [...rows].sort((a, b) => {
+      if (sort === 'oldest') return new Date(a.submittedAt).getTime() - new Date(b.submittedAt).getTime();
+      if (sort === 'lowest') {
+        if (a.llmScore === null) return 1;
+        if (b.llmScore === null) return -1;
+        return a.llmScore - b.llmScore;
+      }
+      if (sort === 'highest') {
+        if (a.llmScore === null) return 1;
+        if (b.llmScore === null) return -1;
+        return b.llmScore - a.llmScore;
+      }
+      return new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime();
+    });
+  }, [submissions, studentId, sort]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredSorted.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageRows = filteredSorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  function handleStudentChange(value: StudentFilterValue) {
+    setStudentId(value);
+    setPage(1);
+  }
+
+  function handleSortChange(value: InstructorSortOrder) {
+    setSort(value);
+    setPage(1);
+  }
+
+  if (loading || !authorized) return null;
+
+  return (
+    <AppShell active="instructor-ac">
+      <div className="mx-auto max-w-5xl">
+        <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">AC Submissions</h1>
+        <p className="mb-6 max-w-2xl text-sm font-semibold text-gray-500">
+          Every student&apos;s acceptance criteria submissions — filter by student or sort to find what you need.
+        </p>
+
+        {error ? (
+          <p className="mb-6 rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-4 text-sm font-semibold text-brand-danger-light">
+            {error}
+          </p>
+        ) : submissions === null ? (
+          <p className="text-sm font-semibold text-gray-500">Loading…</p>
+        ) : (
+          <>
+            <div className="mb-5 flex flex-wrap items-end justify-between gap-4">
+              <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
+                Student
+                <select
+                  value={studentId}
+                  onChange={(e) => handleStudentChange(e.target.value)}
+                  className="mt-1 block rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
+                >
+                  <option value="all">All students</option>
+                  {students.map((s) => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
+                Sort
+                <select
+                  value={sort}
+                  onChange={(e) => handleSortChange(e.target.value as InstructorSortOrder)}
+                  className="mt-1 block rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
+                >
+                  <option value="newest">Newest first</option>
+                  <option value="oldest">Oldest first</option>
+                  <option value="lowest">Lowest score first</option>
+                  <option value="highest">Highest score first</option>
+                </select>
+              </label>
+            </div>
+
+            {pageRows.length === 0 ? (
+              <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
+                {studentId !== 'all' ? 'No submissions from this student yet.' : 'No submissions yet.'}
+              </p>
+            ) : (
+              <div className="overflow-x-auto rounded-2xl border border-gray-100">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="bg-gray-50 text-gray-500">
+                      {studentId === 'all' && (
+                        <th className="px-4 py-2.5 text-left text-xs font-extrabold uppercase tracking-wide">Student</th>
+                      )}
+                      <th className="px-4 py-2.5 text-left text-xs font-extrabold uppercase tracking-wide">User Story</th>
+                      <th className="px-4 py-2.5 text-left text-xs font-extrabold uppercase tracking-wide">Score</th>
+                      <th className="px-4 py-2.5 text-left text-xs font-extrabold uppercase tracking-wide">Submitted</th>
+                      <th className="px-4 py-2.5" />
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pageRows.map((submission) => (
+                      <AcceptanceCriteriaSubmissionRow
+                        key={submission.submissionId}
+                        submission={submission}
+                        showStudent={studentId === 'all'}
+                      />
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <span className="text-xs font-semibold text-gray-500">
+                {filteredSorted.length === 0
+                  ? '0 submissions'
+                  : `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(currentPage * PAGE_SIZE, filteredSorted.length)} of ${filteredSorted.length} submissions`}
+              </span>
+
+              <div className="flex gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1}
+                  className="min-w-9 rounded-brand-md border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-bold text-gray-600 transition hover:border-brand-purple hover:text-brand-purple disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-gray-300 disabled:hover:text-gray-600"
+                >
+                  Prev
+                </button>
+                {Array.from({ length: totalPages }, (_, i) => i + 1).map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => setPage(p)}
+                    className={`min-w-9 rounded-brand-md border px-2.5 py-1.5 text-xs font-bold transition ${
+                      p === currentPage
+                        ? 'border-brand-purple bg-brand-purple text-white'
+                        : 'border-gray-300 bg-white text-gray-600 hover:border-brand-purple hover:text-brand-purple'
+                    }`}
+                  >
+                    {p}
+                  </button>
+                ))}
+                <button
+                  type="button"
+                  onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                  disabled={currentPage === totalPages}
+                  className="min-w-9 rounded-brand-md border border-gray-300 bg-white px-2.5 py-1.5 text-xs font-bold text-gray-600 transition hover:border-brand-purple hover:text-brand-purple disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-gray-300 disabled:hover:text-gray-600"
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/components/AcceptanceCriteriaSubmissionRow.tsx
+++ b/components/AcceptanceCriteriaSubmissionRow.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import type { InstructorACSubmission } from '../lib/acceptanceCriteriaClient';
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max) + '…' : text;
+}
+
+export function AcceptanceCriteriaSubmissionRow({
+  submission,
+  showStudent,
+}: {
+  submission: InstructorACSubmission;
+  showStudent: boolean;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const colSpan = showStudent ? 5 : 4;
+
+  return (
+    <>
+      <tr className="border-t border-gray-100 hover:bg-gray-50">
+        {showStudent && (
+          <td className="px-4 py-2.5 text-sm font-semibold text-brand-navy">
+            {submission.studentName}
+          </td>
+        )}
+        <td className="max-w-xs px-4 py-2.5 text-sm text-gray-600" title={submission.userStoryDescription}>
+          {truncate(submission.userStoryDescription, 60)}
+        </td>
+        <td className="px-4 py-2.5 text-sm tabular-nums">
+          {submission.llmScore !== null ? (
+            <span className="font-bold text-brand-navy">{submission.llmScore} / 10</span>
+          ) : (
+            <span className="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-semibold text-gray-500">
+              Not graded
+            </span>
+          )}
+        </td>
+        <td className="px-4 py-2.5 text-sm text-gray-500">
+          {new Date(submission.submittedAt).toLocaleDateString()}
+        </td>
+        <td className="px-4 py-2.5 text-right">
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="text-xs font-bold text-brand-purple hover:underline"
+          >
+            {expanded ? '▲ Collapse' : '▼ Expand'}
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-t border-gray-100 bg-gray-50">
+          <td colSpan={colSpan} className="px-4 pb-5 pt-3">
+            <div className="space-y-4">
+              <div>
+                <p className="mb-1 text-xs font-extrabold uppercase tracking-wide text-gray-400">User Story</p>
+                <p className="text-sm font-semibold text-gray-700">{submission.userStoryDescription}</p>
+              </div>
+              <div>
+                <p className="mb-1 text-xs font-extrabold uppercase tracking-wide text-gray-400">Submitted Text</p>
+                <p className="whitespace-pre-wrap text-sm text-gray-700">{submission.submittedText}</p>
+              </div>
+              <div>
+                <p className="mb-1 text-xs font-extrabold uppercase tracking-wide text-gray-400">LLM Feedback</p>
+                {submission.llmFeedback ? (
+                  <p className="text-sm text-gray-700">{submission.llmFeedback}</p>
+                ) : (
+                  <p className="text-sm italic text-gray-400">Not yet graded.</p>
+                )}
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -9,7 +9,7 @@ import { loadStudentScore } from '../lib/sessionClient';
 import { LLMProviderSettingsModal } from './LLMProviderSettingsModal';
 import { useUser } from './UserProvider';
 
-type NavKey = 'dashboard' | 'activities' | 'profile' | 'instructor' | 'instructor-questions' | 'instructor-settings';
+type NavKey = 'dashboard' | 'activities' | 'profile' | 'instructor' | 'instructor-questions' | 'instructor-settings' | 'instructor-ac';
 
 const STUDENT_NAV_ITEMS: { key: NavKey; label: string; href: string }[] = [
   { key: 'dashboard', label: 'Dashboard', href: '/dashboard' },
@@ -28,6 +28,7 @@ const STUDENT_NAV_ITEMS: { key: NavKey; label: string; href: string }[] = [
 const INSTRUCTOR_NAV_ITEMS: { key: NavKey; label: string; href: string }[] = [
   { key: 'instructor', label: 'Instructor Dashboard', href: '/instructor' },
   { key: 'instructor-questions', label: 'Question Bank', href: '/instructor/questions' },
+  { key: 'instructor-ac', label: 'AC Submissions', href: '/instructor/acceptance-criteria' },
   { key: 'profile', label: 'Profile', href: '/profile' },
   { key: 'instructor-settings', label: 'LLM Provider Settings', href: '/instructor/settings' },
 ];
@@ -80,6 +81,15 @@ function BookIcon() {
   );
 }
 
+function PencilIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5Z" />
+    </svg>
+  );
+}
+
 function GearIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2}>
@@ -121,6 +131,7 @@ const NAV_ICONS: Record<NavKey, () => JSX.Element> = {
   profile: UserIcon,
   instructor: UsersIcon,
   'instructor-questions': BookIcon,
+  'instructor-ac': PencilIcon,
   'instructor-settings': GearIcon,
 };
 

--- a/lib/acceptanceCriteriaClient.ts
+++ b/lib/acceptanceCriteriaClient.ts
@@ -56,6 +56,31 @@ export function loadUserStory(
   );
 }
 
+export type InstructorACSubmission = {
+  submissionId: string;
+  studentId: string;
+  studentName: string;
+  userStoryDescription: string;
+  submittedText: string;
+  llmScore: number | null;
+  llmFeedback: string | null;
+  submittedAt: string;
+  gradedAt: string | null;
+};
+
+/** GET /api/instructor/acceptance-criteria/submissions — all AC submissions, optionally scoped to one student. */
+export function loadInstructorACSubmissions(
+  token: string,
+  options: { studentId?: string } = {},
+): Promise<ApiResult<{ submissions: InstructorACSubmission[] }>> {
+  const params = options.studentId ? `?studentId=${encodeURIComponent(options.studentId)}` : '';
+  return request<{ submissions: InstructorACSubmission[] }>(
+    `/api/instructor/acceptance-criteria/submissions${params}`,
+    { method: 'GET' },
+    token,
+  );
+}
+
 /**
  * POST .../submissions: commits the answer, then returns the LLM's grading of it.
  *


### PR DESCRIPTION
- New GET /api/instructor/acceptance-criteria/submissions route, protected by requireInstructor, returns all AC submissions with student name, user story text, score, feedback, and timestamps; supports optional ?studentId= filter
- New app/instructor/acceptance-criteria/page.tsx with student dropdown, sort (newest/oldest/highest/lowest), paginated table, and ?student= deep-link support (same pattern as /instructor)
- New AcceptanceCriteriaSubmissionRow component: accordion row that expands in-place to show full user story, submitted text, and LLM feedback; "Not graded" state for score: null rows
- AC Submissions added to INSTRUCTOR_NAV_ITEMS in AppShell

Resolves #154
