### PR TITLE
Add route to get all questions and corresponding answers of a prof

### DIFF
--- a/__tests__/api/instructor-quiz-questions.test.ts
+++ b/__tests__/api/instructor-quiz-questions.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Same harness shape as __tests__/api/instructor-student-history.test.ts: eq() is recorded, not
+// a no-op, and queries without .single()/.maybeSingle() resolve because the builder is thenable.
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    filters: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET } from '../../app/api/instructor/quizzes/[activityType]/[difficultyLevel]/questions/route';
+
+const ACTIVITY_TYPE = 'IDENTIFY_WEAK_USER_STORIES';
+
+function queueCallerRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function req(token: string | null = 'valid-token') {
+  return new Request(`http://localhost/api/instructor/quizzes/${ACTIVITY_TYPE}/1/questions`, {
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+function params(activityType = ACTIVITY_TYPE, difficultyLevel = '1') {
+  return { params: { activityType, difficultyLevel } };
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.filters = [];
+});
+
+describe('GET /api/instructor/quizzes/:activityType/:difficultyLevel/questions', () => {
+  it('returns 401 without a token', async () => {
+    const response = await GET(req(null), params());
+    expect(response.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    const response = await GET(req('bad-token'), params());
+    expect(response.status).toBe(401);
+  });
+
+  it('rejects a student caller with 403 and an empty body, before touching questions', async () => {
+    queueCallerRole('student');
+
+    const response = await GET(req(), params());
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+    expect(h.state.tables).toEqual(['user']);
+  });
+
+  it('returns 404 for an unknown activityType, before querying questions', async () => {
+    queueCallerRole('instructor');
+
+    const response = await GET(req(), params('NOT_A_REAL_ACTIVITY'));
+
+    expect(response.status).toBe(404);
+    expect(h.state.tables).toEqual(['user']);
+  });
+
+  it('returns 404 for a difficultyLevel outside 1-3, before querying questions', async () => {
+    queueCallerRole('instructor');
+
+    const response = await GET(req(), params(ACTIVITY_TYPE, '9'));
+
+    expect(response.status).toBe(404);
+    expect(h.state.tables).toEqual(['user']);
+  });
+
+  it('returns 404 when no question exists for this activityType/difficultyLevel at all', async () => {
+    queueCallerRole('instructor');
+    queue('question', { data: [], error: null });
+
+    const response = await GET(req(), params());
+    const body = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(body.error).toMatch(/quiz not found/i);
+  });
+
+  it('returns 403 when the quiz exists but none of its questions belong to the caller', async () => {
+    queueCallerRole('instructor');
+    queue('question', {
+      data: [{ question_id: 'q1', question_prompt: 'Prompt', user_id: 'someone-else', question_to_answer: [] }],
+      error: null,
+    });
+
+    const response = await GET(req(), params());
+
+    expect(response.status).toBe(403);
+    expect(await response.text()).toBe('');
+  });
+
+  it('returns only the caller\'s own questions, shaped with answers and is_correct', async () => {
+    queueCallerRole('instructor');
+    queue('question', {
+      data: [
+        {
+          question_id: 'q1',
+          question_prompt: 'Which user story is weakest?',
+          user_id: 'instructor-1',
+          question_to_answer: [
+            { answer: { answer_id: 'a1', option_text: 'Weak one', is_correct: true } },
+            { answer: { answer_id: 'a2', option_text: 'Strong one', is_correct: false } },
+          ],
+        },
+        {
+          question_id: 'q2',
+          question_prompt: 'Someone else\'s question',
+          user_id: 'someone-else',
+          question_to_answer: [],
+        },
+      ],
+      error: null,
+    });
+
+    const response = await GET(req(), params());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.activityType).toBe(ACTIVITY_TYPE);
+    expect(body.difficultyLevel).toBe(1);
+    expect(body.questions).toEqual([
+      {
+        question_id: 'q1',
+        question_title: 'Which user story is weakest?',
+        answers: [
+          { answer_id: 'a1', answer_title: 'Weak one', is_correct: true },
+          { answer_id: 'a2', answer_title: 'Strong one', is_correct: false },
+        ],
+      },
+    ]);
+  });
+
+  it('returns 500 when the question query fails', async () => {
+    queueCallerRole('instructor');
+    queue('question', { data: null, error: { message: 'boom' } });
+
+    const response = await GET(req(), params());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('boom');
+  });
+
+  it('filters on the requested activity type and difficulty level', async () => {
+    queueCallerRole('instructor');
+    queue('question', { data: [], error: null });
+
+    await GET(req(), params());
+
+    expect(h.state.filters).toContainEqual({ table: 'question', column: 'activity_type', value: ACTIVITY_TYPE });
+    expect(h.state.filters).toContainEqual({ table: 'question', column: 'difficulty_level', value: 1 });
+  });
+});

--- a/app/api/instructor/quizzes/[activityType]/[difficultyLevel]/questions/route.ts
+++ b/app/api/instructor/quizzes/[activityType]/[difficultyLevel]/questions/route.ts
@@ -1,0 +1,100 @@
+import { getSupabaseClient } from '../../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../../lib/instructorAuth';
+import { isActivityType } from '../../../../../../../lib/activityTypes';
+
+// REQ-DL-1.1: valid difficulty levels are 1 (easy), 2 (medium), 3 (hard) — mirrors
+// ck_question_difficulty_level in supabase/schema.sql.
+const VALID_DIFFICULTY_LEVELS = [1, 2, 3];
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+type AnswerRow = { answer_id: string; option_text: string; is_correct: boolean };
+type QuestionRow = {
+  question_id: string;
+  question_prompt: string;
+  user_id: string | null;
+  question_to_answer: { answer: AnswerRow | null }[] | null;
+};
+
+/**
+ * GET /api/instructor/quizzes/:activityType/:difficultyLevel/questions — every question and
+ * answer of one quiz "owned" by the calling instructor.
+ *
+ * A "quiz" has no table of its own (see the Three half-connected worlds note in CLAUDE.md): it
+ * is the (activityType, difficultyLevel) pair, and "created by" this instructor means
+ * question.user_id (GitHub #201) matches the caller for at least one question in that pair —
+ * this is the "scope to my quiz's questions" read GitHub #116 anticipated.
+ *
+ * - 401: caller is not authenticated (requireInstructor)
+ * - 403: caller is authenticated but not an instructor, OR the quiz exists but none of its
+ *        questions were created by the caller (both answer with no body, matching the 403
+ *        shape GitHub #169 already established for requireInstructor)
+ * - 404: activityType/difficultyLevel is not a real quiz — no question anywhere has that pair
+ * - 500: Supabase is not configured, or the query fails
+ *
+ * Only the caller's own questions are returned — a quiz's (activityType, difficultyLevel) pair
+ * can otherwise mix questions from multiple authors (or none, for the seeded bank), and there is
+ * no other notion of "this instructor's quiz" for those to belong to.
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: { activityType: string; difficultyLevel: string } },
+) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { activityType } = params;
+  const difficultyLevel = Number(params.difficultyLevel);
+
+  // An unknown activityType or an out-of-range difficultyLevel can never match a real question,
+  // so it is indistinguishable from "this quiz does not exist" — no separate 400 branch needed.
+  if (!isActivityType(activityType) || !VALID_DIFFICULTY_LEVELS.includes(difficultyLevel)) {
+    return Response.json({ error: 'Quiz not found.' }, { status: 404 });
+  }
+
+  const { data, error } = await supabase
+    .from('question')
+    .select('question_id, question_prompt, user_id, question_to_answer ( answer:answer_id ( answer_id, option_text, is_correct ) )')
+    .eq('activity_type', activityType)
+    .eq('difficulty_level', difficultyLevel);
+
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  const allQuestions = (data ?? []) as unknown as QuestionRow[];
+  if (allQuestions.length === 0) {
+    return Response.json({ error: 'Quiz not found.' }, { status: 404 });
+  }
+
+  const ownQuestions = allQuestions.filter((question) => question.user_id === guard.user_id);
+  if (ownQuestions.length === 0) {
+    return new Response(null, { status: 403 });
+  }
+
+  const questions = ownQuestions.map((question) => ({
+    question_id: question.question_id,
+    question_title: question.question_prompt,
+    answers: (question.question_to_answer ?? [])
+      .map((link) => link.answer)
+      .filter((answer): answer is AnswerRow => answer !== null)
+      .map((answer) => ({
+        answer_id: answer.answer_id,
+        answer_title: answer.option_text,
+        is_correct: answer.is_correct,
+      })),
+  }));
+
+  return Response.json({ activityType, difficultyLevel, questions }, { status: 200 });
+}


### PR DESCRIPTION
The route should return all questions and corresponding answers for each quiz a prof created. It should return:

    question_id and question_title
    answer_id and answer_title
    The quiz difficulty
    Which answer is right

Error codes:

    401 – professor is not authenticated
    403 – user is not a professor / not the owner of the quiz
    404 – quiz not found / no questions found for this quiz
    500 – internal server error

-Resolve #116 
