### PR TITLE
API: Persist adding and editing questions

### DIFF
--- a/__tests__/api/instructor-question-update.test.ts
+++ b/__tests__/api/instructor-question-update.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    updates: [] as { table: string; payload: unknown }[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
+    filters: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      insert: () => builder,
+      update: (payload: unknown) => {
+        state.updates.push({ table, payload });
+        return builder;
+      },
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        if (isDelete) {
+          state.deletes.push({ table, column, value });
+        } else {
+          state.filters.push({ table, column, value });
+        }
+        return builder;
+      },
+      in: (column: string, value: unknown) => {
+        if (isDelete) {
+          state.deletes.push({ table, column, value });
+        }
+        return builder;
+      },
+      order: () => builder,
+      limit: () => builder,
+      maybeSingle: async () => result,
+      single: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { PATCH } from '../../app/api/instructor/questions/[questionId]/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function queueOwnedQuestion(userId = 'instructor-1') {
+  queue('question', { data: { question_id: 'q-1', user_id: userId }, error: null });
+}
+
+function queueExistingLinks(answerIds = ['a-1', 'a-2']) {
+  queue(
+    'question_to_answer',
+    { data: answerIds.map((answer_id) => ({ answer_id })), error: null },
+  );
+}
+
+function validAnswers() {
+  return [
+    { id: 'a-1', optionText: 'Wrong updated', isCorrect: false },
+    { id: 'a-2', optionText: 'Right updated', isCorrect: true, explanation: 'Because reasons.' },
+  ];
+}
+
+function validBody(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    questionPrompt: 'Updated prompt?',
+    activityType: 'IDENTIFY_WEAK_USER_STORIES',
+    difficultyLevel: 2,
+    answers: validAnswers(),
+    ...overrides,
+  };
+}
+
+function call(body: unknown, token: string | null = 'valid-token', questionId = 'q-1') {
+  const request = new Request(`http://localhost/api/instructor/questions/${questionId}`, {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+  return PATCH(request, { params: { questionId } });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.updates = [];
+  h.state.deletes = [];
+  h.state.filters = [];
+});
+
+describe('PATCH /api/instructor/questions/[questionId]', () => {
+  it('returns 401 without a token', async () => {
+    const res = await call(validBody(), null);
+    expect(res.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    const res = await call(validBody(), 'bad-token');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await call(validBody());
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('question');
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    queueRole('instructor');
+    const request = new Request('http://localhost/api/instructor/questions/q-1', {
+      method: 'PATCH',
+      headers: { Authorization: 'Bearer valid-token' },
+      body: '{not json',
+    });
+    const res = await PATCH(request, { params: { questionId: 'q-1' } });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a missing questionPrompt with 400', async () => {
+    queueRole('instructor');
+    const res = await call(validBody({ questionPrompt: '  ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid activityType with 400', async () => {
+    queueRole('instructor');
+    const res = await call(validBody({ activityType: 'NOT_REAL' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid difficultyLevel with 400', async () => {
+    queueRole('instructor');
+    const res = await call(validBody({ difficultyLevel: 9 }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects fewer than 2 answers with 400', async () => {
+    queueRole('instructor');
+    const res = await call(validBody({ answers: [validAnswers()[0]] }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an answer with no id with 400', async () => {
+    queueRole('instructor');
+    const answers = [{ optionText: 'A', isCorrect: false }, { id: 'a-2', optionText: 'B', isCorrect: true }];
+    const res = await call(validBody({ answers }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects duplicate answer ids with 400', async () => {
+    queueRole('instructor');
+    const answers = [
+      { id: 'a-1', optionText: 'A', isCorrect: false },
+      { id: 'a-1', optionText: 'B', isCorrect: true },
+    ];
+    const res = await call(validBody({ answers }));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects zero correct answers with 400', async () => {
+    queueRole('instructor');
+    const answers = validAnswers().map((a) => ({ ...a, isCorrect: false }));
+    const res = await call(validBody({ answers }));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Exactly one answer must be correct.');
+  });
+
+  it('rejects two correct answers with 400', async () => {
+    queueRole('instructor');
+    const answers = validAnswers().map((a) => ({ ...a, isCorrect: true }));
+    const res = await call(validBody({ answers }));
+    const body = await res.json();
+    expect(res.status).toBe(400);
+    expect(body.error).toBe('Exactly one answer must be correct.');
+  });
+
+  it('returns 404 when the question does not exist', async () => {
+    queueRole('instructor');
+    queue('question', { data: null, error: null });
+
+    const res = await call(validBody());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 with a JSON body when the caller does not own the question', async () => {
+    queueRole('instructor');
+    queueOwnedQuestion('some-other-instructor');
+
+    const res = await call(validBody());
+    const body = await res.json();
+    expect(res.status).toBe(403);
+    expect(body.error).toBe('You do not own this question.');
+  });
+
+  it('returns 400 when the answer count does not match the existing option count', async () => {
+    queueRole('instructor');
+    queueOwnedQuestion();
+    queueExistingLinks(['a-1']); // only one existing option, body sends two
+
+    const res = await call(validBody());
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when an answer id does not belong to this question', async () => {
+    queueRole('instructor');
+    queueOwnedQuestion();
+    queueExistingLinks(['a-1', 'a-3']); // body references a-2, which isn't linked here
+
+    const res = await call(validBody());
+    expect(res.status).toBe(400);
+  });
+
+  it('updates the question and its answers, leaving order_number/max_score/user_id untouched', async () => {
+    queueRole('instructor');
+    queueOwnedQuestion();
+    queueExistingLinks();
+    queue('question', { data: null, error: null }); // question update
+    queue('answer', { data: null, error: null }); // answer a-1 update
+    queue('answer', { data: null, error: null }); // answer a-2 update
+
+    const res = await call(validBody());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ questionId: 'q-1', answerIds: ['a-1', 'a-2'] });
+
+    const questionUpdate = h.state.updates.find((u) => u.table === 'question');
+    expect(questionUpdate?.payload).toEqual({
+      question_prompt: 'Updated prompt?',
+      activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+      difficulty_level: 2,
+    });
+
+    const answerUpdates = h.state.updates.filter((u) => u.table === 'answer');
+    expect(answerUpdates[0].payload).toEqual({ option_text: 'Wrong updated', is_correct: false });
+    expect(answerUpdates[1].payload).toEqual({
+      option_text: 'Right updated',
+      is_correct: true,
+      explanation: 'Because reasons.',
+    });
+  });
+
+  it('does not roll back a partial failure: an answer update failing after the question update succeeds is a plain 500', async () => {
+    queueRole('instructor');
+    queueOwnedQuestion();
+    queueExistingLinks();
+    queue('question', { data: null, error: null }); // question update succeeds
+    queue('answer', { data: null, error: null }); // answer a-1 update succeeds
+    queue('answer', { data: null, error: { message: 'answer update failed' } }); // answer a-2 update fails
+
+    const res = await call(validBody());
+    const body = await res.json();
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('answer update failed');
+    expect(h.state.deletes).toHaveLength(0);
+  });
+});

--- a/__tests__/api/instructor-questions.test.ts
+++ b/__tests__/api/instructor-questions.test.ts
@@ -6,22 +6,51 @@ const h = vi.hoisted(() => {
   const state = {
     queues: {} as Record<string, Result[]>,
     tables: [] as string[],
+    inserts: [] as { table: string; payload: unknown }[],
+    updates: [] as { table: string; payload: unknown }[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
     filters: [] as { table: string; column: string; value: unknown }[],
     orders: [] as { table: string; column: string; ascending: boolean }[],
   };
 
   function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+
     const builder: Record<string, unknown> = {
       select: () => builder,
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      update: (payload: unknown) => {
+        state.updates.push({ table, payload });
+        return builder;
+      },
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
       eq: (column: string, value: unknown) => {
-        state.filters.push({ table, column, value });
+        if (isDelete) {
+          state.deletes.push({ table, column, value });
+        } else {
+          state.filters.push({ table, column, value });
+        }
+        return builder;
+      },
+      in: (column: string, value: unknown) => {
+        if (isDelete) {
+          state.deletes.push({ table, column, value });
+        }
         return builder;
       },
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });
         return builder;
       },
+      limit: () => builder,
       maybeSingle: async () => result,
+      single: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),
     };
@@ -51,7 +80,7 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
-import { GET } from '../../app/api/instructor/questions/route';
+import { GET, POST } from '../../app/api/instructor/questions/route';
 
 function queueRole(role: string) {
   queue('user', { data: { role }, error: null });
@@ -61,6 +90,34 @@ function request(token?: string) {
   return new Request('http://localhost/api/instructor/questions', {
     headers: token ? { Authorization: `Bearer ${token}` } : {},
   });
+}
+
+function postRequest(body: unknown, token: string | null = 'valid-token') {
+  return new Request('http://localhost/api/instructor/questions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function validAnswers() {
+  return [
+    { optionText: 'Wrong option', isCorrect: false, explanation: 'Incorrect: not this one.' },
+    { optionText: 'Right option', isCorrect: true, explanation: 'Correct: this is the weakest one.' },
+  ];
+}
+
+function validBody(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    questionPrompt: 'Which story is weakest?',
+    activityType: 'IDENTIFY_WEAK_USER_STORIES',
+    difficultyLevel: 1,
+    answers: validAnswers(),
+    ...overrides,
+  };
 }
 
 function questionRow(overrides: Partial<Record<string, unknown>> = {}) {
@@ -80,6 +137,9 @@ function questionRow(overrides: Partial<Record<string, unknown>> = {}) {
 beforeEach(() => {
   h.state.queues = {};
   h.state.tables = [];
+  h.state.inserts = [];
+  h.state.updates = [];
+  h.state.deletes = [];
   h.state.filters = [];
   h.state.orders = [];
 });
@@ -164,5 +224,165 @@ describe('GET /api/instructor/questions', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('DB failure');
+  });
+});
+
+describe('POST /api/instructor/questions', () => {
+  it('returns 401 without a token', async () => {
+    const res = await POST(postRequest(validBody(), null));
+    expect(res.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await POST(postRequest(validBody()));
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('question');
+  });
+
+  it('returns 400 for invalid JSON', async () => {
+    queueRole('instructor');
+    const res = await POST(
+      new Request('http://localhost/api/instructor/questions', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer valid-token' },
+        body: '{not json',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a missing questionPrompt with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(postRequest(validBody({ questionPrompt: '  ' })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid activityType with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(postRequest(validBody({ activityType: 'NOT_REAL' })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects an invalid difficultyLevel with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(postRequest(validBody({ difficultyLevel: 9 })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects fewer than 2 answers with 400', async () => {
+    queueRole('instructor');
+    const res = await POST(postRequest(validBody({ answers: [validAnswers()[0]] })));
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects zero correct answers with 400', async () => {
+    queueRole('instructor');
+    const answers = validAnswers().map((a) => ({ ...a, isCorrect: false }));
+    const res = await POST(postRequest(validBody({ answers })));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Exactly one answer must be correct.');
+  });
+
+  it('rejects two correct answers with 400', async () => {
+    queueRole('instructor');
+    const answers = validAnswers().map((a) => ({ ...a, isCorrect: true }));
+    const res = await POST(postRequest(validBody({ answers })));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('Exactly one answer must be correct.');
+  });
+
+  it('creates the question and its answers, assigning order_number and max_score server-side', async () => {
+    queueRole('instructor');
+    queue('question', { data: null, error: null }); // MAX(order_number) — empty pool
+    queue('question', { data: null, error: null }); // question insert
+    queue('answer', { data: null, error: null }); // answer 1 insert
+    queue('question_to_answer', { data: null, error: null }); // link 1
+    queue('answer', { data: null, error: null }); // answer 2 insert
+    queue('question_to_answer', { data: null, error: null }); // link 2
+
+    const res = await POST(postRequest(validBody()));
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(typeof body.questionId).toBe('string');
+    expect(body.answerIds).toHaveLength(2);
+
+    const questionInsert = h.state.inserts.find((i) => i.table === 'question');
+    expect(questionInsert?.payload).toMatchObject({
+      question_prompt: 'Which story is weakest?',
+      activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+      difficulty_level: 1,
+      order_number: 1,
+      max_score: 25,
+      user_id: 'instructor-1',
+    });
+  });
+
+  it('assigns order_number as MAX + 1, scoped to the activity type', async () => {
+    queueRole('instructor');
+    queue('question', { data: { order_number: 7 }, error: null }); // MAX(order_number) = 7
+    queue('question', { data: null, error: null });
+    queue('answer', { data: null, error: null });
+    queue('question_to_answer', { data: null, error: null });
+    queue('answer', { data: null, error: null });
+    queue('question_to_answer', { data: null, error: null });
+
+    await POST(postRequest(validBody()));
+
+    const questionInsert = h.state.inserts.find((i) => i.table === 'question');
+    expect((questionInsert?.payload as { order_number: number }).order_number).toBe(8);
+    expect(h.state.filters).toContainEqual({
+      table: 'question',
+      column: 'activity_type',
+      value: 'IDENTIFY_WEAK_USER_STORIES',
+    });
+  });
+
+  it('rolls back the question when an answer insert fails partway through', async () => {
+    queueRole('instructor');
+    queue('question', { data: null, error: null }); // MAX(order_number)
+    queue('question', { data: null, error: null }); // question insert
+    queue('answer', { data: null, error: null }); // answer 1 insert succeeds
+    queue('question_to_answer', { data: null, error: null }); // link 1 succeeds
+    queue('answer', { data: null, error: { message: 'answer insert failed' } }); // answer 2 insert fails
+
+    const res = await POST(postRequest(validBody()));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('answer insert failed');
+
+    const questionId = (h.state.inserts.find((i) => i.table === 'question')?.payload as { question_id: string })
+      .question_id;
+    const answerId = (h.state.inserts.find((i) => i.table === 'answer')?.payload as { answer_id: string }).answer_id;
+
+    expect(h.state.deletes).toContainEqual({ table: 'question_to_answer', column: 'question_id', value: questionId });
+    expect(h.state.deletes).toContainEqual({ table: 'answer', column: 'answer_id', value: [answerId] });
+    expect(h.state.deletes).toContainEqual({ table: 'question', column: 'question_id', value: questionId });
+  });
+
+  it('rolls back the question when the question_to_answer link insert fails', async () => {
+    queueRole('instructor');
+    queue('question', { data: null, error: null }); // MAX(order_number)
+    queue('question', { data: null, error: null }); // question insert
+    queue('answer', { data: null, error: null }); // answer 1 insert succeeds
+    queue('question_to_answer', { data: null, error: { message: 'link insert failed' } }); // link 1 fails
+
+    const res = await POST(postRequest(validBody()));
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('link insert failed');
+
+    const questionId = (h.state.inserts.find((i) => i.table === 'question')?.payload as { question_id: string })
+      .question_id;
+    const answerId = (h.state.inserts.find((i) => i.table === 'answer')?.payload as { answer_id: string }).answer_id;
+
+    expect(h.state.deletes).toContainEqual({ table: 'question_to_answer', column: 'question_id', value: questionId });
+    expect(h.state.deletes).toContainEqual({ table: 'answer', column: 'answer_id', value: [answerId] });
+    expect(h.state.deletes).toContainEqual({ table: 'question', column: 'question_id', value: questionId });
   });
 });

--- a/app/api/instructor/questions/[questionId]/route.ts
+++ b/app/api/instructor/questions/[questionId]/route.ts
@@ -1,0 +1,166 @@
+import { getSupabaseClient } from '../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../lib/instructorAuth';
+import { isActivityType } from '../../../../../lib/activityTypes';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+type AnswerPatchInput = {
+  id: string;
+  optionText: string;
+  isCorrect: boolean;
+  explanation?: string | null;
+};
+
+/**
+ * PATCH /api/instructor/questions/{questionId} — edits an existing question and its answers
+ * (GitHub #158).
+ *
+ * Body: { questionPrompt, activityType, difficultyLevel, answers: { id, optionText, isCorrect, explanation? }[] }
+ *
+ * - Every answer must carry the id of an answer already linked to this question. This route
+ *   edits option text/correctness in place; it doesn't add or remove options — the form has no
+ *   add/remove-option UI, so nothing would ever send a different count.
+ * - answered_question_log.submitted_option has no ON DELETE clause on its FK to answer, so a
+ *   previously-answered question's answer rows are physically undeletable. Updating in place
+ *   (rather than delete-and-reinsert, as POST does for a brand-new question) is required here,
+ *   not a style choice.
+ * - order_number and max_score are NOT editable through this route: nothing outside this
+ *   instructor's own GET ordering reads order_number, and rescaling max_score on edit would
+ *   silently change the value of a question students may have already partially attempted.
+ * - The question-level explanation is written only onto the answer row with isCorrect: true;
+ *   other rows' explanation column is left untouched (no key sent at all, not null) — QuizQuestion
+ *   has no field to carry a per-wrong-answer explanation, so there's nothing to round-trip for them.
+ *
+ * Unlike POST, a failure partway through the answers loop is not rolled back: a partially-applied
+ * edit still leaves a fully linked, fully playable question (some fields just momentarily stale),
+ * not an orphan — this asymmetry with POST's rollback is intentional.
+ *
+ * Returns 200 with { questionId, answerIds }.
+ */
+export async function PATCH(request: Request, { params }: { params: { questionId: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { questionId } = params;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { questionPrompt, activityType, difficultyLevel, answers } = (body ?? {}) as {
+    questionPrompt?: unknown;
+    activityType?: unknown;
+    difficultyLevel?: unknown;
+    answers?: unknown;
+  };
+
+  if (typeof questionPrompt !== 'string' || questionPrompt.trim() === '') {
+    return Response.json({ error: 'questionPrompt is required.' }, { status: 400 });
+  }
+  if (!isActivityType(activityType)) {
+    return Response.json({ error: 'activityType must be a valid activity type.' }, { status: 400 });
+  }
+  if (difficultyLevel !== 1 && difficultyLevel !== 2 && difficultyLevel !== 3) {
+    return Response.json({ error: 'difficultyLevel must be 1, 2, or 3.' }, { status: 400 });
+  }
+  if (!Array.isArray(answers) || answers.length < 2) {
+    return Response.json({ error: 'answers must be an array with at least 2 items.' }, { status: 400 });
+  }
+
+  const answerInputs = answers as AnswerPatchInput[];
+
+  for (const a of answerInputs) {
+    if (typeof a.id !== 'string' || a.id.trim() === '') {
+      return Response.json({ error: 'Each answer must have an id.' }, { status: 400 });
+    }
+    if (typeof a.optionText !== 'string' || a.optionText.trim() === '') {
+      return Response.json({ error: 'Each answer must have a non-empty optionText.' }, { status: 400 });
+    }
+    if (typeof a.isCorrect !== 'boolean') {
+      return Response.json({ error: 'Each answer must have a boolean isCorrect field.' }, { status: 400 });
+    }
+  }
+
+  if (new Set(answerInputs.map((a) => a.id)).size !== answerInputs.length) {
+    return Response.json({ error: 'Duplicate answer ids in request.' }, { status: 400 });
+  }
+
+  const correctCount = answerInputs.filter((a) => a.isCorrect).length;
+  if (correctCount !== 1) {
+    return Response.json({ error: 'Exactly one answer must be correct.' }, { status: 400 });
+  }
+
+  const { data: question, error: questionFetchError } = await supabase
+    .from('question')
+    .select('question_id, user_id')
+    .eq('question_id', questionId)
+    .maybeSingle();
+
+  if (questionFetchError) return Response.json({ error: questionFetchError.message }, { status: 500 });
+  if (!question) return Response.json({ error: 'Question not found.' }, { status: 404 });
+
+  if ((question as { user_id: string | null }).user_id !== guard.user_id) {
+    return Response.json({ error: 'You do not own this question.' }, { status: 403 });
+  }
+
+  const { data: links, error: linksError } = await supabase
+    .from('question_to_answer')
+    .select('answer_id')
+    .eq('question_id', questionId);
+
+  if (linksError) return Response.json({ error: linksError.message }, { status: 500 });
+
+  const existingAnswerIds = new Set(((links ?? []) as { answer_id: string }[]).map((link) => link.answer_id));
+
+  if (answerInputs.length !== existingAnswerIds.size) {
+    return Response.json(
+      { error: 'answers must match the existing option count for this question.' },
+      { status: 400 },
+    );
+  }
+  if (answerInputs.some((a) => !existingAnswerIds.has(a.id))) {
+    return Response.json({ error: 'One or more answer ids do not belong to this question.' }, { status: 400 });
+  }
+
+  const { error: questionUpdateError } = await supabase
+    .from('question')
+    .update({
+      question_prompt: questionPrompt.trim(),
+      activity_type: activityType,
+      difficulty_level: difficultyLevel,
+    })
+    .eq('question_id', questionId);
+
+  if (questionUpdateError) return Response.json({ error: questionUpdateError.message }, { status: 500 });
+
+  for (const a of answerInputs) {
+    const payload: Record<string, unknown> = {
+      option_text: a.optionText.trim(),
+      is_correct: a.isCorrect,
+    };
+    if (a.isCorrect && typeof a.explanation === 'string') {
+      payload.explanation = a.explanation;
+    }
+
+    const { error: answerUpdateError } = await supabase.from('answer').update(payload).eq('answer_id', a.id);
+    if (answerUpdateError) return Response.json({ error: answerUpdateError.message }, { status: 500 });
+  }
+
+  return Response.json({ questionId, answerIds: answerInputs.map((a) => a.id) }, { status: 200 });
+}

--- a/app/api/instructor/questions/route.ts
+++ b/app/api/instructor/questions/route.ts
@@ -193,11 +193,25 @@ export async function POST(request: Request) {
 
   if (questionError) return Response.json({ error: questionError.message }, { status: 500 });
 
+  // An orphaned question with no (or partial) answers is unplayable and pollutes order_number
+  // sequencing for its activity_type — clean it up on any failure below, in child-before-parent
+  // order (question_to_answer's FKs reference both answer and question). Same fire-and-forget,
+  // best-effort style as the session_to_question rollback in app/api/sessions/route.ts: no
+  // transaction (the Supabase JS client doesn't offer one), and the cleanup's own errors are
+  // ignored in favor of surfacing the original failure.
+  async function rollbackAndFail(insertedAnswerIds: string[], message: string) {
+    await supabase!.from('question_to_answer').delete().eq('question_id', questionId);
+    if (insertedAnswerIds.length > 0) {
+      await supabase!.from('answer').delete().in('answer_id', insertedAnswerIds);
+    }
+    await supabase!.from('question').delete().eq('question_id', questionId);
+    return Response.json({ error: message }, { status: 500 });
+  }
+
   const answerIds: string[] = [];
 
   for (const a of answerInputs) {
     const answerId = crypto.randomUUID();
-    answerIds.push(answerId);
 
     const { error: answerError } = await supabase.from('answer').insert({
       answer_id: answerId,
@@ -206,14 +220,16 @@ export async function POST(request: Request) {
       explanation: a.explanation ?? null,
     });
 
-    if (answerError) return Response.json({ error: answerError.message }, { status: 500 });
+    if (answerError) return rollbackAndFail(answerIds, answerError.message);
+
+    answerIds.push(answerId);
 
     const { error: linkError } = await supabase.from('question_to_answer').insert({
       question_id: questionId,
       answer_id: answerId,
     });
 
-    if (linkError) return Response.json({ error: linkError.message }, { status: 500 });
+    if (linkError) return rollbackAndFail(answerIds, linkError.message);
   }
 
   return Response.json({ questionId, answerIds }, { status: 201 });

--- a/app/instructor/questions/page.tsx
+++ b/app/instructor/questions/page.tsx
@@ -5,7 +5,7 @@ import { AppShell } from '../../../components/AppShell';
 import { QuestionFormModal } from '../../../components/QuestionFormModal';
 import { ACTIVITIES, getActivityByType } from '../../../lib/activityContent';
 import type { ActivityType } from '../../../lib/activityTypes';
-import { loadInstructorQuestions } from '../../../lib/sessionClient';
+import { createQuestion, loadInstructorQuestions, updateQuestion } from '../../../lib/sessionClient';
 import type { QuizQuestion } from '../../../lib/quizQuestionTypes';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
@@ -26,10 +26,9 @@ function EditIcon() {
 type ModalState = { mode: 'add' } | { mode: 'edit'; question: QuizQuestion };
 
 /**
- * Read-only browse of the question bank (GitHub #170, fetched from GET /api/instructor/questions),
- * plus adding (GitHub #120) and editing (GitHub #158) a question — both through the same popup
- * form. The add/edit flow still only updates local React state; wiring it to the existing
- * POST /api/instructor/questions is a separate story.
+ * Browse of the question bank (GitHub #170, fetched from GET /api/instructor/questions), plus
+ * adding (GitHub #120, POST /api/instructor/questions) and editing (GitHub #158,
+ * PATCH /api/instructor/questions/{id}) a question — both through the same popup form.
  */
 export default function InstructorQuestionsPage() {
   const { token, loading, authorized } = useRequireRole('instructor');
@@ -68,28 +67,47 @@ export default function InstructorQuestionsPage() {
     return true;
   });
 
-  function handleSaveQuestion(question: QuizQuestion) {
-    // The id already existing in state is what tells an edit and a new question apart — the
-    // form itself doesn't need to report which one it was.
-    const isEdit = (questions ?? []).some((existing) => existing.id === question.id);
+  async function handleSaveQuestion(question: QuizQuestion): Promise<{ ok: true } | { ok: false; error: string }> {
+    if (!token) return { ok: false, error: 'Your session has expired. Please sign in again.' };
+
+    // The modal's own mode (not an id lookup) is what tells an edit and a new question apart —
+    // a client-generated placeholder id could otherwise collide with nothing and look like "add".
+    const isEdit = modalState?.mode === 'edit';
+    const result = isEdit ? await updateQuestion(token, question) : await createQuestion(token, question);
+    if (!result.ok) return { ok: false, error: result.error };
+
+    // POST assigns real UUIDs server-side; the modal's placeholder ids (q-${Date.now()}, etc.)
+    // must not be kept, or a later edit would send ids the PATCH route has never seen.
+    const savedQuestion: QuizQuestion = isEdit
+      ? question
+      : {
+          ...question,
+          id: result.data.questionId,
+          answerOptions: question.answerOptions.map((option, index) => ({
+            ...option,
+            id: result.data.answerIds[index],
+          })),
+        };
 
     setQuestions((current) =>
       isEdit
-        ? (current ?? []).map((existing) => (existing.id === question.id ? question : existing))
-        : [question, ...(current ?? [])],
+        ? (current ?? []).map((existing) => (existing.id === savedQuestion.id ? savedQuestion : existing))
+        : [savedQuestion, ...(current ?? [])],
     );
 
     // Jump the view to wherever the question landed — otherwise a save that also moved the
     // question to a different quiz/level would look like it silently failed.
-    setActivityType(question.quizType);
-    setLevel(question.level);
-    setHighlight({ id: question.id, label: isEdit ? '✓ Updated' : '✓ Just added' });
+    setActivityType(savedQuestion.quizType);
+    setLevel(savedQuestion.level);
+    setHighlight({ id: savedQuestion.id, label: isEdit ? '✓ Updated' : '✓ Just added' });
 
-    const quizName = getActivityByType(question.quizType)?.name ?? question.quizType;
+    const quizName = getActivityByType(savedQuestion.quizType)?.name ?? savedQuestion.quizType;
     setToastMessage(isEdit ? `Changes saved to ${quizName}.` : `Question added to ${quizName}.`);
 
     window.setTimeout(() => setToastMessage(null), TOAST_MS);
     window.setTimeout(() => setHighlight(null), HIGHLIGHT_MS);
+
+    return { ok: true };
   }
 
   return (

--- a/components/QuestionFormModal.tsx
+++ b/components/QuestionFormModal.tsx
@@ -54,7 +54,8 @@ export function QuestionFormModal({
   /** Which quiz's tab/filter the page currently has active — the starting value in 'add' mode. */
   defaultQuizType: ActivityType;
   onClose: () => void;
-  onSave: (question: QuizQuestion) => void;
+  /** Async so a failed save can keep the modal open with an error instead of closing blindly. */
+  onSave: (question: QuizQuestion) => Promise<{ ok: true } | { ok: false; error: string }>;
 }) {
   const [quizType, setQuizType] = useState<ActivityType>(initialData?.quizType ?? defaultQuizType);
   const [level, setLevel] = useState<1 | 2 | 3>(initialData?.level ?? 1);
@@ -67,6 +68,8 @@ export function QuestionFormModal({
   );
   const [explanation, setExplanation] = useState(initialData?.explanation ?? '');
   const [errors, setErrors] = useState<FormErrors>({});
+  const [isSaving, setIsSaving] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const firstFieldRef = useRef<HTMLSelectElement>(null);
@@ -81,7 +84,7 @@ export function QuestionFormModal({
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === 'Escape') {
         event.preventDefault();
-        close();
+        requestClose();
         return;
       }
 
@@ -112,11 +115,17 @@ export function QuestionFormModal({
     previouslyFocusedRef.current?.focus();
   }
 
+  /** Cancel/×/backdrop/Escape all route through here so an in-flight save can't be abandoned. */
+  function requestClose() {
+    if (isSaving) return;
+    close();
+  }
+
   function updateOptionText(index: number, value: string) {
     setOptionTexts((current) => current.map((text, i) => (i === index ? value : text)));
   }
 
-  function handleSubmit(event: React.FormEvent) {
+  async function handleSubmit(event: React.FormEvent) {
     event.preventDefault();
 
     const nextErrors: FormErrors = {};
@@ -128,11 +137,11 @@ export function QuestionFormModal({
     setErrors(nextErrors);
     if (Object.keys(nextErrors).length > 0) return;
 
-    // Editing keeps the question's id, and each option's id at its position, so a real backend
-    // could update existing rows instead of treating every edit as a delete-and-recreate.
+    // Editing keeps the question's id, and each option's id at its position, so the PATCH route
+    // can update existing rows instead of treating every edit as a delete-and-recreate.
     const questionId = mode === 'edit' && initialData ? initialData.id : `q-${Date.now()}`;
 
-    onSave({
+    const question: QuizQuestion = {
       id: questionId,
       quizType,
       level,
@@ -143,9 +152,18 @@ export function QuestionFormModal({
         isCorrect: index === correctIndex,
       })),
       explanation: explanation.trim(),
-    });
+    };
 
-    close();
+    setSubmitError(null);
+    setIsSaving(true);
+    const result = await onSave(question);
+    setIsSaving(false);
+
+    if (result.ok) {
+      close();
+    } else {
+      setSubmitError(result.error);
+    }
   }
 
   const isEdit = mode === 'edit';
@@ -154,7 +172,7 @@ export function QuestionFormModal({
     <div
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8"
       onClick={(event) => {
-        if (event.target === event.currentTarget) close();
+        if (event.target === event.currentTarget) requestClose();
       }}
     >
       <div
@@ -173,9 +191,10 @@ export function QuestionFormModal({
           </div>
           <button
             type="button"
-            onClick={close}
+            onClick={requestClose}
+            disabled={isSaving}
             aria-label="Close"
-            className="flex h-8 w-8 flex-none items-center justify-center rounded-full border border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted transition hover:text-white"
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-full border border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted transition hover:text-white disabled:opacity-60"
           >
             <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
               <path d="M6 6l12 12M18 6L6 18" />
@@ -260,19 +279,27 @@ export function QuestionFormModal({
           </label>
           {errors.explanation ? <p className="mb-4 text-xs font-bold text-brand-danger">{errors.explanation}</p> : null}
 
+          {submitError ? (
+            <p className="mb-4 rounded-brand-md border border-brand-danger/40 bg-brand-danger/10 p-3 text-xs font-bold text-brand-danger-light">
+              {submitError}
+            </p>
+          ) : null}
+
           <div className="mt-6 flex justify-end gap-3">
             <button
               type="button"
-              onClick={close}
-              className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white"
+              onClick={requestClose}
+              disabled={isSaving}
+              className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white disabled:opacity-60"
             >
               Cancel
             </button>
             <button
               type="submit"
-              className="rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+              disabled={isSaving}
+              className="rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-60"
             >
-              {isEdit ? 'Save Changes' : 'Save Question'}
+              {isSaving ? 'Saving…' : isEdit ? 'Save Changes' : 'Save Question'}
             </button>
           </div>
         </form>

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -154,6 +154,14 @@ function postJson(payload: unknown): RequestInit {
   };
 }
 
+function patchJson(payload: unknown): RequestInit {
+  return {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  };
+}
+
 /**
  * Starts an activity — or picks up the one already running.
  *
@@ -355,13 +363,62 @@ export function loadInstructorActivities(token: string) {
  * The entire question bank (GET /api/instructor/questions, GitHub #170) — what the instructor's
  * Question Bank page renders instead of the old MOCK_QUESTIONS array.
  *
- * Deliberately **not** cached, same reasoning as loadInstructorActivities: nothing on the page
- * that reads this list currently writes back through it (the add/edit modal only updates local
- * React state, not the database), so there's no in-page action that could ever call
- * forceRefresh to invalidate a stale cache.
+ * Deliberately **not** cached, same reasoning as loadInstructorActivities: createQuestion/
+ * updateQuestion update the page's in-memory list directly from their own response instead of
+ * refetching, so there's still no in-page action that would ever call forceRefresh here.
  */
 export function loadInstructorQuestions(token: string) {
   return request<{ questions: QuizQuestion[] }>('/api/instructor/questions', { method: 'GET' }, token);
+}
+
+/** What POST/PATCH /api/instructor/questions echo back — ids only, not a full QuizQuestion. */
+export type SaveQuestionResult = { questionId: string; answerIds: string[] };
+
+/**
+ * Translates a QuizQuestion (UI shape) into the request body POST/PATCH expect (DB-facing field
+ * names). The question-level `explanation` only has anywhere to go on the correct answer — the
+ * database stores explanation per answer option, but QuizQuestion carries just one string, so
+ * that's the only round trip this shape can support.
+ *
+ * includeIds is false for create: the modal's placeholder ids (`q-${Date.now()}`, etc.) aren't
+ * real answer ids, and POST doesn't accept or use them — only PATCH needs an id per option, to
+ * know which existing answer row each entry updates.
+ */
+function answersPayload(question: QuizQuestion, includeIds: boolean) {
+  return question.answerOptions.map((option) => ({
+    ...(includeIds ? { id: option.id } : {}),
+    optionText: option.text,
+    isCorrect: option.isCorrect,
+    ...(option.isCorrect ? { explanation: question.explanation } : {}),
+  }));
+}
+
+/** Adds a new question to the bank (POST /api/instructor/questions, GitHub #121). */
+export function createQuestion(token: string, question: QuizQuestion) {
+  return request<SaveQuestionResult>(
+    '/api/instructor/questions',
+    postJson({
+      questionPrompt: question.questionText,
+      activityType: question.quizType,
+      difficultyLevel: question.level,
+      answers: answersPayload(question, false),
+    }),
+    token,
+  );
+}
+
+/** Edits an existing question in place (PATCH /api/instructor/questions/{id}, GitHub #158). */
+export function updateQuestion(token: string, question: QuizQuestion) {
+  return request<SaveQuestionResult>(
+    `/api/instructor/questions/${encodeURIComponent(question.id)}`,
+    patchJson({
+      questionPrompt: question.questionText,
+      activityType: question.quizType,
+      difficultyLevel: question.level,
+      answers: answersPayload(question, true),
+    }),
+    token,
+  );
 }
 
 /** One student row as returned by GET /api/instructor/students. */


### PR DESCRIPTION
# Question bank add/edit now persists

**Story:** As a professor, I want a question I add or edit to still be there after a reload, so that the question bank is a real editing tool and not a preview.

## Summary

`app/instructor/questions/page.tsx`'s save flow previously only touched local React state — every add/edit vanished on reload. This closes that gap.

Note: by the time this was picked up, `GET`/`POST /api/instructor/questions` already existed and the page already loaded real data (no `MOCK_QUESTIONS` left) — the original story description was written against an older state of the codebase. The actual remaining gaps were narrower: no `PATCH` route, no rollback on a partial `POST` failure, and the save flow never called the API at all.

## Changes

- **`POST /api/instructor/questions` now rolls back on a partial failure.** If an `answer` or `question_to_answer` insert fails partway through creating a question, the already-inserted rows (and the orphaned `question` row) are cleaned up instead of being left behind unplayable. Mirrors the existing `session_to_question` rollback pattern in `app/api/sessions/route.ts`.

- **New `PATCH /api/instructor/questions/[questionId]`.** Edits an existing question and its answers in place.
  - Guarded by `requireInstructor`, plus an ownership check (403 if the question belongs to a different instructor).
  - Updates answers **in place by their existing `answer_id`**, never delete-and-reinsert — `answered_question_log.submitted_option` has an FK to `answer` with no `ON DELETE` clause, so a previously-answered question's option rows are physically undeletable.
  - `order_number` and `max_score` are deliberately **not** editable here — nothing outside the instructor's own list ordering reads `order_number`, and rescaling `max_score` on edit would silently change scoring for a question students may have already attempted.
  - Enforces exactly one correct answer server-side (not just client-side).
  - Unlike `POST`, a partial failure here is **not** rolled back — a half-updated question is still valid and playable, just momentarily stale, so there's nothing to undo.

- **`lib/sessionClient.ts`**: new `createQuestion`/`updateQuestion` functions that translate the UI's `QuizQuestion` shape into the API's request body and call `POST`/`PATCH`.

- **`components/QuestionFormModal.tsx`**: `onSave` is now async and returns a result instead of `void`. A failed save keeps the modal open with an inline error instead of closing optimistically; Cancel/×/Escape/backdrop-click are routed through a guard so an in-flight save can't be abandoned (same pattern as `ImageCropModal`).

- **`app/instructor/questions/page.tsx`**: `handleSaveQuestion` now calls the real API and only updates local state / fires the toast + highlight after a successful response — not optimistically. Add-vs-edit is now determined from `modalState.mode` instead of a fragile id-lookup, and a newly created question's client-side placeholder ids are swapped for the server-issued ones so a later edit sends ids `PATCH` recognizes.

## Tests

- Extended `__tests__/api/instructor-questions.test.ts` with `POST` coverage: validation errors, the "exactly one correct answer" rule, server-assigned `order_number`/`max_score`, and two rollback scenarios (answer insert fails / link insert fails).
- New `__tests__/api/instructor-question-update.test.ts` for `PATCH`: auth/role guards, validation, 404 for an unknown question, 403 for an ownership mismatch, answer-count/id-membership checks, the happy path (asserting `order_number`/`max_score`/`user_id` are never touched), and a case confirming `PATCH` intentionally does *not* roll back a partial failure.

`npm test` (394 tests) and `npm run build` both pass.

resolve #172 