### PR TITLE
Add local cache for all questions and answers of a professor

### DIFF
--- a/app/instructor/questions/page.tsx
+++ b/app/instructor/questions/page.tsx
@@ -5,7 +5,7 @@ import { AppShell } from '../../../components/AppShell';
 import { QuestionFormModal } from '../../../components/QuestionFormModal';
 import { ACTIVITIES, getActivityByType } from '../../../lib/activityContent';
 import type { ActivityType } from '../../../lib/activityTypes';
-import { createQuestion, loadInstructorQuestions, updateQuestion } from '../../../lib/sessionClient';
+import { cacheInstructorQuestions, createQuestion, loadInstructorQuestions, updateQuestion } from '../../../lib/sessionClient';
 import type { QuizQuestion } from '../../../lib/quizQuestionTypes';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
@@ -31,7 +31,7 @@ type ModalState = { mode: 'add' } | { mode: 'edit'; question: QuizQuestion };
  * PATCH /api/instructor/questions/{id}) a question — both through the same popup form.
  */
 export default function InstructorQuestionsPage() {
-  const { token, loading, authorized } = useRequireRole('instructor');
+  const { token, profile, loading, authorized } = useRequireRole('instructor');
 
   const [questions, setQuestions] = useState<QuizQuestion[] | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -42,10 +42,10 @@ export default function InstructorQuestionsPage() {
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!token) return;
+    if (!token || !profile?.user_id) return;
     let cancelled = false;
 
-    loadInstructorQuestions(token).then((result) => {
+    loadInstructorQuestions(token, profile.user_id).then((result) => {
       if (cancelled) return;
       if (result.ok) {
         setQuestions(result.data.questions);
@@ -57,7 +57,7 @@ export default function InstructorQuestionsPage() {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, profile?.user_id]);
 
   if (loading || !authorized) return null;
 
@@ -68,7 +68,7 @@ export default function InstructorQuestionsPage() {
   });
 
   async function handleSaveQuestion(question: QuizQuestion): Promise<{ ok: true } | { ok: false; error: string }> {
-    if (!token) return { ok: false, error: 'Your session has expired. Please sign in again.' };
+    if (!token || !profile?.user_id) return { ok: false, error: 'Your session has expired. Please sign in again.' };
 
     // The modal's own mode (not an id lookup) is what tells an edit and a new question apart —
     // a client-generated placeholder id could otherwise collide with nothing and look like "add".
@@ -89,11 +89,15 @@ export default function InstructorQuestionsPage() {
           })),
         };
 
-    setQuestions((current) =>
-      isEdit
-        ? (current ?? []).map((existing) => (existing.id === savedQuestion.id ? savedQuestion : existing))
-        : [savedQuestion, ...(current ?? [])],
-    );
+    const updatedQuestions = isEdit
+      ? (questions ?? []).map((existing) => (existing.id === savedQuestion.id ? savedQuestion : existing))
+      : [savedQuestion, ...(questions ?? [])];
+
+    setQuestions(updatedQuestions);
+    // Invalidates loadInstructorQuestions' cache by overwriting it with the fresh list, instead
+    // of just dropping it — the next mount (this tab or another) sees the save immediately
+    // rather than falling back to a network round trip.
+    cacheInstructorQuestions(profile.user_id, updatedQuestions);
 
     // Jump the view to wherever the question landed — otherwise a save that also moved the
     // question to a different quiz/level would look like it silently failed.

--- a/lib/clientCaches.ts
+++ b/lib/clientCaches.ts
@@ -15,6 +15,7 @@ import { clearCachedAcceptanceCriteriaSubmissions } from './acceptanceCriteriaSu
 import { clearCachedActivityLog } from './activityLogStore';
 import { clearCachedCompletedAttempts } from './completedAttemptsStore';
 import { clearCachedCompletedSessions } from './completedSessionsStore';
+import { clearCachedInstructorQuestions } from './instructorQuestionsStore';
 import { clearCachedInstructorStudents } from './instructorStudentsStore';
 import { clearCachedLlmConfig } from './instructorLlmConfigStore';
 import { clearCachedScore } from './scoreStore';
@@ -38,6 +39,7 @@ export function clearAllClientCaches(): void {
   clearCachedCompletedAttempts();
   clearCachedActivityLog();
   clearCachedInstructorStudents();
+  clearCachedInstructorQuestions();
   clearCachedAcceptanceCriteriaSubmissions();
   clearCachedLlmConfig();
 }

--- a/lib/instructorQuestionsStore.ts
+++ b/lib/instructorQuestionsStore.ts
@@ -1,0 +1,47 @@
+// Local cache for the instructor's question bank (GET /api/instructor/questions, GitHub #170).
+// Same shape as instructorStudentsStore/activityLogStore: versioned key, SSR-guarded read/write,
+// only typed getter/setter exported — no raw store object.
+//
+// Keyed by instructorId so the cache survives across mounts without re-fetching the whole bank,
+// and so switching accounts on the same device doesn't serve one instructor's questions to
+// another. Unlike instructorStudentsStore, this one *does* need invalidation: createQuestion/
+// updateQuestion (lib/sessionClient.ts) write the fresh list back in on every save, since a
+// question the instructor just added or edited is exactly the kind of change this page must
+// never show stale.
+import type { QuizQuestion } from './quizQuestionTypes';
+
+const STORAGE_KEY = 'rc_instructor_questions_v1';
+
+type InstructorQuestionsStore = Partial<Record<string, QuizQuestion[]>>;
+
+function readStore(): InstructorQuestionsStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as InstructorQuestionsStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: InstructorQuestionsStore) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedInstructorQuestions(instructorId: string): QuizQuestion[] | null {
+  const store = readStore();
+  return store[instructorId] ?? null;
+}
+
+export function setCachedInstructorQuestions(instructorId: string, questions: QuizQuestion[]): void {
+  const store = readStore();
+  store[instructorId] = questions;
+  writeStore(store);
+}
+
+/** Drops every entry, for every instructor — see lib/clientCaches.ts. */
+export function clearCachedInstructorQuestions(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -17,6 +17,7 @@ import { getCachedActivityLog, setCachedActivityLog } from './activityLogStore';
 import { getCachedCompletedSessions, setCachedCompletedSessions } from './completedSessionsStore';
 import { getCachedScore, setCachedScore } from './scoreStore';
 import { getCachedInstructorStudents, setCachedInstructorStudents } from './instructorStudentsStore';
+import { getCachedInstructorQuestions, setCachedInstructorQuestions } from './instructorQuestionsStore';
 import {
   getCachedAcceptanceCriteriaSubmissions,
   setCachedAcceptanceCriteriaSubmissions,
@@ -371,12 +372,39 @@ export function loadInstructorActivities(token: string) {
  * The entire question bank (GET /api/instructor/questions, GitHub #170) — what the instructor's
  * Question Bank page renders instead of the old MOCK_QUESTIONS array.
  *
- * Deliberately **not** cached, same reasoning as loadInstructorActivities: createQuestion/
- * updateQuestion update the page's in-memory list directly from their own response instead of
- * refetching, so there's still no in-page action that would ever call forceRefresh here.
+ * Cache-first: returns the stored list on a hit, calls the network only on a miss or when
+ * forceRefresh is true — same pattern as loadInstructorStudents. Keyed by instructorId so
+ * switching accounts on the same device doesn't serve one instructor's questions to another.
+ *
+ * createQuestion/updateQuestion (below) only echo back ids, not a full QuizQuestion, so they
+ * can't write the cache themselves — app/instructor/questions/page.tsx's handleSaveQuestion
+ * does it once it has assembled the saved question, via setCachedInstructorQuestions. That's
+ * the invalidation for this cache: a save always leaves it holding the exact list the page just
+ * rendered, so the next mount (or another tab) never sees a bank that's missing the new question.
  */
-export function loadInstructorQuestions(token: string) {
-  return request<{ questions: QuizQuestion[] }>('/api/instructor/questions', { method: 'GET' }, token);
+export function loadInstructorQuestions(
+  token: string,
+  instructorId: string,
+  options: { forceRefresh?: boolean } = {},
+) {
+  if (!options.forceRefresh) {
+    const cached = getCachedInstructorQuestions(instructorId);
+    if (cached !== null) {
+      return Promise.resolve<ApiResult<{ questions: QuizQuestion[] }>>({
+        ok: true,
+        data: { questions: cached },
+      });
+    }
+  }
+
+  return request<{ questions: QuizQuestion[] }>('/api/instructor/questions', { method: 'GET' }, token).then(
+    (result) => {
+      if (result.ok) {
+        setCachedInstructorQuestions(instructorId, result.data.questions);
+      }
+      return result;
+    },
+  );
 }
 
 /** What POST/PATCH /api/instructor/questions echo back — ids only, not a full QuizQuestion. */
@@ -427,6 +455,17 @@ export function updateQuestion(token: string, question: QuizQuestion) {
     }),
     token,
   );
+}
+
+/**
+ * Writes the question bank into the cache loadInstructorQuestions reads from. Called by
+ * app/instructor/questions/page.tsx's handleSaveQuestion once a createQuestion/updateQuestion
+ * response has been merged into the page's list, so the cache is invalidated with the fresh
+ * data rather than just dropped — the next load (this tab or another) sees the save immediately
+ * instead of falling back to a network round trip.
+ */
+export function cacheInstructorQuestions(instructorId: string, questions: QuizQuestion[]): void {
+  setCachedInstructorQuestions(instructorId, questions);
 }
 
 /** One student row as returned by GET /api/instructor/students. */


### PR DESCRIPTION
- New lib/instructorQuestionsStore.ts — a localStorage cache for the question bank, following the exact shape of the existing stores (versioned key, SSR-guarded, typed getters/setters, keyed by instructorId).
- lib/sessionClient.ts — loadInstructorQuestions is now cache-first: checks the store, returns it if present, otherwise calls GET /api/instructor/questions and caches the response. Added cacheInstructorQuestions so the page can invalidate the cache after a save.
- app/instructor/questions/page.tsx — passes profile.user_id into loadInstructorQuestions; handleSaveQuestion now writes the freshly merged list into the cache after both createQuestion and updateQuestion succeed, so it never goes stale.
- lib/clientCaches.ts — wired into clearAllClientCaches() so logout clears it too, same as the other six caches.

resolve #119 