### PR TITLE
UI-2: Student sidebar — "Join Course" button

### DIFF
--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AppShell } from '../../components/AppShell';
+import { StudentCourseCard } from '../../components/StudentCourseCard';
+import { loadCourses, type Course } from '../../lib/mockCourses';
+import { useRequireRole } from '../../lib/useRequireRole';
+
+/**
+ * GitHub #242 (UI-2): browse every available course and join one — the expanded version of
+ * "Join Course" the issue asks for, a full page instead of a bare code-entry modal. Backend
+ * (API-2) doesn't exist yet, so this runs on lib/mockCourses.ts; see that file's header for
+ * what a real integration needs to swap in (notably: a student-facing GET /api/courses, not
+ * reusing the instructor-scoped one this mock's loadCourses stands in for either way).
+ */
+export default function BrowseCoursesPage() {
+  // Also redirects an instructor account away (GitHub #82) — joining a course as a student is
+  // not something an instructor account does.
+  const { token, profile, loading, authorized } = useRequireRole('student');
+
+  const [courses, setCourses] = useState<Course[] | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+
+  const [codeQuery, setCodeQuery] = useState('');
+  const [nameQuery, setNameQuery] = useState('');
+  const [professorQuery, setProfessorQuery] = useState('');
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+
+    setLoadFailed(false);
+
+    loadCourses(token).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setCourses(result.data.courses);
+      else setLoadFailed(true);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, retryCount]);
+
+  // Three independent, always-combinable filters (AND, not OR) — matches the Activity Log's
+  // filter row (components/ActivityFilters.tsx): each field narrows the list on its own,
+  // client-side, as soon as the mock course list is in hand.
+  const filtered = useMemo(() => {
+    if (!courses) return [];
+    const code = codeQuery.trim().toLowerCase();
+    const name = nameQuery.trim().toLowerCase();
+    const professor = professorQuery.trim().toLowerCase();
+
+    return courses.filter(
+      (course) =>
+        (!code || course.code.toLowerCase().includes(code)) &&
+        (!name || course.name.toLowerCase().includes(name)) &&
+        (!professor || course.professorName.toLowerCase().includes(professor)),
+    );
+  }, [courses, codeQuery, nameQuery, professorQuery]);
+
+  if (loading || !authorized) return null;
+  if (!token || !profile) return null;
+
+  function handleJoined(updated: Course) {
+    setCourses((current) => current?.map((c) => (c.id === updated.id ? updated : c)) ?? current);
+  }
+
+  return (
+    <AppShell active="courses">
+      <div className="mx-auto max-w-4xl">
+        <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">Courses</h1>
+        <p className="mb-6 max-w-2xl text-sm font-semibold text-gray-500">
+          Find your professor&apos;s course by code, name, or their name, and join with one click.
+        </p>
+
+        <div className="mb-5 flex flex-wrap gap-4">
+          <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
+            Course code
+            <input
+              type="text"
+              value={codeQuery}
+              onChange={(event) => setCodeQuery(event.target.value)}
+              placeholder="e.g. FALL26"
+              className="mt-1 block w-40 rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
+            />
+          </label>
+          <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
+            Course name
+            <input
+              type="text"
+              value={nameQuery}
+              onChange={(event) => setNameQuery(event.target.value)}
+              placeholder="Search by name…"
+              className="mt-1 block w-56 rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
+            />
+          </label>
+          <label className="block text-xs font-extrabold uppercase tracking-wide text-gray-400">
+            Professor
+            <input
+              type="text"
+              value={professorQuery}
+              onChange={(event) => setProfessorQuery(event.target.value)}
+              placeholder="Search by professor…"
+              className="mt-1 block w-56 rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
+            />
+          </label>
+        </div>
+
+        {loadFailed ? (
+          <div className="rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-6 text-center">
+            <p className="mb-4 text-sm font-semibold text-brand-danger">Failed to load courses.</p>
+            <button
+              type="button"
+              onClick={() => setRetryCount((count) => count + 1)}
+              className="rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white hover:bg-brand-purple-dark"
+            >
+              Retry
+            </button>
+          </div>
+        ) : courses === null ? (
+          <p className="text-sm font-semibold text-gray-500">Loading…</p>
+        ) : filtered.length === 0 ? (
+          <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
+            No courses match your search.
+          </p>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {filtered.map((course) => (
+              <StudentCourseCard key={course.id} course={course} token={token} studentId={profile.user_id} onJoined={handleJoined} />
+            ))}
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -25,6 +25,15 @@ function EditIcon() {
   );
 }
 
+function LockIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <rect x="5" y="11" width="14" height="9" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </svg>
+  );
+}
+
 /**
  * GitHub #241 follow-up: one course's detail view — code + roster management. Backend doesn't
  * exist yet, so this runs on lib/mockCourses.ts; see that file's header for what a real
@@ -105,7 +114,18 @@ export default function CourseDetailPage({ params }: { params: { id: string } })
             <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
               <div>
                 <h1 className="text-2xl font-extrabold text-brand-navy">{course.name}</h1>
-                <p className="mt-1.5 text-sm font-semibold tracking-[0.15em] text-brand-purple">{course.code}</p>
+                <div className="mt-1.5 flex flex-wrap items-center gap-2">
+                  <span className="text-sm font-semibold tracking-[0.15em] text-brand-purple">{course.code}</span>
+                  {course.enrollmentKey ? (
+                    <span
+                      className="inline-flex items-center gap-1 rounded-full bg-brand-gold/25 px-2.5 py-0.5 text-[11px] font-extrabold text-brand-gold-dark"
+                      title="Students need the enrollment key to join"
+                    >
+                      <LockIcon />
+                      Key required
+                    </span>
+                  ) : null}
+                </div>
               </div>
               <div className="flex flex-none items-center gap-3">
                 <CopyCodeButton code={course.code} />

--- a/app/instructor/courses/page.tsx
+++ b/app/instructor/courses/page.tsx
@@ -16,7 +16,7 @@ import { useRequireRole } from '../../../lib/useRequireRole';
 export default function InstructorCoursesPage() {
   // Same guard as every other /instructor/* page (GitHub #82/#169) — a student hitting this
   // URL directly is redirected, never shown the courses list or create form.
-  const { token, loading, authorized } = useRequireRole('instructor');
+  const { token, profile, loading, authorized } = useRequireRole('instructor');
 
   const [courses, setCourses] = useState<Course[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -40,7 +40,9 @@ export default function InstructorCoursesPage() {
   }, [token, retryCount]);
 
   if (loading || !authorized) return null;
-  if (!token) return null;
+  if (!token || !profile) return null;
+
+  const professorName = `${profile.first_name} ${profile.last_name}`.trim() || profile.username;
 
   return (
     <AppShell active="instructor-courses">
@@ -78,7 +80,11 @@ export default function InstructorCoursesPage() {
         )}
 
         <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">Create a course</p>
-        <CreateCourseForm token={token} onCreated={(course) => setCourses((current) => [course, ...(current ?? [])])} />
+        <CreateCourseForm
+          token={token}
+          professorName={professorName}
+          onCreated={(course) => setCourses((current) => [course, ...(current ?? [])])}
+        />
       </div>
     </AppShell>
   );

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -7,6 +7,7 @@ import { AppShell } from '../../components/AppShell';
 import { ChangePasswordForm } from '../../components/ChangePasswordForm';
 import { EditableField } from '../../components/EditableField';
 import { ImageCropModal } from '../../components/ImageCropModal';
+import { MyCoursesSection } from '../../components/MyCoursesSection';
 import { useUser } from '../../components/UserProvider';
 import { getInitials } from '../../lib/initials';
 
@@ -475,6 +476,11 @@ export default function ProfilePage() {
                 </button>
               )}
             </div>
+
+            {/* GitHub #242 (UI-2): a course concept only exists for students right now — an
+                instructor manages courses from /instructor/courses instead, so this doesn't
+                apply to their profile. */}
+            {!isInstructor ? <MyCoursesSection token={token} studentId={profile.user_id} /> : null}
           </>
         )}
       </section>

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -9,11 +9,24 @@ import { loadStudentScore } from '../lib/sessionClient';
 import { LLMProviderSettingsModal } from './LLMProviderSettingsModal';
 import { useUser } from './UserProvider';
 
-type NavKey = 'dashboard' | 'activities' | 'profile' | 'instructor' | 'instructor-questions' | 'instructor-settings' | 'instructor-ac' | 'instructor-courses';
+type NavKey =
+  | 'dashboard'
+  | 'activities'
+  | 'courses'
+  | 'profile'
+  | 'instructor'
+  | 'instructor-questions'
+  | 'instructor-settings'
+  | 'instructor-ac'
+  | 'instructor-courses';
 
+// GitHub #242 (UI-2): 'courses' here is the student-facing browse/join page (app/courses/page.tsx)
+// — a distinct NavKey/route from the instructor's 'instructor-courses' (create/manage), same
+// split as every other instructor-vs-student pair in this sidebar.
 const STUDENT_NAV_ITEMS: { key: NavKey; label: string; href: string }[] = [
   { key: 'dashboard', label: 'Dashboard', href: '/dashboard' },
   { key: 'activities', label: 'Activities', href: '/activities' },
+  { key: 'courses', label: 'Courses', href: '/courses' },
   { key: 'profile', label: 'Profile', href: '/profile' },
 ];
 
@@ -139,6 +152,7 @@ function CloseIcon() {
 const NAV_ICONS: Record<NavKey, () => JSX.Element> = {
   dashboard: GridIcon,
   activities: ListIcon,
+  courses: GraduationCapIcon,
   profile: UserIcon,
   instructor: UsersIcon,
   'instructor-courses': GraduationCapIcon,

--- a/components/CreateCourseForm.tsx
+++ b/components/CreateCourseForm.tsx
@@ -11,8 +11,18 @@ import { createCourse, type Course } from '../lib/mockCourses';
  * (GitHub #150) — disabled until there's a non-blank name, label swaps to "Creating…" while the
  * (mock) request is in flight.
  */
-export function CreateCourseForm({ token, onCreated }: { token: string; onCreated?: (course: Course) => void }) {
+export function CreateCourseForm({
+  token,
+  professorName,
+  onCreated,
+}: {
+  token: string;
+  /** The signed-in instructor's own display name — see lib/mockCourses.ts's createCourse docstring for why this comes from the caller instead of being looked up inside the mock. */
+  professorName: string;
+  onCreated?: (course: Course) => void;
+}) {
   const [name, setName] = useState('');
+  const [enrollmentKey, setEnrollmentKey] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
   const [course, setCourse] = useState<Course | null>(null);
@@ -26,7 +36,8 @@ export function CreateCourseForm({ token, onCreated }: { token: string; onCreate
     setSubmitting(true);
     setError('');
 
-    const result = await createCourse(token, name.trim());
+    // Blank input means open enrollment — Course.enrollmentKey is null, not an empty string.
+    const result = await createCourse(token, name.trim(), professorName, enrollmentKey.trim() || null);
     setSubmitting(false);
 
     if (!result.ok) {
@@ -38,6 +49,7 @@ export function CreateCourseForm({ token, onCreated }: { token: string; onCreate
     // one section shouldn't need to leave and come back to this page.
     setCourse(result.data.course);
     setName('');
+    setEnrollmentKey('');
     onCreated?.(result.data.course);
   }
 
@@ -51,6 +63,17 @@ export function CreateCourseForm({ token, onCreated }: { token: string; onCreate
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="e.g. Software Requirements — Fall 2026"
+            className="mt-1.5 block w-full rounded-brand-md border border-gray-300 bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-700 outline-none transition focus:border-brand-purple"
+          />
+        </label>
+
+        <label className="mb-1.5 mt-4 block text-sm font-bold text-gray-600">
+          Enrollment key (optional)
+          <input
+            type="text"
+            value={enrollmentKey}
+            onChange={(event) => setEnrollmentKey(event.target.value)}
+            placeholder="Leave empty for open enrollment"
             className="mt-1.5 block w-full rounded-brand-md border border-gray-300 bg-white px-3.5 py-2.5 text-sm font-semibold text-gray-700 outline-none transition focus:border-brand-purple"
           />
         </label>

--- a/components/EditCourseModal.tsx
+++ b/components/EditCourseModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { updateCourseName, type Course } from '../lib/mockCourses';
+import { updateCourse, type Course } from '../lib/mockCourses';
 
 const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
 
@@ -24,6 +24,8 @@ export function EditCourseModal({
   onSaved: (course: Course) => void;
 }) {
   const [name, setName] = useState(course.name);
+  // Empty when the course has no key — mirrors CreateCourseForm's "blank input = null" rule.
+  const [enrollmentKey, setEnrollmentKey] = useState(course.enrollmentKey ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
 
@@ -78,7 +80,7 @@ export function EditCourseModal({
     setSubmitting(true);
     setError('');
 
-    const result = await updateCourseName(token, course.id, name.trim());
+    const result = await updateCourse(token, course.id, { name: name.trim(), enrollmentKey: enrollmentKey.trim() || null });
     setSubmitting(false);
 
     if (!result.ok) {
@@ -134,6 +136,18 @@ export function EditCourseModal({
               className="mt-1.5 block w-full rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
             />
           </label>
+
+          <label className="mb-1.5 mt-4 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+            Enrollment key (optional)
+            <input
+              type="text"
+              value={enrollmentKey}
+              onChange={(event) => setEnrollmentKey(event.target.value)}
+              placeholder="Leave empty for open enrollment"
+              className="mt-1.5 block w-full rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
+            />
+          </label>
+          <p className="mt-1.5 text-xs font-semibold text-brand-ink-muted">Clear this field to remove the key and re-open enrollment.</p>
 
           {error ? <p className="mt-3 text-xs font-bold text-brand-danger">{error}</p> : null}
 

--- a/components/MyCoursesSection.tsx
+++ b/components/MyCoursesSection.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { loadCourses, type Course } from '../lib/mockCourses';
+
+/**
+ * GitHub #242 (UI-2): persistent "which courses am I in" display — the profile page half of the
+ * issue's requirement 5 (sidebar and/or profile; this app went with profile, since the sidebar
+ * is already tight on space and a growing course list wouldn't fit it well). Same
+ * "border-t pt-6, uppercase label" section style as the Change Password block right above it on
+ * app/profile/page.tsx, so it reads as one more section of that page, not a bolted-on widget.
+ */
+export function MyCoursesSection({ token, studentId }: { token: string; studentId: string }) {
+  const [courses, setCourses] = useState<Course[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    loadCourses(token).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setCourses(result.data.courses.filter((course) => course.studentIds.includes(studentId)));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, studentId]);
+
+  return (
+    <div className="mt-8 border-t border-gray-100 pt-6">
+      <p className="text-xs font-bold uppercase tracking-widest text-gray-400">My Courses</p>
+
+      {courses === null ? (
+        <p className="mt-3 text-sm font-semibold text-gray-500">Loading…</p>
+      ) : courses.length === 0 ? (
+        <p className="mt-3 text-sm font-semibold text-gray-500">
+          You haven&apos;t joined a course yet.{' '}
+          <Link href="/courses" className="text-brand-purple hover:underline">
+            Browse courses
+          </Link>
+        </p>
+      ) : (
+        <ul className="mt-3 space-y-2">
+          {courses.map((course) => (
+            <li key={course.id} className="flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white px-4 py-2.5">
+              <div className="min-w-0">
+                <p className="truncate text-sm font-bold text-brand-navy">{course.name}</p>
+                <p className="text-xs font-semibold text-gray-500">{course.professorName}</p>
+              </div>
+              <span className="flex-none text-xs font-extrabold tracking-[0.1em] text-brand-purple">{course.code}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/StudentCourseCard.tsx
+++ b/components/StudentCourseCard.tsx
@@ -1,0 +1,156 @@
+'use client';
+
+import { useState } from 'react';
+import { joinCourse, type Course } from '../lib/mockCourses';
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-3 w-3" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <rect x="5" y="11" width="14" height="9" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </svg>
+  );
+}
+
+/**
+ * GitHub #242 (UI-2) + follow-up (enrollment key): one course on the student-facing browse/join
+ * page. Same card look as components/CourseCard.tsx (the instructor's version — rounded-brand-lg,
+ * border-gray-100/bg-gray-50) but a distinct component rather than a shared one: this card's
+ * action is "join", that one's is "go manage this course as its instructor" — different
+ * audiences, different data, not just a style variant.
+ *
+ * `!!course.enrollmentKey` gates the whole extra step below — a course without one joins in one
+ * click exactly as before this field existed; only key-protected courses reveal the input.
+ */
+export function StudentCourseCard({
+  course,
+  token,
+  studentId,
+  onJoined,
+}: {
+  course: Course;
+  token: string;
+  studentId: string;
+  onJoined: (course: Course) => void;
+}) {
+  const [joining, setJoining] = useState(false);
+  const [error, setError] = useState('');
+  const [keyInputOpen, setKeyInputOpen] = useState(false);
+  const [enteredKey, setEnteredKey] = useState('');
+
+  const alreadyJoined = course.studentIds.includes(studentId);
+  const requiresKey = Boolean(course.enrollmentKey);
+
+  async function handleJoin(enrollmentKey?: string) {
+    if (joining) return;
+
+    setJoining(true);
+    setError('');
+
+    const result = await joinCourse(token, course.id, studentId, enrollmentKey);
+    setJoining(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return; // key input (if open) stays open so the student can immediately retry
+    }
+
+    setKeyInputOpen(false);
+    setEnteredKey('');
+    onJoined(result.data.course);
+  }
+
+  function handleJoinClick() {
+    if (requiresKey) {
+      setKeyInputOpen(true);
+      return;
+    }
+    void handleJoin();
+  }
+
+  return (
+    <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-4">
+      <span className="font-extrabold text-brand-navy">{course.name}</span>
+      <div className="mt-1 flex flex-wrap items-center gap-2">
+        <span className="text-xs font-semibold tracking-[0.15em] text-brand-purple">{course.code}</span>
+        {requiresKey ? (
+          <span
+            className="inline-flex items-center gap-1 rounded-full bg-brand-gold/25 px-2 py-0.5 text-[11px] font-extrabold text-brand-gold-dark"
+            title="Requires an enrollment key from your instructor"
+          >
+            <LockIcon />
+            Requires key
+          </span>
+        ) : null}
+      </div>
+      <p className="mt-1.5 text-xs font-semibold text-gray-500">
+        {course.professorName} · {course.studentIds.length} student{course.studentIds.length === 1 ? '' : 's'}
+      </p>
+
+      {error ? <p className="mt-2 text-xs font-semibold text-brand-danger">{error}</p> : null}
+
+      <div className="mt-3.5">
+        {alreadyJoined ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-brand-teal/20 px-4 py-2 text-sm font-extrabold text-brand-teal-dark">
+            <CheckIcon />
+            Joined
+          </span>
+        ) : keyInputOpen ? (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleJoin(enteredKey);
+            }}
+            className="flex flex-col gap-2 sm:flex-row sm:items-center"
+          >
+            <input
+              type="text"
+              value={enteredKey}
+              onChange={(event) => setEnteredKey(event.target.value)}
+              placeholder="Enrollment key"
+              autoFocus
+              className="rounded-brand-md border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-700 outline-none transition focus:border-brand-purple"
+            />
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                disabled={!enteredKey.trim() || joining}
+                className="rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {joining ? 'Joining…' : 'Join'}
+              </button>
+              <button
+                type="button"
+                onClick={() => {
+                  setKeyInputOpen(false);
+                  setEnteredKey('');
+                  setError('');
+                }}
+                className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-bold text-gray-600 transition hover:border-gray-300"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        ) : (
+          <button
+            type="button"
+            onClick={handleJoinClick}
+            disabled={joining}
+            className="rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {joining ? 'Joining…' : 'Join'}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/mockCourses.ts
+++ b/lib/mockCourses.ts
@@ -1,8 +1,8 @@
 'use client';
 
-// GitHub #241 (UI-1) + its follow-up (course overview/detail/roster management): mock for
-// API-1 and friends — the courses backend, which doesn't exist yet (built separately, per the
-// issue). Same "mock now, swap later" shape as lib/acceptanceCriteriaClient.ts and
+// GitHub #241 (UI-1, instructor create/manage) + #242 (UI-2, student browse/join): mock for
+// API-1/API-2 and friends — the courses backend, which doesn't exist yet (built separately, per
+// both issues). Same "mock now, swap later" shape as lib/acceptanceCriteriaClient.ts and
 // lib/instructorLlmConfigClient.ts: ApiResult<T>, a token parameter already threaded through
 // even though unused, and a simulated network delay so the UI's disabled/loading states are
 // exercised the same way they will be against the real calls.
@@ -13,11 +13,19 @@
 //     (course_id, student user_id) instead of this file's studentIds: string[] array.
 //   - POST /api/instructor/courses, PATCH /api/instructor/courses/:id, GET .../courses,
 //     GET .../courses/:id — all behind requireInstructor() (lib/instructorAuth.ts), and scoped
-//     so an instructor only ever sees/edits their own courses.
+//     so an instructor only ever sees/edits their own courses. createCourse's professorName
+//     must come from the instructor's own "user" row server-side, never a client-supplied value.
 //   - POST/DELETE .../courses/:id/students — add/remove, with the search-by-name-or-email this
 //     mock's searchMockStudents stands in for actually querying "user" instead of a fixed list.
-//   - Whatever "a student joins a course by code" flow eventually consumes the code — still out
-//     of scope here, same as it was for the original create-course issue.
+//   - POST /api/courses/:id/join (API-2) — student-facing, deriving the student from the
+//     caller's own token, never a body param the way joinCourse still has to accept one here.
+//     The enrollmentKey comparison MUST happen in this route, server-side — see the SECURITY
+//     NOTE on Course.enrollmentKey below for why the mock's approach (comparing in the client)
+//     is only acceptable because it's mock data.
+//     GET /api/courses (student-facing "browse all") likely needs its own route too, rather
+//     than reusing the instructor's GET .../courses — a student shouldn't need
+//     instructor-scoped auth just to browse what's joinable, and its response must not include
+//     the raw enrollmentKey (a requiresEnrollmentKey boolean instead).
 //   - This whole mock is one shared module-level array — it resets on a hard reload and is not
 //     scoped per instructor (every instructor account sees the same mock courses). A real
 //     implementation scopes every read/write to the caller's own courses.
@@ -29,6 +37,24 @@ export type Course = {
   createdAt: string;
   /** Real backend: a course_student join table, not an embedded array — see file header. */
   studentIds: string[];
+  /**
+   * Denormalized display name — a real GET would join this from the instructor's "user" row
+   * (first_name/last_name), the same way it's derived here from the real signed-in instructor's
+   * own profile at creation time (see CreateCourseForm), not stored as a separate relation.
+   */
+  professorName: string;
+  /**
+   * GitHub #242 follow-up: optional gate on self-service joining — null means open enrollment.
+   * Mirrors a nullable DB column exactly (not an empty string for "none"), so `!!course.enrollmentKey`
+   * is always the right "does this course require a key" check on both sides.
+   *
+   * SECURITY NOTE for the real integration: this mock embeds the real key value directly in
+   * what loadCourses/loadCourse return, which a real GET /api/courses must never do — the
+   * student-facing list response should only ever carry a boolean (e.g. requiresEnrollmentKey),
+   * and the actual key comparison in joinCourse below must happen server-side in the real
+   * route, not in client code where the key would be readable in the network response/bundle.
+   */
+  enrollmentKey: string | null;
 };
 
 /**
@@ -89,6 +115,9 @@ let mockCourses: Course[] = [
     code: 'FALL26',
     createdAt: new Date(Date.now() - 21 * 24 * 60 * 60 * 1000).toISOString(),
     studentIds: ['mock-student-1', 'mock-student-2', 'mock-student-3', 'mock-student-4'],
+    professorName: 'Dr. Brockenbrough',
+    // Has a key, so both states (with/without) are exercisable in the UI out of the box.
+    enrollmentKey: 'REQ2026',
   },
   {
     id: 'mock-course-2',
@@ -96,6 +125,8 @@ let mockCourses: Course[] = [
     code: 'SPR26X',
     createdAt: new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString(),
     studentIds: ['mock-student-5', 'mock-student-6'],
+    professorName: 'Dr. Osei',
+    enrollmentKey: null,
   },
 ];
 
@@ -124,9 +155,17 @@ export async function loadCourse(token: string, courseId: string): Promise<ApiRe
 /**
  * Mocks POST /api/instructor/courses. Takes `token` (unused for now) so the call site already
  * matches every other client wrapper's request(url, init, token) convention — swapping this for
- * a real fetch later doesn't change the signature CreateCourseForm calls it with.
+ * a real fetch later doesn't change the signature CreateCourseForm calls it with. professorName
+ * is passed in by the caller (the real signed-in instructor's own name) rather than looked up
+ * here — a real route would derive it server-side from the "user" row the token resolves to,
+ * the same way it derives user_id everywhere else in this app, never trust a client-supplied name.
  */
-export async function createCourse(token: string, name: string): Promise<ApiResult<{ course: Course }>> {
+export async function createCourse(
+  token: string,
+  name: string,
+  professorName: string,
+  enrollmentKey: string | null,
+): Promise<ApiResult<{ course: Course }>> {
   void token;
   await delay(MOCK_DELAY_MS);
 
@@ -140,24 +179,36 @@ export async function createCourse(token: string, name: string): Promise<ApiResu
     code: generateCourseCode(),
     createdAt: new Date().toISOString(),
     studentIds: [],
+    professorName,
+    enrollmentKey,
   };
 
   mockCourses = [course, ...mockCourses];
   return { ok: true, data: { course } };
 }
 
-/** Mocks PATCH /api/instructor/courses/:id — currently only the name is editable. */
-export async function updateCourseName(token: string, courseId: string, name: string): Promise<ApiResult<{ course: Course }>> {
+/**
+ * Mocks PATCH /api/instructor/courses/:id — name and enrollmentKey together (one Save in
+ * EditCourseModal, one call). Renamed from the original updateCourseName now that it covers
+ * more than the name.
+ */
+export async function updateCourse(
+  token: string,
+  courseId: string,
+  updates: { name: string; enrollmentKey: string | null },
+): Promise<ApiResult<{ course: Course }>> {
   void token;
   await delay(MOCK_DELAY_MS);
 
-  if (!name.trim()) {
+  if (!updates.name.trim()) {
     return { ok: false, status: 400, error: 'Course name is required.' };
   }
   const found = findCourseOrError(courseId);
   if (!found.ok) return found;
 
-  mockCourses = mockCourses.map((c) => (c.id === courseId ? { ...c, name: name.trim() } : c));
+  mockCourses = mockCourses.map((c) =>
+    c.id === courseId ? { ...c, name: updates.name.trim(), enrollmentKey: updates.enrollmentKey } : c,
+  );
   return { ok: true, data: { course: mockCourses.find((c) => c.id === courseId)! } };
 }
 
@@ -174,6 +225,39 @@ export async function addStudentToCourse(token: string, courseId: string, studen
 
   mockCourses = mockCourses.map((c) => (c.id === courseId ? { ...c, studentIds: [...c.studentIds, studentId] } : c));
   return { ok: true, data: { course: mockCourses.find((c) => c.id === courseId)! } };
+}
+
+/**
+ * GitHub #242 (UI-2) + follow-up (enrollment key): mocks POST /api/courses/:id/join — a student
+ * joining a course themselves, by code/browsing rather than being added by an instructor.
+ * Validates enrollmentKey here, in the mock, purely so the UI's error path has something real
+ * to exercise — this comparison MUST move server-side in the real route (see this file's header
+ * and the SECURITY NOTE on Course.enrollmentKey); a real GET response should never have sent
+ * the key to the client in the first place, so there'd be nothing to compare against here.
+ *
+ * Delegates to addStudentToCourse for the actual studentIds mutation once the key checks out —
+ * kept as its own export because the real API-2 this stands in for is a genuinely different
+ * endpoint from addStudentToCourse's real counterpart: self-service, and — like every other
+ * student-facing route in this app — deriving the student from the caller's own token
+ * server-side, never a body param the way this mock still has to accept one.
+ */
+export async function joinCourse(
+  token: string,
+  courseId: string,
+  studentId: string,
+  enrollmentKey?: string,
+): Promise<ApiResult<{ course: Course }>> {
+  void token;
+  await delay(MOCK_DELAY_MS);
+
+  const found = findCourseOrError(courseId);
+  if (!found.ok) return found;
+
+  if (found.course.enrollmentKey && found.course.enrollmentKey !== (enrollmentKey ?? '').trim()) {
+    return { ok: false, status: 403, error: 'Incorrect enrollment key. Check with your instructor and try again.' };
+  }
+
+  return addStudentToCourse(token, courseId, studentId);
 }
 
 /** Mocks DELETE /api/instructor/courses/:id/students/:studentId. */


### PR DESCRIPTION
<img width="2488" height="1572" alt="image" src="https://github.com/user-attachments/assets/76dfcf85-9901-48ab-b42a-c591fff7c97d" />
resolves #242 

Student can search and join a course.
Instructors can set an optional key when creating or editing a course; students joining a key-protected course must enter it before the join succeeds, while open courses continue to join with a single click. Mocked in lib/mockCourses.ts with a nullable enrollmentKey field, ready to be swapped for real server-side validation.