### PR TITLE
Cache instructor activity list to avoid re-fetching on navigation

### DIFF
--- a/__tests__/lib/sessionClient.test.ts
+++ b/__tests__/lib/sessionClient.test.ts
@@ -9,6 +9,7 @@ import type { InstructorActivityEntry } from '../../lib/sessionTypes';
 // vitest's node environment.
 
 const TOKEN = 'instructor-token';
+const INSTRUCTOR_ID = 'instructor-1';
 
 function stubFetch(impl: (url: string, init: RequestInit) => Promise<Response> | Promise<never>) {
   const spy = vi.fn(impl);
@@ -47,7 +48,7 @@ describe('loadInstructorActivities', () => {
   it('returns the class-wide sessions and sends the bearer token', async () => {
     const fetchSpy = stubFetch(() => jsonResponse({ sessions: [SESSION] }, 200));
 
-    const result = await loadInstructorActivities(TOKEN);
+    const result = await loadInstructorActivities(TOKEN, INSTRUCTOR_ID);
 
     expect(result).toEqual({ ok: true, data: { sessions: [SESSION] } });
 
@@ -61,7 +62,7 @@ describe('loadInstructorActivities', () => {
   it('reports a non-2xx response as a failed result instead of throwing', async () => {
     stubFetch(() => jsonResponse({ error: 'Something went wrong.' }, 500));
 
-    await expect(loadInstructorActivities(TOKEN)).resolves.toEqual({
+    await expect(loadInstructorActivities(TOKEN, INSTRUCTOR_ID)).resolves.toEqual({
       ok: false,
       status: 500,
       error: 'Something went wrong.',
@@ -73,7 +74,7 @@ describe('loadInstructorActivities', () => {
     // { error } to pick apart — the caller still has to get 403 rather than an exception.
     stubFetch(() => Promise.resolve(new Response(null, { status: 403 })));
 
-    const result = await loadInstructorActivities(TOKEN);
+    const result = await loadInstructorActivities(TOKEN, INSTRUCTOR_ID);
 
     expect(result.ok).toBe(false);
     expect(result).toMatchObject({ status: 403 });
@@ -84,7 +85,7 @@ describe('loadInstructorActivities', () => {
 
     // Status 0 is what lets the page say "server unreachable" instead of blaming the server
     // for an error it never got the chance to send.
-    await expect(loadInstructorActivities(TOKEN)).resolves.toEqual({
+    await expect(loadInstructorActivities(TOKEN, INSTRUCTOR_ID)).resolves.toEqual({
       ok: false,
       status: 0,
       error: 'Could not reach the server. Please try again.',

--- a/app/instructor/page.tsx
+++ b/app/instructor/page.tsx
@@ -40,26 +40,24 @@ function InstructorDashboardContent() {
   const [entries, setEntries] = useState<StudentActivitySummary[] | null>(null);
   const [allStudents, setAllStudents] = useState<StudentSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
 
   const [studentId, setStudentId] = useState<StudentFilterValue>('all');
   const [level, setLevel] = useState<LevelFilterValue>('all');
   const [sort, setSort] = useState<InstructorSortOrder>('newest');
   const [page, setPage] = useState(1);
 
-  // GET /api/instructor/activities (GitHub #171) — the whole class, guarded server-side by
-  // requireInstructor. Uncached on purpose: any student's answer changes this list, and this
-  // tab never hears about it (see loadInstructorActivities).
+  // GET /api/instructor/activities (GitHub #171/#176) — cache-first; forceRefresh on the
+  // Refresh button or when profile.user_id becomes available for the first time.
   useEffect(() => {
-    if (!token) return;
+    if (!token || !profile?.user_id) return;
     let cancelled = false;
 
-    loadInstructorActivities(token).then((result) => {
+    loadInstructorActivities(token, profile.user_id).then((result) => {
       if (cancelled) return;
       if (result.ok) {
         setEntries(result.data.sessions.map((session: InstructorActivityEntry) => toStudentActivitySummary(session)));
       } else {
-        // result.error already distinguishes "server said no" from "never reached the server"
-        // (status 0) — see the request helper in lib/sessionClient.ts.
         setError(result.error);
       }
     });
@@ -67,7 +65,21 @@ function InstructorDashboardContent() {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, profile?.user_id]);
+
+  function handleRefresh() {
+    if (!token || !profile?.user_id || refreshing) return;
+    setRefreshing(true);
+    loadInstructorActivities(token, profile.user_id, { forceRefresh: true }).then((result) => {
+      setRefreshing(false);
+      if (result.ok) {
+        setEntries(result.data.sessions.map((session: InstructorActivityEntry) => toStudentActivitySummary(session)));
+        setError(null);
+      } else {
+        setError(result.error);
+      }
+    });
+  }
 
   useEffect(() => {
     if (!token || !profile?.user_id) return;
@@ -136,7 +148,16 @@ function InstructorDashboardContent() {
   return (
     <AppShell active="instructor">
       <div className="mx-auto max-w-5xl">
-        <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">Instructor Dashboard</h1>
+        <div className="mb-1.5 flex items-center justify-between gap-4">
+          <h1 className="text-2xl font-extrabold text-brand-navy">Instructor Dashboard</h1>
+          <button
+            onClick={handleRefresh}
+            disabled={refreshing || entries === null}
+            className="rounded-full border border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm transition hover:border-brand-purple hover:text-brand-purple disabled:opacity-40"
+          >
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+        </div>
         <p className="mb-6 max-w-2xl text-sm font-semibold text-gray-500">
           Every student&apos;s activity, across every activity type — filter by student or level, or sort to surface who needs a
           hand.

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -45,13 +45,12 @@ export default function AllStudentsPage() {
   const [sort, setSort] = useState<SortOrder>('needs-attention');
   const [page, setPage] = useState(1);
 
-  // Same class-wide fetch as the dashboard, made independently rather than shared: this list is
-  // uncached (see loadInstructorActivities), and the two pages are separate entry points.
+  // Cache-first: shares the rc_instructor_activity_v1 cache with the dashboard (GitHub #176).
   useEffect(() => {
-    if (!token) return;
+    if (!token || !profile?.user_id) return;
     let cancelled = false;
 
-    loadInstructorActivities(token).then((result) => {
+    loadInstructorActivities(token, profile.user_id).then((result) => {
       if (cancelled) return;
       if (result.ok) {
         setEntries(result.data.sessions.map((session: InstructorActivityEntry) => toStudentActivitySummary(session)));
@@ -63,7 +62,7 @@ export default function AllStudentsPage() {
     return () => {
       cancelled = true;
     };
-  }, [token]);
+  }, [token, profile?.user_id]);
 
   useEffect(() => {
     if (!token || !profile?.user_id) return;

--- a/lib/clientCaches.ts
+++ b/lib/clientCaches.ts
@@ -15,6 +15,7 @@ import { clearCachedAcceptanceCriteriaSubmissions } from './acceptanceCriteriaSu
 import { clearCachedActivityLog } from './activityLogStore';
 import { clearCachedCompletedAttempts } from './completedAttemptsStore';
 import { clearCachedCompletedSessions } from './completedSessionsStore';
+import { clearCachedInstructorActivities } from './instructorActivityStore';
 import { clearCachedInstructorQuestions } from './instructorQuestionsStore';
 import { clearCachedInstructorStudents } from './instructorStudentsStore';
 import { clearCachedLlmConfig } from './instructorLlmConfigStore';
@@ -38,6 +39,7 @@ export function clearAllClientCaches(): void {
   clearCachedCompletedSessions();
   clearCachedCompletedAttempts();
   clearCachedActivityLog();
+  clearCachedInstructorActivities();
   clearCachedInstructorStudents();
   clearCachedInstructorQuestions();
   clearCachedAcceptanceCriteriaSubmissions();

--- a/lib/instructorActivityStore.ts
+++ b/lib/instructorActivityStore.ts
@@ -1,0 +1,43 @@
+// Local cache for the class-wide activity list (GET /api/instructor/activities, GitHub #176).
+// Same shape as instructorStudentsStore: versioned key, SSR-guarded read/write, only typed
+// getter/setter exported — no raw store object.
+//
+// Keyed by the instructor's user_id so a shared browser does not hand one instructor's cache
+// to the next. Cleared on logout alongside every other cache that holds students' personal data.
+import type { InstructorActivityEntry } from './sessionTypes';
+
+const STORAGE_KEY = 'rc_instructor_activity_v1';
+
+type InstructorActivityStore = Partial<Record<string, InstructorActivityEntry[]>>;
+
+function readStore(): InstructorActivityStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as InstructorActivityStore) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: InstructorActivityStore) {
+  if (typeof window === 'undefined') return;
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+}
+
+export function getCachedInstructorActivities(instructorId: string): InstructorActivityEntry[] | null {
+  const store = readStore();
+  return store[instructorId] ?? null;
+}
+
+export function setCachedInstructorActivities(instructorId: string, activities: InstructorActivityEntry[]): void {
+  const store = readStore();
+  store[instructorId] = activities;
+  writeStore(store);
+}
+
+/** Drops every entry, for every instructor — see lib/clientCaches.ts. */
+export function clearCachedInstructorActivities(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(STORAGE_KEY);
+}

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -17,6 +17,7 @@ import { getCachedActivityLog, setCachedActivityLog } from './activityLogStore';
 import { getCachedCompletedSessions, setCachedCompletedSessions } from './completedSessionsStore';
 import { getCachedScore, setCachedScore } from './scoreStore';
 import { getCachedInstructorStudents, setCachedInstructorStudents } from './instructorStudentsStore';
+import { getCachedInstructorActivities, setCachedInstructorActivities } from './instructorActivityStore';
 import { getCachedInstructorQuestions, setCachedInstructorQuestions } from './instructorQuestionsStore';
 import {
   getCachedAcceptanceCriteriaSubmissions,
@@ -355,17 +356,38 @@ export function loadActivityLog(
 /**
  * Every student's attempts across the class (GET /api/instructor/activities, GitHub #171) —
  * what the Instructor Dashboard renders. The route answers 403 for anyone who isn't a
- * confirmed instructor, so there is no studentId to pass: the whole class is the scope.
+ * confirmed instructor.
  *
- * Deliberately **not** cached in localStorage, unlike loadStudentScore/loadSessions('completed')
- * /loadActivityLog. Those four caches are keyed by studentId and hold the student's own data,
- * which only that student's own actions change — so the page that causes a change can
- * forceRefresh it. This list changes whenever *any* student in the class answers, starts or
- * abandons something, and this tab never learns about it, so a cache here would just show
- * an instructor stale results with no invalidation point to fix it.
+ * Cache-first: returns the stored list on a hit, calls the network only on a miss or when
+ * forceRefresh is true (GitHub #176). Keyed by instructorId so the cache is not shared
+ * between different instructor accounts on the same device. Students write the data, so
+ * staleness is bounded by mount and the explicit Refresh control on the dashboard.
  */
-export function loadInstructorActivities(token: string) {
-  return request<{ sessions: InstructorActivityEntry[] }>('/api/instructor/activities', { method: 'GET' }, token);
+export function loadInstructorActivities(
+  token: string,
+  instructorId: string,
+  options: { forceRefresh?: boolean } = {},
+) {
+  if (!options.forceRefresh) {
+    const cached = getCachedInstructorActivities(instructorId);
+    if (cached !== null) {
+      return Promise.resolve<ApiResult<{ sessions: InstructorActivityEntry[] }>>({
+        ok: true,
+        data: { sessions: cached },
+      });
+    }
+  }
+
+  return request<{ sessions: InstructorActivityEntry[] }>(
+    '/api/instructor/activities',
+    { method: 'GET' },
+    token,
+  ).then((result) => {
+    if (result.ok) {
+      setCachedInstructorActivities(instructorId, result.data.sessions);
+    }
+    return result;
+  });
 }
 
 /**


### PR DESCRIPTION
Caches the class-wide activity list (`GET /api/instructor/activities`) in localStorage under `rc_instructor_activity_v1`, keyed by the instructor's `user_id`.

- `lib/instructorActivityStore.ts` — new store, same shape as all other stores
- `loadInstructorActivities` now takes `instructorId` + `forceRefresh` option
- Cache is cleared on logout via `clearAllClientCaches`
- Dashboard shows a **Refresh** button (top-right) for manual invalidation
- Roster page (`/instructor/students`) is now a cache hit when the dashboard was visited first

Resolves #176
