### PR TITLE
Enforce sequential story submission and return next story after grading

### DIFF
--- a/app/api/activities/write-acceptance-criteria/submissions/route.ts
+++ b/app/api/activities/write-acceptance-criteria/submissions/route.ts
@@ -4,6 +4,8 @@ import {
   isLLMProviderName,
 } from "../../../../../lib/llm/factory";
 
+const STORIES_PER_SESSION = 4;
+
 type UserStoryRow = { user_story_id: string; story_text: string; creator_id: string };
 type LLMConfigRow = { provider: string; api_key: string; model: string };
 
@@ -16,10 +18,16 @@ function getToken(request: Request): string | null {
  * POST /api/activities/write-acceptance-criteria/submissions — grades one free-text
  * acceptance-criteria submission against a given user story (REQ-FU-2).
  *
- * Write-before-disclose, same shape as POST .../answers: the submission row is committed
- * with the grading columns still null, then the LLM call runs, then the row is updated with
- * the result. A crash between insert and update leaves an ungraded row rather than a graded
- * answer that was never recorded.
+ * Write-before-disclose: the submission row is committed with grading columns null, then
+ * the LLM call runs, then the row is updated. A crash between insert and update leaves an
+ * ungraded row rather than a graded answer that was never recorded.
+ *
+ * When sessionId is provided (GitHub #256):
+ *   - Validates the session is in-progress and belongs to this student.
+ *   - Enforces sequential order: only the next unanswered story may be submitted. Attempting
+ *     a story the student hasn't reached yet returns 409.
+ *   - After grading, checks whether all four stories are now answered. If so, marks the
+ *     session completed and returns sessionCompleted: true with the totals.
  */
 export async function POST(request: Request) {
   const token = getToken(request);
@@ -32,43 +40,75 @@ export async function POST(request: Request) {
     return Response.json({ error: "Invalid JSON body." }, { status: 400 });
   }
 
-  const { userStoryId, submittedText } = (body ?? {}) as {
+  const { userStoryId, submittedText, sessionId } = (body ?? {}) as {
     userStoryId?: unknown;
     submittedText?: unknown;
+    sessionId?: unknown;
   };
 
   if (typeof userStoryId !== "string" || userStoryId.trim() === "") {
-    return Response.json(
-      { error: "userStoryId is required." },
-      { status: 400 },
-    );
+    return Response.json({ error: "userStoryId is required." }, { status: 400 });
   }
 
-  // Rejected before any DB write or LLM call.
   if (typeof submittedText !== "string" || submittedText.trim() === "") {
-    return Response.json(
-      { error: "submittedText is required." },
-      { status: 400 },
-    );
+    return Response.json({ error: "submittedText is required." }, { status: 400 });
   }
 
   const supabase = getSupabaseClient();
   if (!supabase)
-    return Response.json(
-      { error: "Supabase credentials are not configured." },
-      { status: 500 },
-    );
+    return Response.json({ error: "Supabase credentials are not configured." }, { status: 500 });
 
-  // The student id comes from the auth session, never from the request body.
-  const {
-    data: { user },
-    error: authError,
-  } = await supabase.auth.getUser(token);
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
   if (authError || !user)
-    return Response.json(
-      { error: "Invalid or expired token." },
-      { status: 401 },
-    );
+    return Response.json({ error: "Invalid or expired token." }, { status: 401 });
+
+  const resolvedSessionId: string | null = typeof sessionId === "string" ? sessionId : null;
+
+  if (resolvedSessionId) {
+    // Validate the session belongs to this student and is still open.
+    const { data: session, error: sessionError } = await supabase
+      .from("ac_session")
+      .select("ac_session_id, status")
+      .eq("ac_session_id", resolvedSessionId)
+      .eq("user_id", user.id)
+      .maybeSingle();
+
+    if (sessionError) return Response.json({ error: sessionError.message }, { status: 500 });
+    if (!session) return Response.json({ error: "Session not found." }, { status: 404 });
+    if (session.status === "completed") {
+      return Response.json({ error: "This session is already completed." }, { status: 409 });
+    }
+
+    // Determine the current story (next unanswered position).
+    const { data: sessionStories, error: storiesError } = await supabase
+      .from("ac_session_story")
+      .select("position, user_story_id")
+      .eq("ac_session_id", resolvedSessionId)
+      .order("position", { ascending: true });
+
+    if (storiesError) return Response.json({ error: storiesError.message }, { status: 500 });
+
+    const { data: existingSubmissions, error: subError } = await supabase
+      .from("submission")
+      .select("user_story_id")
+      .eq("ac_session_id", resolvedSessionId);
+
+    if (subError) return Response.json({ error: subError.message }, { status: 500 });
+
+    const submittedIds = new Set((existingSubmissions ?? []).map((s) => s.user_story_id));
+    const currentStory = (sessionStories ?? []).find((s) => !submittedIds.has(s.user_story_id));
+
+    if (!currentStory) {
+      return Response.json({ error: "This session is already completed." }, { status: 409 });
+    }
+
+    if (userStoryId !== currentStory.user_story_id) {
+      return Response.json(
+        { error: `You must submit story ${currentStory.position} before moving on.` },
+        { status: 409 },
+      );
+    }
+  }
 
   const { data: story, error: storyError } = await supabase
     .from("user_story")
@@ -76,14 +116,9 @@ export async function POST(request: Request) {
     .eq("user_story_id", userStoryId)
     .maybeSingle();
 
-  if (storyError)
-    return Response.json({ error: storyError.message }, { status: 500 });
-  if (!story)
-    return Response.json({ error: "User story not found." }, { status: 404 });
+  if (storyError) return Response.json({ error: storyError.message }, { status: 500 });
+  if (!story) return Response.json({ error: "User story not found." }, { status: 404 });
 
-  // Scoped to the instructor who authored this story, not a single global toggle — an
-  // instructor can accumulate multiple config rows over time (POST /api/instructor/llm-config
-  // always inserts, never updates in place), so this takes their most recently saved one.
   const { data: config, error: configError } = await supabase
     .from("instructor_llm_config")
     .select("provider, api_key, model")
@@ -92,8 +127,7 @@ export async function POST(request: Request) {
     .limit(1)
     .maybeSingle();
 
-  if (configError)
-    return Response.json({ error: configError.message }, { status: 500 });
+  if (configError) return Response.json({ error: configError.message }, { status: 500 });
   if (!config)
     return Response.json(
       { error: "The instructor who created this prompt has not configured an LLM provider." },
@@ -102,34 +136,25 @@ export async function POST(request: Request) {
 
   const { provider: providerName, api_key: apiKey, model } = config as LLMConfigRow;
   if (!isLLMProviderName(providerName)) {
-    return Response.json(
-      { error: "Configured LLM provider is invalid." },
-      { status: 500 },
-    );
+    return Response.json({ error: "Configured LLM provider is invalid." }, { status: 500 });
   }
 
   const provider = getLLMProvider(providerName, apiKey, model);
   if (!provider) {
-    return Response.json(
-      { error: "Configured LLM provider is missing an API key." },
-      { status: 500 },
-    );
+    return Response.json({ error: "Configured LLM provider is missing an API key." }, { status: 500 });
   }
 
   const submissionId = crypto.randomUUID();
 
-  // Committed before the LLM call runs, with llm_score/llm_feedback/llm_provider/graded_at
-  // still null — see the Submission Bank comment in supabase/schema.sql for why they start
-  // nullable.
   const { error: insertError } = await supabase.from("submission").insert({
     submission_id: submissionId,
     user_id: user.id,
     user_story_id: userStoryId,
     submitted_text: submittedText,
+    ac_session_id: resolvedSessionId,
   });
 
-  if (insertError)
-    return Response.json({ error: insertError.message }, { status: 500 });
+  if (insertError) return Response.json({ error: insertError.message }, { status: 500 });
 
   let rating;
   try {
@@ -138,8 +163,7 @@ export async function POST(request: Request) {
       submittedText,
     );
   } catch (err) {
-    const message =
-      err instanceof Error ? err.message : "The LLM provider request failed.";
+    const message = err instanceof Error ? err.message : "The LLM provider request failed.";
     return Response.json({ error: message }, { status: 502 });
   }
 
@@ -153,11 +177,55 @@ export async function POST(request: Request) {
     })
     .eq("submission_id", submissionId);
 
-  if (updateError)
-    return Response.json({ error: updateError.message }, { status: 500 });
+  if (updateError) return Response.json({ error: updateError.message }, { status: 500 });
+
+  // Session completion check and next-story pointer.
+  let sessionCompleted = false;
+  let nextStoryId: string | null = null;
+  let totalScore: number | null = null;
+  let averageScore: number | null = null;
+
+  if (resolvedSessionId) {
+    const { data: allSubmissions, error: countError } = await supabase
+      .from("submission")
+      .select("llm_score, user_story_id")
+      .eq("ac_session_id", resolvedSessionId);
+
+    if (!countError && allSubmissions) {
+      const count = allSubmissions.length;
+
+      if (count >= STORIES_PER_SESSION) {
+        const scores = allSubmissions.map((s) => s.llm_score ?? 0);
+        totalScore = scores.reduce((sum, s) => sum + s, 0);
+        averageScore = Math.round(((totalScore ?? 0) / count) * 10) / 10;
+
+        await supabase
+          .from("ac_session")
+          .update({
+            status: "completed",
+            completed_at: new Date().toISOString(),
+            total_score: totalScore,
+          })
+          .eq("ac_session_id", resolvedSessionId);
+
+        sessionCompleted = true;
+      } else {
+        // Find the next unanswered story.
+        const { data: sessionStories } = await supabase
+          .from("ac_session_story")
+          .select("position, user_story_id")
+          .eq("ac_session_id", resolvedSessionId)
+          .order("position", { ascending: true });
+
+        const submittedIds = new Set(allSubmissions.map((s) => s.user_story_id));
+        const nextStory = (sessionStories ?? []).find((s) => !submittedIds.has(s.user_story_id));
+        nextStoryId = nextStory?.user_story_id ?? null;
+      }
+    }
+  }
 
   return Response.json(
-    { submissionId, score: rating.score, feedback: rating.feedback },
+    { submissionId, score: rating.score, feedback: rating.feedback, sessionCompleted, nextStoryId, totalScore, averageScore },
     { status: 200 },
   );
 }


### PR DESCRIPTION
Updates POST /api/activities/write-acceptance-criteria/submissions to enforce sequential story order within a session.

When sessionId is provided:
- Validates the session is in-progress and belongs to the student
- Rejects submissions for stories that haven't been reached yet (409)
- Returns nextStoryId after a successful submission so the client knows what comes next
- After the 4th submission: marks session completed, returns sessionCompleted: true with totalScore and averageScore
- Stores ac_session_id on each submission row

Without sessionId: behaves exactly as before (single standalone submission, no session tracking).

Resolves #256
