### PR TITLE
UI: Show progress while navigating through the four stories in a session

### DIFF
--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from "react";
 import { AppShell } from "../../../../components/AppShell";
 import { FeedbackCard } from "../../../../components/FeedbackCard";
 import { QuestionCard } from "../../../../components/QuestionCard";
+import { SessionProgressDots, type ProgressDotStatus } from "../../../../components/SessionProgressDots";
 import { getActivity } from "../../../../lib/activityContent";
 import {
   type CurrentSessionResult,
@@ -232,34 +233,21 @@ export default function PlayActivityPage({
   // the API already returned questions in position order — dot i must line up with position i+1
   // for the per-question correctness lookup below to point at the right answer.
   const dotQuestions = [...questions].sort((a, b) => a.position - b.position);
+  const dotStatuses: ProgressDotStatus[] = dotQuestions.map((question, i) => {
+    if (i === answeredDots) return "current";
+    if (i >= answeredDots) return "upcoming";
+    // GitHub #236: correctness for an already-answered question comes from session.answers —
+    // kept accurate across "Next question" clicks by handleContinue above, so no separate
+    // per-question tracking is needed here.
+    const isCorrect = session.answers.find((a) => a.question_id === question.question_id)?.correct === true;
+    return isCorrect ? "correct" : "incorrect";
+  });
 
   return (
     <AppShell active="activities">
       <div className="mx-auto max-w-xl">
         <div className="mb-5 flex items-center justify-between">
-          <div className="flex items-center gap-1.5">
-            {dotQuestions.map((question, i) => {
-              const isCurrent = i === answeredDots;
-              const isAnswered = i < answeredDots;
-              // GitHub #236: correctness for an already-answered question comes from
-              // session.answers — kept accurate across "Next question" clicks by handleContinue
-              // above, so no separate per-question tracking is needed here.
-              const isCorrect = isAnswered && session.answers.find((a) => a.question_id === question.question_id)?.correct === true;
-
-              return (
-                <span
-                  key={question.question_id}
-                  className={`rounded-full transition-all duration-300 ${
-                    isCurrent
-                      ? "h-3 w-3 bg-brand-purple"
-                      : isAnswered
-                        ? `h-2 w-2 ${isCorrect ? "bg-brand-green" : "bg-brand-danger"}`
-                        : "h-2 w-2 bg-brand-navy-border"
-                  }`}
-                />
-              );
-            })}
-          </div>
+          <SessionProgressDots statuses={dotStatuses} />
           <span className="text-sm font-bold text-gray-500">
             Question {Math.min(answeredDots + 1, totalQuestions)} of{" "}
             {totalQuestions} · {cumulativeScore} pts

--- a/app/activities/write-acceptance-criteria/page.tsx
+++ b/app/activities/write-acceptance-criteria/page.tsx
@@ -8,6 +8,7 @@ import { AcceptanceCriteriaFeedbackScreen } from '../../../components/Acceptance
 import { AcceptanceCriteriaWritingScreen } from '../../../components/AcceptanceCriteriaWritingScreen';
 import { AcceptanceCriteriaWritingScreenSkeleton } from '../../../components/AcceptanceCriteriaWritingScreenSkeleton';
 import { ResumeOrAbandonPrompt } from '../../../components/ResumeOrAbandonPrompt';
+import { SessionProgressDots, type ProgressDotStatus } from '../../../components/SessionProgressDots';
 import { drawSessionStories, submitAcceptanceCriteria } from '../../../lib/acceptanceCriteriaClient';
 import type { AcceptanceCriteriaResult, UserStoryPrompt } from '../../../lib/acceptanceCriteriaTypes';
 import {
@@ -148,6 +149,21 @@ export default function WriteAcceptanceCriteriaPage() {
   const storyPosition = currentIndex >= 0 ? currentIndex + 1 : 0;
   const isLastStory = session ? currentIndex === session.stories.length - 1 : false;
 
+  // GitHub #261: mirrors Type A's dot row (app/activities/[slug]/play/page.tsx, GitHub #236),
+  // but a submitted story only ever reaches "done" — there is no immediate right/wrong here,
+  // grading is an async LLM call (GitHub #149), so no dot is ever "correct"/"incorrect". Once
+  // the last story's result lands, every dot flips to "done" in the same render — including
+  // while its own feedback is still on screen — so the indicator reads as "session finished"
+  // before the student even clicks Finish, per the issue's explicit completion requirement.
+  const allStoriesComplete = session ? isSessionComplete(session) : false;
+  const dotStatuses: ProgressDotStatus[] = session
+    ? session.stories.map((story, i) => {
+        if (allStoriesComplete) return 'done';
+        if (i === currentIndex) return 'current';
+        return story.result !== null ? 'done' : 'upcoming';
+      })
+    : [];
+
   return (
     <AppShell active="activities">
       <div className="mx-auto max-w-xl">
@@ -155,14 +171,18 @@ export default function WriteAcceptanceCriteriaPage() {
           ← Back to Activities
         </Link>
 
-        <div className="mb-5 flex items-center justify-between">
-          <h3 className="text-lg font-extrabold">Write Acceptance Criteria</h3>
-          {!isLoading && !loadFailed && !showPrompt && session ? (
-            <span className="text-sm font-extrabold text-gray-500">
-              Story {storyPosition} of {STORIES_PER_SESSION}
+        <h3 className="mb-5 text-lg font-extrabold">Write Acceptance Criteria</h3>
+
+        {!isLoading && !loadFailed && !showPrompt && session ? (
+          <div className="mb-5 flex items-center justify-between">
+            <SessionProgressDots statuses={dotStatuses} />
+            <span className="text-sm font-bold text-gray-500">
+              {allStoriesComplete
+                ? `${STORIES_PER_SESSION} of ${STORIES_PER_SESSION} complete`
+                : `Story ${storyPosition} of ${STORIES_PER_SESSION}`}
             </span>
-          ) : null}
-        </div>
+          </div>
+        ) : null}
 
         {isLoading ? (
           <AcceptanceCriteriaWritingScreenSkeleton />

--- a/components/SessionProgressDots.tsx
+++ b/components/SessionProgressDots.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+/**
+ * GitHub #261: the position-in-session dot row, extracted from the size/color logic
+ * app/activities/[slug]/play/page.tsx already had (GitHub #236) so
+ * app/activities/write-acceptance-criteria/page.tsx can show the same visual pattern without a
+ * second, parallel implementation.
+ *
+ * Type A can judge a dot "correct"/"incorrect" the moment it's answered; Write Acceptance
+ * Criteria can't — grading is an LLM call with no immediate right/wrong, so a submitted story
+ * only ever reaches "done" (filled, no verdict). Rather than a boolean prop toggling a
+ * hard-coded pair of color branches, each dot's status is passed in already resolved — the
+ * caller (which alone knows whether correctness applies) decides "correct"/"incorrect" vs.
+ * "done" per item; this component only maps status to appearance.
+ */
+export type ProgressDotStatus = 'upcoming' | 'current' | 'done' | 'correct' | 'incorrect';
+
+const DOT_CLASS: Record<ProgressDotStatus, string> = {
+  upcoming: 'h-2 w-2 bg-brand-navy-border',
+  current: 'h-3 w-3 bg-brand-purple',
+  done: 'h-2 w-2 bg-brand-teal',
+  correct: 'h-2 w-2 bg-brand-green',
+  incorrect: 'h-2 w-2 bg-brand-danger',
+};
+
+export function SessionProgressDots({ statuses }: { statuses: ProgressDotStatus[] }) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {statuses.map((status, i) => (
+        <span key={i} className={`rounded-full transition-all duration-300 ${DOT_CLASS[status]}`} />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Add a shared SessionProgressDots component and use it in both the
Type A quiz flow and the Write Acceptance Criteria flow, so each
story's position (upcoming / current / done) is visible at a glance
and updates immediately on submit.

- components/SessionProgressDots.tsx: new reusable dot indicator;
  each dot's status is passed in already resolved by the caller
  (upcoming/current/done, or correct/incorrect for Type A) instead
  of a boolean toggling hardcoded branches.
- app/activities/[slug]/play/page.tsx: refactored to use the shared
  component instead of its inline dot markup (GitHub #236 behavior
  unchanged).
- app/activities/write-acceptance-criteria/page.tsx: adds the same
  dot row plus a "Story X of 4" / "4 of 4 complete" label, derived
  from the existing session state (current index, per-story result).
  Since AC grading has no immediate right/wrong, submitted stories
  only ever reach "done", never correct/incorrect.
