### PR TITLE
UI: Present each user story with its title, description, and acceptance criteria clearly separated and copyable

### DIFF
--- a/__tests__/lib/storyMarkdown.test.ts
+++ b/__tests__/lib/storyMarkdown.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { deriveStoryTitle, formatStoryAsMarkdown } from '../../lib/storyMarkdown';
+
+describe('deriveStoryTitle', () => {
+  it('extracts the "I want to <goal>" clause as a title', () => {
+    expect(deriveStoryTitle('As a shopper, I want to apply a promo code at checkout, so that a valid discount is reflected in my order total before I pay.')).toBe(
+      'Apply a promo code at checkout',
+    );
+  });
+
+  it('works without a "to" after "I want"', () => {
+    expect(deriveStoryTitle('As a user, I want faster page loads, so that I do not get frustrated.')).toBe('Faster page loads');
+  });
+
+  it('is case-insensitive on "As a"/"I want"', () => {
+    expect(deriveStoryTitle('as a user, i want to log in, so that i can access my account.')).toBe('Log in');
+  });
+
+  it('falls back to a generic label when the story does not follow the template', () => {
+    expect(deriveStoryTitle('Users should be able to reset their password.')).toBe('User Story');
+  });
+
+  it('falls back to a generic label for an empty string', () => {
+    expect(deriveStoryTitle('')).toBe('User Story');
+  });
+});
+
+describe('formatStoryAsMarkdown', () => {
+  it('formats title and description only when there are no acceptance criteria', () => {
+    const markdown = formatStoryAsMarkdown({
+      title: 'Apply a promo code at checkout',
+      description: 'As a shopper, I want to apply a promo code at checkout, so that a valid discount is reflected in my order total before I pay.',
+    });
+
+    expect(markdown).toBe(
+      '# Apply a promo code at checkout\n\n' +
+        'As a shopper, I want to apply a promo code at checkout, so that a valid discount is reflected in my order total before I pay.',
+    );
+  });
+
+  it('appends an Acceptance Criteria section, one bullet per non-empty line', () => {
+    const markdown = formatStoryAsMarkdown({
+      title: 'Apply a promo code',
+      description: 'As a shopper, I want to apply a promo code, so that I get a discount.',
+      acceptanceCriteria: 'Given a valid code, when applied, then the discount shows.\n\nGiven an invalid code, when applied, then an error shows.',
+    });
+
+    expect(markdown).toBe(
+      '# Apply a promo code\n\n' +
+        'As a shopper, I want to apply a promo code, so that I get a discount.\n\n' +
+        '## Acceptance Criteria\n' +
+        '- Given a valid code, when applied, then the discount shows.\n' +
+        '- Given an invalid code, when applied, then an error shows.',
+    );
+  });
+
+  it('does not double up a leading "-" or "*" the student already typed', () => {
+    const markdown = formatStoryAsMarkdown({
+      title: 'T',
+      description: 'D',
+      acceptanceCriteria: '- Given a, when b, then c.\n* Given d, when e, then f.',
+    });
+
+    expect(markdown).toContain('- Given a, when b, then c.\n- Given d, when e, then f.');
+  });
+
+  it('omits the Acceptance Criteria section for blank or whitespace-only input', () => {
+    expect(formatStoryAsMarkdown({ title: 'T', description: 'D', acceptanceCriteria: '   \n  ' })).toBe('# T\n\nD');
+    expect(formatStoryAsMarkdown({ title: 'T', description: 'D' })).toBe('# T\n\nD');
+  });
+});

--- a/components/AcceptanceCriteriaFeedbackScreen.tsx
+++ b/components/AcceptanceCriteriaFeedbackScreen.tsx
@@ -1,10 +1,15 @@
 import type { AcceptanceCriteriaResult, UserStoryPrompt } from '../lib/acceptanceCriteriaTypes';
+import { StoryDisplayCard } from './StoryDisplayCard';
 
 /**
  * GitHub #149: the result phase of the "Write Acceptance Criteria" activity (REQ-FU-2) — the
  * free-text counterpart to FeedbackCard. Structurally mirrors it (prompt recap, then a score
  * panel, then an explanation block) but shows the student's own written answer back to them
  * instead of a set of pre-authored options, since there is nothing else to compare it against.
+ *
+ * GitHub #262: the story + the student's own answer now render together via StoryDisplayCard,
+ * whose third section ("Acceptance Criteria") only exists here — the writing screen has nothing
+ * to put there yet, since the story itself never has pre-written criteria.
  */
 export function AcceptanceCriteriaFeedbackScreen({
   userStory,
@@ -18,13 +23,8 @@ export function AcceptanceCriteriaFeedbackScreen({
   const passed = result.score >= 8;
 
   return (
-    <div className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6">
-      <p className="mb-5 text-base font-extrabold leading-snug text-white">{userStory.description}</p>
-
-      <div className="mb-5 rounded-brand-md border border-brand-navy-border bg-brand-navy-2 p-4">
-        <strong className="mb-1 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">Your acceptance criteria</strong>
-        <p className="whitespace-pre-wrap text-sm leading-relaxed text-brand-ink">{result.submittedText}</p>
-      </div>
+    <>
+      <StoryDisplayCard description={userStory.description} acceptanceCriteria={result.submittedText} className="mb-5" />
 
       <div className={`mb-4 rounded-brand-lg p-6 text-center ${passed ? 'bg-gradient-to-br from-brand-teal-dark to-brand-navy-2' : 'bg-gradient-to-br from-brand-purple-dark to-brand-navy-2'}`}>
         <h2 className="text-xl font-extrabold text-white">{passed ? 'Nice work!' : 'Keep refining'}</h2>
@@ -37,6 +37,6 @@ export function AcceptanceCriteriaFeedbackScreen({
         <strong className="mb-1 block font-extrabold text-white">Feedback</strong>
         {result.feedback}
       </div>
-    </div>
+    </>
   );
 }

--- a/components/AcceptanceCriteriaWritingScreen.tsx
+++ b/components/AcceptanceCriteriaWritingScreen.tsx
@@ -2,12 +2,17 @@
 
 import { useState } from 'react';
 import type { UserStoryPrompt } from '../lib/acceptanceCriteriaTypes';
+import { StoryDisplayCard } from './StoryDisplayCard';
 
 /**
  * GitHub #149: the input phase of the "Write Acceptance Criteria" activity (REQ-FU-2) — the
  * free-text counterpart to QuestionCard. Submit is disabled while the textarea is blank (after
  * trimming whitespace-only input) or while a submission is already in flight, with the same
  * "Submitting…" label swap QuestionCard uses for the equivalent state.
+ *
+ * GitHub #262: the story itself now renders via StoryDisplayCard as its own card, separate from
+ * this form — the story isn't part of what the student is filling in, so it shouldn't share a
+ * card with the input.
  */
 export function AcceptanceCriteriaWritingScreen({
   userStory,
@@ -28,32 +33,34 @@ export function AcceptanceCriteriaWritingScreen({
   }
 
   return (
-    <form onSubmit={handleSubmit} className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6">
-      <p className="mb-5 text-base font-extrabold leading-snug text-white">{userStory.description}</p>
+    <>
+      <StoryDisplayCard description={userStory.description} className="mb-5" />
 
-      <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted" htmlFor="acceptance-criteria-input">
-        Your acceptance criteria
-      </label>
-      <textarea
-        id="acceptance-criteria-input"
-        value={text}
-        onChange={(event) => setText(event.target.value)}
-        disabled={submitting}
-        rows={8}
-        placeholder="Given ..., when ..., then ..."
-        className="block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm leading-relaxed text-brand-ink outline-none transition focus:border-brand-purple disabled:cursor-not-allowed disabled:opacity-60"
-      />
-      <p className="mb-5 mt-1.5 text-xs font-semibold text-brand-ink-muted">
-        Write one or more Given/When/Then criteria. Aim for criteria that are specific, testable, and clearly connected to the story above.
-      </p>
+      <form onSubmit={handleSubmit} className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6">
+        <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted" htmlFor="acceptance-criteria-input">
+          Your acceptance criteria
+        </label>
+        <textarea
+          id="acceptance-criteria-input"
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+          disabled={submitting}
+          rows={8}
+          placeholder="Given ..., when ..., then ..."
+          className="block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm leading-relaxed text-brand-ink outline-none transition focus:border-brand-purple disabled:cursor-not-allowed disabled:opacity-60"
+        />
+        <p className="mb-5 mt-1.5 text-xs font-semibold text-brand-ink-muted">
+          Write one or more Given/When/Then criteria. Aim for criteria that are specific, testable, and clearly connected to the story above.
+        </p>
 
-      <button
-        type="submit"
-        disabled={isBlank || submitting}
-        className="w-full rounded-brand-md bg-brand-purple py-3 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
-      >
-        {submitting ? 'Submitting…' : 'Submit'}
-      </button>
-    </form>
+        <button
+          type="submit"
+          disabled={isBlank || submitting}
+          className="w-full rounded-brand-md bg-brand-purple py-3 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? 'Submitting…' : 'Submit'}
+        </button>
+      </form>
+    </>
   );
 }

--- a/components/AcceptanceCriteriaWritingScreenSkeleton.tsx
+++ b/components/AcceptanceCriteriaWritingScreenSkeleton.tsx
@@ -1,17 +1,26 @@
 /**
  * GitHub #149: shown while the writing prompt loads, in the same shimmer-block style as
- * ActivityCardSkeleton (GitHub #108) — shaped like the writing screen it stands in for
- * (story text lines, then a tall textarea, then a submit button) rather than reusing that
- * component's activity-card shape directly.
+ * ActivityCardSkeleton (GitHub #108) — shaped like the writing screen it stands in for.
+ *
+ * GitHub #262: two blocks now, matching the writing screen's split into StoryDisplayCard
+ * (title + description) and the input form, so there's no layout jump once the real content
+ * (and its own card boundary) replaces the skeleton.
  */
 export function AcceptanceCriteriaWritingScreenSkeleton() {
   return (
-    <div className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6" role="status" aria-label="Loading writing prompt">
-      <span className="skeleton-block mb-2 block h-3 w-24 rounded-full" />
-      <span className="skeleton-block mb-1.5 block h-4 w-full rounded-full" />
-      <span className="skeleton-block mb-5 block h-4 w-2/3 rounded-full" />
-      <span className="skeleton-block block h-32 w-full rounded-brand-md" />
-      <span className="skeleton-block mt-5 block h-12 w-full rounded-brand-md" />
+    <div role="status" aria-label="Loading writing prompt">
+      <div className="mb-5 rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6">
+        <span className="skeleton-block mb-2 block h-3 w-16 rounded-full" />
+        <span className="skeleton-block mb-4 block h-4 w-1/2 rounded-full" />
+        <span className="skeleton-block mb-1.5 block h-3 w-24 rounded-full" />
+        <span className="skeleton-block mb-1.5 block h-4 w-full rounded-full" />
+        <span className="skeleton-block block h-4 w-2/3 rounded-full" />
+      </div>
+      <div className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6">
+        <span className="skeleton-block mb-1.5 block h-3 w-40 rounded-full" />
+        <span className="skeleton-block block h-32 w-full rounded-brand-md" />
+        <span className="skeleton-block mt-5 block h-12 w-full rounded-brand-md" />
+      </div>
       <style jsx>{`
         .skeleton-block {
           background: linear-gradient(90deg, rgba(255, 255, 255, 0.06) 25%, rgba(255, 255, 255, 0.16) 37%, rgba(255, 255, 255, 0.06) 63%);

--- a/components/StoryDisplayCard.tsx
+++ b/components/StoryDisplayCard.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+import { deriveStoryTitle, formatStoryAsMarkdown } from '../lib/storyMarkdown';
+
+const COPIED_MESSAGE_MS = 2000;
+
+function CopyIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <rect x="9" y="9" width="12" height="12" rx="2" />
+      <path d="M5 15H4a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v1" />
+    </svg>
+  );
+}
+
+function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 6 9 17l-5-5" />
+    </svg>
+  );
+}
+
+/**
+ * GitHub #262: shared story display for both phases of Write Acceptance Criteria — replaces
+ * the single `<p>{userStory.description}</p>` line each screen used to render inline.
+ *
+ * The writing screen (AcceptanceCriteriaWritingScreen) passes only `description`, since the
+ * story genuinely has no acceptance criteria yet at that point — writing them is the student's
+ * task, not a property of the story. The feedback screen (AcceptanceCriteriaFeedbackScreen)
+ * additionally passes `acceptanceCriteria` (the student's own submitted text) as the third
+ * section once it exists, rather than this component inventing or guessing at one.
+ *
+ * Title/Description/Acceptance Criteria use the same small-caps label style as "Your acceptance
+ * criteria" above the textarea, so the card reads as distinct labeled fields rather than prose.
+ */
+export function StoryDisplayCard({
+  description,
+  acceptanceCriteria,
+  className = '',
+}: {
+  description: string;
+  /** The student's own written criteria — pass only once a submission exists. */
+  acceptanceCriteria?: string;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState('');
+
+  const title = deriveStoryTitle(description);
+  const criteriaLines = (acceptanceCriteria ?? '')
+    .split('\n')
+    .map((line) => line.trim().replace(/^[-*]\s*/, ''))
+    .filter((line) => line.length > 0);
+
+  async function handleCopy() {
+    const markdown = formatStoryAsMarkdown({ title, description, acceptanceCriteria });
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopyError('');
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), COPIED_MESSAGE_MS);
+    } catch {
+      setCopyError('Could not copy automatically — please copy the text manually.');
+    }
+  }
+
+  return (
+    <div className={`rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6 ${className}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <span className="mb-1 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">Title</span>
+          <h3 className="text-base font-extrabold leading-snug text-white">{title}</h3>
+        </div>
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex shrink-0 items-center gap-1.5 rounded-full border border-brand-navy-border bg-brand-navy-2 px-3 py-1.5 text-xs font-extrabold text-brand-ink-muted transition hover:border-brand-purple hover:text-white"
+        >
+          {copied ? (
+            <>
+              <CheckIcon />
+              Copied!
+            </>
+          ) : (
+            <>
+              <CopyIcon />
+              Copy
+            </>
+          )}
+        </button>
+      </div>
+
+      <div className="mt-4 border-t border-brand-navy-border pt-4">
+        <span className="mb-1 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">Description</span>
+        <p className="text-sm leading-relaxed text-brand-ink">{description}</p>
+      </div>
+
+      {criteriaLines.length > 0 ? (
+        <div className="mt-4 border-t border-brand-navy-border pt-4">
+          <span className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">Acceptance Criteria</span>
+          <ul className="list-disc space-y-1 pl-5 text-sm leading-relaxed text-brand-ink">
+            {criteriaLines.map((line, i) => (
+              <li key={i}>{line}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {copyError ? <p className="mt-2 text-xs font-semibold text-brand-danger">{copyError}</p> : null}
+    </div>
+  );
+}

--- a/lib/storyMarkdown.ts
+++ b/lib/storyMarkdown.ts
@@ -1,0 +1,49 @@
+/**
+ * GitHub #262: derives a short title from a user story's text and formats a story (plus, once
+ * written, the student's own acceptance criteria) as clean, copyable markdown.
+ *
+ * user_story has only one text column, story_text (see lib/acceptanceCriteriaTypes.ts's own
+ * comment on UserStoryPrompt.description) — there is no title column. Rather than inventing
+ * content, the title is extracted from the story's own "I want to <goal>" clause, which every
+ * seeded story already follows (the standard "As a <role>, I want to <goal>, so that <benefit>"
+ * template — see supabase/seed.sql). A story that doesn't match the template falls back to a
+ * generic label instead of rendering "undefined".
+ */
+const GOAL_CLAUSE = /,\s*i want (?:to\s+)?(.+?),\s*so that/i;
+
+export function deriveStoryTitle(description: string): string {
+  const match = description.match(GOAL_CLAUSE);
+  if (!match) return 'User Story';
+
+  const goal = match[1].trim().replace(/[.,;]+$/, '');
+  if (!goal) return 'User Story';
+
+  return goal.charAt(0).toUpperCase() + goal.slice(1);
+}
+
+export type StoryMarkdownInput = {
+  title: string;
+  description: string;
+  /** The student's own written criteria, once submitted — omitted while still writing. */
+  acceptanceCriteria?: string;
+};
+
+/**
+ * One criterion per line in the output, whether or not the student already typed a leading
+ * "-"/"*" — matches the Given/When/Then-per-line convention AcceptanceCriteriaWritingScreen's
+ * placeholder and helper text ask for, without assuming the student actually followed it.
+ */
+export function formatStoryAsMarkdown({ title, description, acceptanceCriteria }: StoryMarkdownInput): string {
+  const sections = [`# ${title}`, '', description];
+
+  const criteria = (acceptanceCriteria ?? '')
+    .split('\n')
+    .map((line) => line.trim().replace(/^[-*]\s*/, ''))
+    .filter((line) => line.length > 0);
+
+  if (criteria.length > 0) {
+    sections.push('', '## Acceptance Criteria', ...criteria.map((line) => `- ${line}`));
+  }
+
+  return sections.join('\n');
+}


### PR DESCRIPTION
Give the Write Acceptance Criteria story a proper StoryDisplayCard
instead of a single inline paragraph, and let students copy it as
clean markdown.

- lib/storyMarkdown.ts: derives a short title from the story's own
  "I want to <goal>" clause (user_story has no title column) and
  formats title/description/acceptance-criteria as markdown; unit
  tested in __tests__/lib/storyMarkdown.test.ts.
- components/StoryDisplayCard.tsx: shared card with a copy-to-
  clipboard button (icon + "Copied!"), reused by both the writing
  screen (title + description) and the feedback screen (adds the
  student's own submitted criteria as the third section, since the
  story itself never has pre-written acceptance criteria).
- Verified the seeded user_story rows are already free of
  implementation details — no content changes needed there.
