### PR TITLE
UI: Show an overall summary once all four stories have been rated

### DIFF
--- a/app/activities/write-acceptance-criteria/page.tsx
+++ b/app/activities/write-acceptance-criteria/page.tsx
@@ -9,6 +9,7 @@ import { AcceptanceCriteriaWritingScreen } from '../../../components/AcceptanceC
 import { AcceptanceCriteriaWritingScreenSkeleton } from '../../../components/AcceptanceCriteriaWritingScreenSkeleton';
 import { ResumeOrAbandonPrompt } from '../../../components/ResumeOrAbandonPrompt';
 import { SessionProgressDots, type ProgressDotStatus } from '../../../components/SessionProgressDots';
+import { SessionSummaryScreen } from '../../../components/SessionSummaryScreen';
 import { drawSessionStories, submitAcceptanceCriteria } from '../../../lib/acceptanceCriteriaClient';
 import type { AcceptanceCriteriaResult, UserStoryPrompt } from '../../../lib/acceptanceCriteriaTypes';
 import {
@@ -34,6 +35,7 @@ export default function WriteAcceptanceCriteriaPage() {
 
   const [session, setSession] = useState<AcceptanceCriteriaSession | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
+  const [showSummary, setShowSummary] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
   const [loadAttempt, setLoadAttempt] = useState(0);
@@ -56,6 +58,7 @@ export default function WriteAcceptanceCriteriaPage() {
     if (existing) {
       setSession(existing);
       setShowPrompt(true);
+      setShowSummary(false);
       setOutcome(null);
       setSubmitError(null);
       setIsLoading(false);
@@ -67,6 +70,7 @@ export default function WriteAcceptanceCriteriaPage() {
     setIsLoading(true);
     setLoadFailed(false);
     setShowPrompt(false);
+    setShowSummary(false);
     setOutcome(null);
     setSubmitError(null);
 
@@ -98,6 +102,7 @@ export default function WriteAcceptanceCriteriaPage() {
     clearSession();
     setSession(null);
     setShowPrompt(false);
+    setShowSummary(false);
     setLoadAttempt((count) => count + 1);
   }
 
@@ -130,11 +135,19 @@ export default function WriteAcceptanceCriteriaPage() {
   function handleContinue() {
     if (!session) return;
     if (isSessionComplete(session)) {
-      clearSession();
-      router.push('/activities');
+      // GitHub #263: the fourth story's feedback is still what "Finish" closes — the summary
+      // is a separate screen the student explicitly moves on from via handleFinishSummary,
+      // not something that flashes past on the way out.
+      setOutcome(null);
+      setShowSummary(true);
       return;
     }
     setOutcome(null);
+  }
+
+  function handleFinishSummary() {
+    clearSession();
+    router.push('/activities');
   }
 
   const pendingSlot = session ? session.stories[nextStoryIndex(session)] : undefined;
@@ -173,7 +186,7 @@ export default function WriteAcceptanceCriteriaPage() {
 
         <h3 className="mb-5 text-lg font-extrabold">Write Acceptance Criteria</h3>
 
-        {!isLoading && !loadFailed && !showPrompt && session ? (
+        {!isLoading && !loadFailed && !showPrompt && !showSummary && session ? (
           <div className="mb-5 flex items-center justify-between">
             <SessionProgressDots statuses={dotStatuses} />
             <span className="text-sm font-bold text-gray-500">
@@ -210,6 +223,8 @@ export default function WriteAcceptanceCriteriaPage() {
               confirmMessage="Are you sure you want to abandon this session? Your current answers will be lost."
             />
           </div>
+        ) : showSummary && session ? (
+          <SessionSummaryScreen session={session} onDone={handleFinishSummary} />
         ) : currentUserStory ? (
           outcome ? (
             <>

--- a/components/AcceptanceCriteriaFeedbackScreen.tsx
+++ b/components/AcceptanceCriteriaFeedbackScreen.tsx
@@ -1,3 +1,4 @@
+import { AC_PASS_SCORE } from '../lib/acceptanceCriteriaSessionStore';
 import type { AcceptanceCriteriaResult, UserStoryPrompt } from '../lib/acceptanceCriteriaTypes';
 import { StoryDisplayCard } from './StoryDisplayCard';
 
@@ -18,9 +19,10 @@ export function AcceptanceCriteriaFeedbackScreen({
   userStory: UserStoryPrompt;
   result: AcceptanceCriteriaResult;
 }) {
-  // 8/10 is this activity's own pass bar, independent of the Type A quiz's PASS_RATIO
-  // (lib/sessionRules.ts) — the two are scored on different scales and are not coupled.
-  const passed = result.score >= 8;
+  // AC_PASS_SCORE (8/10) is this activity's own pass bar, independent of the Type A quiz's
+  // PASS_RATIO (lib/sessionRules.ts) — the two are scored on different scales and are not
+  // coupled. Shared with SessionSummaryScreen so the two screens can't drift apart.
+  const passed = result.score >= AC_PASS_SCORE;
 
   return (
     <>

--- a/components/SessionSummaryScreen.tsx
+++ b/components/SessionSummaryScreen.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { deriveStoryTitle } from '../lib/storyMarkdown';
+import { AC_PASS_SCORE, summarizeSession, type AcceptanceCriteriaSession } from '../lib/acceptanceCriteriaSessionStore';
+
+/**
+ * GitHub #263: shown once every story in the session has been submitted and graded — distinct
+ * from AcceptanceCriteriaFeedbackScreen (which recaps one story's own criteria and feedback)
+ * both in content (every story's score at a glance, not one story's full write-up) and look
+ * (gold "session complete" framing instead of that screen's per-story teal/purple pass/fail
+ * gradient), so a student can tell which screen they're looking at without reading the heading.
+ *
+ * Takes the whole session rather than a pre-computed total, per the issue's instruction to
+ * derive this from the existing session state instead of tracking scores separately —
+ * summarizeSession (lib/acceptanceCriteriaSessionStore.ts) does the aggregation.
+ */
+export function SessionSummaryScreen({
+  session,
+  onDone,
+}: {
+  session: AcceptanceCriteriaSession;
+  onDone: () => void;
+}) {
+  const { totalScore, maxScore, passedCount, storyCount } = summarizeSession(session);
+
+  const message =
+    storyCount === 0
+      ? 'No stories were graded in this session.'
+      : passedCount === storyCount
+        ? `Great job — all ${storyCount} stories passed!`
+        : passedCount === 0
+          ? `Keep practicing — none of the ${storyCount} stories passed this time.`
+          : `Nice progress — ${passedCount} of ${storyCount} stories passed.`;
+
+  return (
+    <div className="rounded-brand-lg border border-brand-gold/40 bg-gradient-to-br from-brand-gold-dark to-brand-navy p-8 text-center">
+      <span className="mb-2 block text-xs font-extrabold uppercase tracking-wide text-brand-gold">Session complete</span>
+
+      <div className="text-5xl font-extrabold text-white">
+        {totalScore}
+        <span className="text-2xl font-bold text-brand-ink-muted"> / {maxScore}</span>
+      </div>
+      <p className="mt-2 text-sm font-semibold text-brand-ink-muted">{message}</p>
+
+      <div className="mt-6 space-y-2 text-left">
+        {session.stories.map((story) => (
+          <div
+            key={story.userStoryId}
+            className="flex items-center justify-between gap-3 rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-3"
+          >
+            <span className="text-sm font-semibold text-brand-ink">{deriveStoryTitle(story.description)}</span>
+            <span
+              className={`shrink-0 text-sm font-extrabold ${
+                story.result && story.result.score >= AC_PASS_SCORE ? 'text-brand-green' : 'text-brand-ink-muted'
+              }`}
+            >
+              {story.result ? `${story.result.score} / 10` : '—'}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={onDone}
+        className="mt-6 w-full rounded-brand-md bg-brand-purple py-3 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+      >
+        Back to Activities
+      </button>
+    </div>
+  );
+}

--- a/lib/acceptanceCriteriaSessionStore.ts
+++ b/lib/acceptanceCriteriaSessionStore.ts
@@ -16,6 +16,9 @@ import type { AcceptanceCriteriaResult, UserStoryPrompt } from './acceptanceCrit
  */
 export const STORIES_PER_SESSION = 4;
 
+/** 8/10 is this activity's own pass bar — see AcceptanceCriteriaFeedbackScreen's comment. */
+export const AC_PASS_SCORE = 8;
+
 const STORAGE_KEY = 'rc_ac_writing_session_v1';
 
 export type SessionStorySlot = {
@@ -96,4 +99,29 @@ export function recordStoryResult(
 export function clearSession(): void {
   if (typeof window === 'undefined') return;
   window.localStorage.removeItem(STORAGE_KEY);
+}
+
+export type SessionSummary = {
+  totalScore: number;
+  maxScore: number;
+  passedCount: number;
+  storyCount: number;
+};
+
+/**
+ * GitHub #263: the whole-session totals for SessionSummaryScreen, derived from the same
+ * per-story results this store already tracks — counts only graded stories, so calling this
+ * before the session is complete just yields a partial (rather than wrong) total.
+ */
+export function summarizeSession(session: AcceptanceCriteriaSession): SessionSummary {
+  const graded = session.stories.filter(
+    (story): story is SessionStorySlot & { result: AcceptanceCriteriaResult } => story.result !== null,
+  );
+
+  return {
+    totalScore: graded.reduce((sum, story) => sum + story.result.score, 0),
+    maxScore: graded.length * 10,
+    passedCount: graded.filter((story) => story.result.score >= AC_PASS_SCORE).length,
+    storyCount: graded.length,
+  };
 }


### PR DESCRIPTION
Adds a dedicated summary screen shown once a student finishes grading the fourth and final story in a Write Acceptance Criteria session, so they see their overall performance instead of only the last story's individual feedback.

What changed
After the fourth story's feedback is acknowledged ("Finish"), the page now shows a new SessionSummaryScreen instead of immediately clearing the session and navigating away.
The summary displays the session's total score (sum across all four stories, out of 40), a pass/fail message based on how many stories cleared the activity's existing 8/10 pass bar, and a compact per-story list (derived title + score, highlighted green when passed).
Visually distinct from the per-story AcceptanceCriteriaFeedbackScreen on purpose: gold "Session complete" framing instead of the teal/purple pass/fail gradient, an overview list instead of a single Q&A layout, and the progress-dot header is hidden while the summary is showing.
A "Back to Activities" button on the summary clears the local session and navigates to /activities — this is now the only place that happens; simply advancing past the fourth story no longer does it implicitly.
Extracted the shared AC_PASS_SCORE (8/10) constant so the individual feedback screen and the new summary can't drift apart on what counts as "passed".

Files touched
components/SessionSummaryScreen.tsx (new) — the summary screen itself.
lib/acceptanceCriteriaSessionStore.ts — added summarizeSession() (derives totals from the existing per-story result data, no parallel state) and the exported AC_PASS_SCORE constant.
components/AcceptanceCriteriaFeedbackScreen.tsx — now imports AC_PASS_SCORE instead of a local magic number.
app/activities/write-acceptance-criteria/page.tsx — new showSummary state; handleContinue shows the summary instead of navigating away on the last story; new handleFinishSummary owns the actual cleanup/navigation; progress header hidden during the summary.