### PR TITLE
Fix: session summary could be silently discarded before a student saw it

### DIFF
--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -7,7 +7,9 @@ import { AppShell } from "../../../../components/AppShell";
 import { FeedbackCard } from "../../../../components/FeedbackCard";
 import { QuestionCard } from "../../../../components/QuestionCard";
 import { SessionProgressDots, type ProgressDotStatus } from "../../../../components/SessionProgressDots";
+import { SessionSummaryScreen, type SessionSummaryItem } from "../../../../components/SessionSummaryScreen";
 import { getActivity } from "../../../../lib/activityContent";
+import { isPassing } from "../../../../lib/sessionRules";
 import {
   type CurrentSessionResult,
   type FeedbackResult,
@@ -46,6 +48,7 @@ export default function PlayActivityPage({
   const [cumulativeScore, setCumulativeScore] = useState(0);
   const [answeredCount, setAnsweredCount] = useState(0);
   const [outcome, setOutcome] = useState<AnswerOutcome | null>(null);
+  const [showSummary, setShowSummary] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -53,9 +56,16 @@ export default function PlayActivityPage({
    * The server is the only source of progress — there is no stored "current question",
    * it is derived from which of the drawn questions have an answer logged. So resuming,
    * reloading, and recovering from a double submit are all the same read.
+   *
+   * GitHub #263 bug fix: skipped while showSummary is true. A finished session is no longer
+   * "current" server-side (GET .../current only ever answers for an in-progress one), so
+   * re-syncing at that point doesn't refresh anything — it finds session: null and immediately
+   * navigates away, discarding the summary the student hasn't dismissed yet. This can happen
+   * without any explicit reload: syncFromServer's identity changes whenever token does, and
+   * UserProvider refreshes the token on its own 45-minute timer.
    */
   const syncFromServer = useCallback(async () => {
-    if (!token || !activity) return;
+    if (!token || !activity || showSummary) return;
 
     const result = await loadCurrentSession(token, activity.activityType);
 
@@ -80,7 +90,7 @@ export default function PlayActivityPage({
     setCumulativeScore(result.data.session.cumulative_score);
     setAnsweredCount(result.data.answers.length);
     setOutcome(null);
-  }, [token, activity, router]);
+  }, [token, activity, router, showSummary]);
 
   useEffect(() => {
     void syncFromServer();
@@ -177,32 +187,15 @@ export default function PlayActivityPage({
     });
   }
 
-  async function handleContinue() {
+  function handleContinue() {
     if (!outcome) return;
-    if (outcome.completed) {
-      if (token && profile?.user_id) {
-        // Await the completed-attempts refresh before navigating so the activity
-        // page's cache is already up to date when it mounts — without this the
-        // "previous attempts" table still shows the stale list (GitHub #130).
-        await Promise.all([
-          loadStudentScore(token, profile.user_id, { forceRefresh: true }),
-          loadSessions(token, "completed", {
-            studentId: profile.user_id,
-            forceRefresh: true,
-          }),
-          loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
-            forceRefresh: true,
-          }),
-        ]);
-      }
-      router.push(`/activities/${activity!.slug}`);
-      return;
-    }
 
     // GitHub #236: fold the just-graded answer into session.answers before dropping the
-    // feedback view — that's what lets the progress dots know this question's correctness
-    // once it stops being "current". Built entirely from outcome (already-fetched, real data
-    // from the submit/feedback round trip), not a second network call or a new parallel state.
+    // feedback view — that's what lets the progress dots (and, once the session is done, the
+    // GitHub #263 summary) know this question's correctness once it stops being "current".
+    // Built entirely from outcome (already-fetched, real data from the submit/feedback round
+    // trip), not a second network call or a new parallel state. Needed for both branches below
+    // now — completed or not, this question's result must be in session.answers.
     setSession((current) =>
       current
         ? {
@@ -221,11 +214,43 @@ export default function PlayActivityPage({
           }
         : current,
     );
+
+    if (outcome.completed) {
+      // GitHub #263: show the session summary instead of navigating away immediately — the
+      // cache refresh + navigation that used to happen right here now happens once the student
+      // dismisses the summary, in handleFinishSummary.
+      setOutcome(null);
+      setShowSummary(true);
+      return;
+    }
+
     // The whole draw is already in hand — advancing is just dropping the feedback view.
     setOutcome(null);
   }
 
-  if (!currentQuestion) return null;
+  async function handleFinishSummary() {
+    if (token && profile?.user_id) {
+      // Await the completed-attempts refresh before navigating so the activity
+      // page's cache is already up to date when it mounts — without this the
+      // "previous attempts" table still shows the stale list (GitHub #130).
+      await Promise.all([
+        loadStudentScore(token, profile.user_id, { forceRefresh: true }),
+        loadSessions(token, "completed", {
+          studentId: profile.user_id,
+          forceRefresh: true,
+        }),
+        loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
+          forceRefresh: true,
+        }),
+      ]);
+    }
+    router.push(`/activities/${activity!.slug}`);
+  }
+
+  // Once the session is complete, currentQuestion legitimately becomes undefined (nextPosition
+  // is null server-side, nothing left to draw) — that's expected while showSummary is up, not
+  // a "got here without starting" case, so it must not hit the same early-out.
+  if (!currentQuestion && !showSummary) return null;
 
   const { feedback } = outcome ?? {};
   const answeredDots = outcome ? answeredCount - 1 : answeredCount;
@@ -243,18 +268,48 @@ export default function PlayActivityPage({
     return isCorrect ? "correct" : "incorrect";
   });
 
+  // GitHub #263: SessionSummaryScreen is generic (score/message/items) — this page maps its
+  // own points-and-correctness session into that shape, the same division of responsibility as
+  // write-acceptance-criteria/page.tsx does for its 1-10 LLM scores. isPassing (lib/sessionRules.ts)
+  // is the same formula the server uses for session_log.passed, so the two can't disagree.
+  const maxScore = session.session.max_score;
+  const correctCount = session.answers.filter((answer) => answer.correct).length;
+  const sessionPassed = isPassing(cumulativeScore, maxScore);
+  const summaryMessage = sessionPassed
+    ? `Great job — you passed with ${correctCount} of ${totalQuestions} correct!`
+    : `Keep practicing — ${correctCount} of ${totalQuestions} correct this time.`;
+  const summaryItems: SessionSummaryItem[] = dotQuestions.map((question) => {
+    const answer = session.answers.find((a) => a.question_id === question.question_id);
+    return {
+      key: question.question_id,
+      label: question.question_prompt,
+      scoreLabel: answer ? `${answer.score} pts` : "—",
+      passed: answer?.correct === true,
+    };
+  });
+
   return (
     <AppShell active="activities">
       <div className="mx-auto max-w-xl">
-        <div className="mb-5 flex items-center justify-between">
-          <SessionProgressDots statuses={dotStatuses} />
-          <span className="text-sm font-bold text-gray-500">
-            Question {Math.min(answeredDots + 1, totalQuestions)} of{" "}
-            {totalQuestions} · {cumulativeScore} pts
-          </span>
-        </div>
+        {!showSummary ? (
+          <div className="mb-5 flex items-center justify-between">
+            <SessionProgressDots statuses={dotStatuses} />
+            <span className="text-sm font-bold text-gray-500">
+              Question {Math.min(answeredDots + 1, totalQuestions)} of{" "}
+              {totalQuestions} · {cumulativeScore} pts
+            </span>
+          </div>
+        ) : null}
 
-        {outcome && feedback ? (
+        {showSummary ? (
+          <SessionSummaryScreen
+            scoreValue={cumulativeScore}
+            scoreMax={maxScore}
+            message={summaryMessage}
+            items={summaryItems}
+            onDone={handleFinishSummary}
+          />
+        ) : outcome && feedback ? (
           <>
             <FeedbackCard
               prompt={outcome.question.question_prompt}
@@ -283,7 +338,7 @@ export default function PlayActivityPage({
               </button>
             </div>
           </>
-        ) : (
+        ) : currentQuestion ? (
           // Keyed so a change of question remounts the card and clears its selection —
           // otherwise the re-sync after a 409 would leave the previous pick staged.
           <QuestionCard
@@ -292,7 +347,7 @@ export default function PlayActivityPage({
             disabled={submitting}
             onSubmit={handleAnswer}
           />
-        )}
+        ) : null}
       </div>
     </AppShell>
   );

--- a/app/activities/write-acceptance-criteria/page.tsx
+++ b/app/activities/write-acceptance-criteria/page.tsx
@@ -9,20 +9,23 @@ import { AcceptanceCriteriaWritingScreen } from '../../../components/AcceptanceC
 import { AcceptanceCriteriaWritingScreenSkeleton } from '../../../components/AcceptanceCriteriaWritingScreenSkeleton';
 import { ResumeOrAbandonPrompt } from '../../../components/ResumeOrAbandonPrompt';
 import { SessionProgressDots, type ProgressDotStatus } from '../../../components/SessionProgressDots';
-import { SessionSummaryScreen } from '../../../components/SessionSummaryScreen';
+import { SessionSummaryScreen, type SessionSummaryItem } from '../../../components/SessionSummaryScreen';
 import { drawSessionStories, submitAcceptanceCriteria } from '../../../lib/acceptanceCriteriaClient';
-import type { AcceptanceCriteriaResult, UserStoryPrompt } from '../../../lib/acceptanceCriteriaTypes';
 import {
+  AC_PASS_SCORE,
   answeredCount,
   clearSession,
-  getInProgressSession,
+  getStoredSession,
   isSessionComplete,
   nextStoryIndex,
   recordStoryResult,
   startNewSession,
   STORIES_PER_SESSION,
+  summarizeSession,
   type AcceptanceCriteriaSession,
 } from '../../../lib/acceptanceCriteriaSessionStore';
+import type { AcceptanceCriteriaResult, UserStoryPrompt } from '../../../lib/acceptanceCriteriaTypes';
+import { deriveStoryTitle } from '../../../lib/storyMarkdown';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
 type Outcome = { userStory: UserStoryPrompt; result: AcceptanceCriteriaResult };
@@ -46,22 +49,32 @@ export default function WriteAcceptanceCriteriaPage() {
   const [lastAttemptedText, setLastAttemptedText] = useState<string | null>(null);
 
   // GitHub #260: mirrors the Type A start/resume flow (app/activities/[slug]/page.tsx) — on
-  // mount, an in-progress local session (lib/acceptanceCriteriaSessionStore.ts) wins over
-  // starting fresh. loadAttempt doubles as "start a brand-new session", bumped by the
-  // failed-draw Retry button and by handleAbandon (after it clears the old session first, so
-  // the re-run below finds nothing in progress and draws a new one).
+  // mount, a stored local session (lib/acceptanceCriteriaSessionStore.ts) wins over starting
+  // fresh. loadAttempt doubles as "start a brand-new session", bumped by the failed-draw Retry
+  // button and by handleAbandon (after it clears the old session first, so the re-run below
+  // finds nothing stored and draws a new one).
+  //
+  // GitHub #263 bug fix: a stored session that's already complete is routed straight to the
+  // summary, not treated as "nothing to resume" — getStoredSession() no longer discards it (see
+  // that function's own comment for why the old behavior silently lost a finished session if
+  // the effect re-ran — e.g. a reload — before the student clicked past the summary).
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
 
-    const existing = getInProgressSession();
-    if (existing) {
-      setSession(existing);
-      setShowPrompt(true);
-      setShowSummary(false);
+    const stored = getStoredSession();
+    if (stored) {
+      setSession(stored);
       setOutcome(null);
       setSubmitError(null);
       setIsLoading(false);
+      if (isSessionComplete(stored)) {
+        setShowPrompt(false);
+        setShowSummary(true);
+      } else {
+        setShowPrompt(true);
+        setShowSummary(false);
+      }
       return () => {
         cancelled = true;
       };
@@ -177,6 +190,28 @@ export default function WriteAcceptanceCriteriaPage() {
       })
     : [];
 
+  // GitHub #263: SessionSummaryScreen is generic (score/message/items), so this page is the one
+  // that maps its own LLM-graded, 1-10-per-story session into that shape — see the component's
+  // own comment for why it doesn't know about stories/LLM scores itself.
+  const summary = session && allStoriesComplete ? summarizeSession(session) : null;
+  const summaryItems: SessionSummaryItem[] = session
+    ? session.stories.map((story) => ({
+        key: story.userStoryId,
+        label: deriveStoryTitle(story.description),
+        scoreLabel: story.result ? `${story.result.score} / 10` : '—',
+        passed: (story.result?.score ?? 0) >= AC_PASS_SCORE,
+      }))
+    : [];
+  const summaryMessage = summary
+    ? summary.storyCount === 0
+      ? 'No stories were graded in this session.'
+      : summary.passedCount === summary.storyCount
+        ? `Great job — all ${summary.storyCount} stories passed!`
+        : summary.passedCount === 0
+          ? `Keep practicing — none of the ${summary.storyCount} stories passed this time.`
+          : `Nice progress — ${summary.passedCount} of ${summary.storyCount} stories passed.`
+    : '';
+
   return (
     <AppShell active="activities">
       <div className="mx-auto max-w-xl">
@@ -223,8 +258,14 @@ export default function WriteAcceptanceCriteriaPage() {
               confirmMessage="Are you sure you want to abandon this session? Your current answers will be lost."
             />
           </div>
-        ) : showSummary && session ? (
-          <SessionSummaryScreen session={session} onDone={handleFinishSummary} />
+        ) : showSummary && summary ? (
+          <SessionSummaryScreen
+            scoreValue={summary.totalScore}
+            scoreMax={summary.maxScore}
+            message={summaryMessage}
+            items={summaryItems}
+            onDone={handleFinishSummary}
+          />
         ) : currentUserStory ? (
           outcome ? (
             <>

--- a/components/SessionSummaryScreen.tsx
+++ b/components/SessionSummaryScreen.tsx
@@ -1,60 +1,61 @@
 'use client';
 
-import { deriveStoryTitle } from '../lib/storyMarkdown';
-import { AC_PASS_SCORE, summarizeSession, type AcceptanceCriteriaSession } from '../lib/acceptanceCriteriaSessionStore';
-
 /**
- * GitHub #263: shown once every story in the session has been submitted and graded — distinct
- * from AcceptanceCriteriaFeedbackScreen (which recaps one story's own criteria and feedback)
- * both in content (every story's score at a glance, not one story's full write-up) and look
- * (gold "session complete" framing instead of that screen's per-story teal/purple pass/fail
- * gradient), so a student can tell which screen they're looking at without reading the heading.
+ * GitHub #263: shown once every item in a session has been graded — distinct from a per-item
+ * feedback screen (AcceptanceCriteriaFeedbackScreen, FeedbackCard) both in content (every
+ * item's result at a glance, not one item's full write-up) and look (gold "session complete"
+ * framing instead of a per-item pass/fail gradient), so a student can tell which screen they're
+ * looking at without reading the heading.
  *
- * Takes the whole session rather than a pre-computed total, per the issue's instruction to
- * derive this from the existing session state instead of tracking scores separately —
- * summarizeSession (lib/acceptanceCriteriaSessionStore.ts) does the aggregation.
+ * Generic on purpose (GitHub #263 follow-up): the Write Acceptance Criteria session (LLM score
+ * out of 10 per story) and the Type A quiz session (points, correct/incorrect per question)
+ * score on entirely different scales, so this component takes pre-formatted numbers and a
+ * pre-built item list rather than either domain's own types — each caller (write-acceptance-
+ * criteria/page.tsx, [slug]/play/page.tsx) maps its own session state into these props, the same
+ * division of responsibility as SessionProgressDots (GitHub #261) and ResumeOrAbandonPrompt
+ * (GitHub #260).
  */
+export type SessionSummaryItem = {
+  key: string;
+  label: string;
+  scoreLabel: string;
+  passed: boolean;
+};
+
 export function SessionSummaryScreen({
-  session,
+  scoreValue,
+  scoreMax,
+  message,
+  items,
   onDone,
+  doneLabel = 'Back to Activities',
 }: {
-  session: AcceptanceCriteriaSession;
+  scoreValue: number | string;
+  scoreMax: number | string;
+  message: string;
+  items: SessionSummaryItem[];
   onDone: () => void;
+  doneLabel?: string;
 }) {
-  const { totalScore, maxScore, passedCount, storyCount } = summarizeSession(session);
-
-  const message =
-    storyCount === 0
-      ? 'No stories were graded in this session.'
-      : passedCount === storyCount
-        ? `Great job — all ${storyCount} stories passed!`
-        : passedCount === 0
-          ? `Keep practicing — none of the ${storyCount} stories passed this time.`
-          : `Nice progress — ${passedCount} of ${storyCount} stories passed.`;
-
   return (
     <div className="rounded-brand-lg border border-brand-gold/40 bg-gradient-to-br from-brand-gold-dark to-brand-navy p-8 text-center">
       <span className="mb-2 block text-xs font-extrabold uppercase tracking-wide text-brand-gold">Session complete</span>
 
       <div className="text-5xl font-extrabold text-white">
-        {totalScore}
-        <span className="text-2xl font-bold text-brand-ink-muted"> / {maxScore}</span>
+        {scoreValue}
+        <span className="text-2xl font-bold text-brand-ink-muted"> / {scoreMax}</span>
       </div>
       <p className="mt-2 text-sm font-semibold text-brand-ink-muted">{message}</p>
 
       <div className="mt-6 space-y-2 text-left">
-        {session.stories.map((story) => (
+        {items.map((item) => (
           <div
-            key={story.userStoryId}
+            key={item.key}
             className="flex items-center justify-between gap-3 rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-3"
           >
-            <span className="text-sm font-semibold text-brand-ink">{deriveStoryTitle(story.description)}</span>
-            <span
-              className={`shrink-0 text-sm font-extrabold ${
-                story.result && story.result.score >= AC_PASS_SCORE ? 'text-brand-green' : 'text-brand-ink-muted'
-              }`}
-            >
-              {story.result ? `${story.result.score} / 10` : '—'}
+            <span className="text-sm font-semibold text-brand-ink">{item.label}</span>
+            <span className={`shrink-0 text-sm font-extrabold ${item.passed ? 'text-brand-green' : 'text-brand-ink-muted'}`}>
+              {item.scoreLabel}
             </span>
           </div>
         ))}
@@ -65,7 +66,7 @@ export function SessionSummaryScreen({
         onClick={onDone}
         className="mt-6 w-full rounded-brand-md bg-brand-purple py-3 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
       >
-        Back to Activities
+        {doneLabel}
       </button>
     </div>
   );

--- a/lib/acceptanceCriteriaSessionStore.ts
+++ b/lib/acceptanceCriteriaSessionStore.ts
@@ -62,15 +62,25 @@ export function nextStoryIndex(session: AcceptanceCriteriaSession): number {
 }
 
 /**
- * The in-progress session, if one exists — null both when there's none stored and when a
- * stored session turns out to already be fully answered (a stale leftover from a session that
- * finished without going through clearSession — e.g. a closed tab). A "resume" prompt with
- * nothing left to answer would be a dead end, so this is treated the same as "no session".
+ * Whatever session is stored, whether it's still being answered or already complete — null
+ * only when nothing is stored at all. The caller (app/activities/write-acceptance-criteria/
+ * page.tsx) is the one that decides what a complete session means (show the summary) versus
+ * an incomplete one (show the resume/abandon prompt); this function does not discard either.
+ *
+ * GitHub #263 bug fix: this used to return null for an already-complete session too, treating
+ * it as a "stale leftover" (e.g. a closed tab) — safe back when handleContinue cleared the
+ * session the instant it became complete, so a complete-and-still-stored session could only
+ * mean "abandoned mid-flight". Once #263 started leaving a complete session in storage on
+ * purpose (so SessionSummaryScreen has something to show until the student dismisses it), that
+ * same "treat complete as stale" logic started discarding sessions that were simply awaiting
+ * acknowledgment — any remount while the summary was up (a reload, a background token refresh
+ * re-running the mount effect) silently replaced the finished session with a brand new one
+ * before the student ever saw their results. A session only ever leaves storage via
+ * clearSession() now, called from the student's own "Back to Activities" click — never
+ * implicitly by this getter.
  */
-export function getInProgressSession(): AcceptanceCriteriaSession | null {
-  const session = readRaw();
-  if (!session || isSessionComplete(session)) return null;
-  return session;
+export function getStoredSession(): AcceptanceCriteriaSession | null {
+  return readRaw();
 }
 
 export function startNewSession(stories: UserStoryPrompt[]): AcceptanceCriteriaSession {


### PR DESCRIPTION
Both the Write Acceptance Criteria and Type A quiz flows could lose a
just-finished session's summary if anything re-ran the page's data-sync
logic before the student clicked past it (e.g. a background token
refresh, or — for AC specifically — any reload).