### PR TITLE
Hardened avatar icon upload vounerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ In your Supabase project, open the **SQL Editor** and run the contents of [`supa
 
 ### 4. Create the avatars storage bucket
 
-In your Supabase project, go to **Storage → New bucket**, name it `avatars`, and check **Public bucket**.
+In your Supabase project, go to **Storage → New bucket**, name it `avatars`, and check **Public bucket**. In the same dialog, set **Allowed MIME types** to `image/png, image/jpeg, image/webp` and **File size limit** to `2 MB` — the upload route enforces the same rules, but the bucket is public, so a second line of defence is worth having.
 
 ## Quick start
 

--- a/__tests__/api/avatar.test.ts
+++ b/__tests__/api/avatar.test.ts
@@ -1,16 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAX_AVATAR_BYTES } from '../../lib/imageRules';
 
 const mockProfile = { user_id: 'user-123', username: 'testuser', biography: 'Hello!', avatar_url: 'https://example.com/avatars/user-123.jpg', role: 'student' };
+
+type SupabaseError = { message: string } | null;
+type UploadOptions = { upsert: boolean; contentType: string };
 
 const mockBuilder = {
   update: vi.fn().mockReturnThis(),
   eq: vi.fn().mockReturnThis(),
   select: vi.fn().mockReturnThis(),
-  single: vi.fn(async () => ({ data: mockProfile, error: null })),
+  single: vi.fn(async () => ({ data: mockProfile as typeof mockProfile | null, error: null as SupabaseError })),
 };
 
+// upload()'s parameters are spelled out so mock.calls is typed — the assertions below are all about
+// which key and contentType the route derived, which is the substance of GitHub #278.
 const mockStorage = {
-  upload: vi.fn(async () => ({ error: null })),
+  upload: vi.fn(async (_path: string, _file: Blob, _options: UploadOptions) => ({ error: null as SupabaseError })),
+  remove: vi.fn(async (_paths: string[]) => ({ error: null as SupabaseError })),
   getPublicUrl: vi.fn(() => ({ data: { publicUrl: 'https://example.com/avatars/user-123.jpg' } })),
 };
 
@@ -25,22 +32,44 @@ vi.mock('../../lib/supabase', () => ({
       }),
     },
     from: vi.fn(() => mockBuilder),
-    storage: {
-      from: vi.fn(() => mockStorage),
-    },
+    storage: { from: vi.fn(() => mockStorage) },
   })),
 }));
 
 import { POST } from '../../app/api/profile/avatar/route';
 
-function makeRequest(file?: Blob, token = 'valid-token') {
+/**
+ * Real magic bytes matter now: the route sniffs the header instead of trusting `file.type` or the
+ * filename, so a placeholder like new Blob(['fake-image']) is rejected as "not an image".
+ */
+function imageBlob(signature: number[], type = 'image/png'): Blob {
+  const bytes = new Uint8Array(32);
+  bytes.set(signature);
+  return new Blob([bytes], { type });
+}
+
+const pngBlob = (type?: string) => imageBlob([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], type ?? 'image/png');
+const jpegBlob = () => imageBlob([0xff, 0xd8, 0xff, 0xe0], 'image/jpeg');
+const webpBlob = () =>
+  imageBlob([0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50], 'image/webp');
+
+function makeRequest(file?: Blob, token = 'valid-token', filename = 'avatar.jpg') {
   const formData = new FormData();
-  if (file) formData.append('image', file, 'avatar.jpg');
+  if (file) formData.append('image', file, filename);
   return new Request('http://localhost/api/profile/avatar', {
     method: 'POST',
     headers: token ? { authorization: `Bearer ${token}` } : {},
     body: formData,
   });
+}
+
+/** The storage key the route passed to upload() — the whole point of GitHub #278. */
+function uploadedPath(): string {
+  return mockStorage.upload.mock.calls[0][0];
+}
+
+function uploadOptions(): UploadOptions {
+  return mockStorage.upload.mock.calls[0][2];
 }
 
 describe('Avatar upload route', () => {
@@ -51,25 +80,23 @@ describe('Avatar upload route', () => {
     mockBuilder.select.mockReturnThis();
     mockBuilder.single.mockResolvedValue({ data: mockProfile, error: null });
     mockStorage.upload.mockResolvedValue({ error: null });
+    mockStorage.remove.mockResolvedValue({ error: null });
     mockStorage.getPublicUrl.mockReturnValue({ data: { publicUrl: 'https://example.com/avatars/user-123.jpg' } });
   });
 
   it('uploads an image and returns updated profile', async () => {
-    const file = new Blob(['fake-image'], { type: 'image/jpeg' });
-    const response = await POST(makeRequest(file));
+    const response = await POST(makeRequest(jpegBlob()));
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual({ profile: mockProfile });
   });
 
   it('returns 401 without a token', async () => {
-    const file = new Blob(['fake-image'], { type: 'image/jpeg' });
-    const response = await POST(makeRequest(file, ''));
+    const response = await POST(makeRequest(jpegBlob(), ''));
     expect(response.status).toBe(401);
   });
 
   it('returns 401 for an invalid token', async () => {
-    const file = new Blob(['fake-image'], { type: 'image/jpeg' });
-    const response = await POST(makeRequest(file, 'bad-token'));
+    const response = await POST(makeRequest(jpegBlob(), 'bad-token'));
     expect(response.status).toBe(401);
   });
 
@@ -81,17 +108,81 @@ describe('Avatar upload route', () => {
 
   it('returns 400 when storage upload fails', async () => {
     mockStorage.upload.mockResolvedValue({ error: { message: 'Bucket not found' } });
-    const file = new Blob(['fake-image'], { type: 'image/jpeg' });
-    const response = await POST(makeRequest(file));
+    const response = await POST(makeRequest(jpegBlob()));
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: 'Bucket not found' });
   });
 
   it('returns 400 when profile update fails', async () => {
     mockBuilder.single.mockResolvedValue({ data: null, error: { message: 'Profile not found' } });
-    const file = new Blob(['fake-image'], { type: 'image/jpeg' });
-    const response = await POST(makeRequest(file));
+    const response = await POST(makeRequest(jpegBlob()));
     expect(response.status).toBe(400);
     expect(await response.json()).toEqual({ error: 'Profile not found' });
+  });
+
+  describe('format whitelist (GitHub #278)', () => {
+    it.each([
+      ['PNG', pngBlob, 'user-123.png', 'image/png'],
+      ['JPEG', jpegBlob, 'user-123.jpg', 'image/jpeg'],
+      ['WebP', webpBlob, 'user-123.webp', 'image/webp'],
+    ])('accepts %s and derives the key and contentType from the bytes', async (_label, blob, path, contentType) => {
+      const response = await POST(makeRequest((blob as () => Blob)()));
+      expect(response.status).toBe(200);
+      expect(uploadedPath()).toBe(path);
+      expect(uploadOptions()).toEqual({ upsert: true, contentType });
+    });
+
+    it('rejects an SVG payload without touching storage', async () => {
+      const svg = new Blob(['<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"/>'], { type: 'image/svg+xml' });
+      const response = await POST(makeRequest(svg, 'valid-token', 'avatar.svg'));
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'Only PNG, JPEG or WebP images are allowed.' });
+      expect(mockStorage.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects an HTML payload disguised as a PNG', async () => {
+      const html = new Blob(['<!DOCTYPE html><script>alert(document.cookie)</script>'], { type: 'image/png' });
+      const response = await POST(makeRequest(html, 'valid-token', 'avatar.png'));
+      expect(response.status).toBe(400);
+      expect(mockStorage.upload).not.toHaveBeenCalled();
+    });
+
+    it('ignores the client-supplied filename and MIME type entirely', async () => {
+      // Real PNG bytes, but the client claims it is HTML and names it evil.html. The old route
+      // built the key from that name, which is what made the bucket serve executable content.
+      const response = await POST(makeRequest(pngBlob('text/html'), 'valid-token', 'evil.html'));
+      expect(response.status).toBe(200);
+      expect(uploadedPath()).toBe('user-123.png');
+      expect(uploadOptions().contentType).toBe('image/png');
+    });
+
+    it('cannot be pushed out of the user id namespace by a path-like filename', async () => {
+      const response = await POST(makeRequest(pngBlob(), 'valid-token', '../other-user/avatar.png'));
+      expect(response.status).toBe(200);
+      expect(uploadedPath()).toBe('user-123.png');
+    });
+  });
+
+  describe('size limit (GitHub #278)', () => {
+    it('rejects a file over the limit without reading it into storage', async () => {
+      const oversized = new Blob([new Uint8Array(MAX_AVATAR_BYTES + 1)], { type: 'image/png' });
+      const response = await POST(makeRequest(oversized));
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'Image must be 2 MB or smaller.' });
+      expect(mockStorage.upload).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty file', async () => {
+      const response = await POST(makeRequest(new Blob([], { type: 'image/png' })));
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'The image file is empty.' });
+      expect(mockStorage.upload).not.toHaveBeenCalled();
+    });
+  });
+
+  it('removes the previous avatar stored under a different extension', async () => {
+    const response = await POST(makeRequest(pngBlob()));
+    expect(response.status).toBe(200);
+    expect(mockStorage.remove).toHaveBeenCalledWith(['user-123.jpg', 'user-123.webp']);
   });
 });

--- a/__tests__/lib/imageRules.test.ts
+++ b/__tests__/lib/imageRules.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AVATAR_MIME_EXTENSIONS,
+  MAX_AVATAR_BYTES,
+  avatarSizeError,
+  sniffAvatarMime,
+} from '../../lib/imageRules';
+
+/** Pads a signature out to the 12 bytes sniffAvatarMime reads, so short-input handling is separate. */
+function header(...bytes: number[]): Uint8Array {
+  const head = new Uint8Array(12);
+  head.set(bytes);
+  return head;
+}
+
+const JPEG = header(0xff, 0xd8, 0xff, 0xe0);
+const PNG = header(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
+const WEBP = header(0x52, 0x49, 0x46, 0x46, 0x1a, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50);
+
+function textHeader(text: string): Uint8Array {
+  return new TextEncoder().encode(text.padEnd(12, ' '));
+}
+
+describe('sniffAvatarMime', () => {
+  it('recognises the three allowed formats', () => {
+    expect(sniffAvatarMime(JPEG)).toBe('image/jpeg');
+    expect(sniffAvatarMime(PNG)).toBe('image/png');
+    expect(sniffAvatarMime(WEBP)).toBe('image/webp');
+  });
+
+  it('rejects SVG and HTML — the stored-XSS payloads (GitHub #278)', () => {
+    expect(sniffAvatarMime(textHeader('<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)">'))).toBeNull();
+    expect(sniffAvatarMime(textHeader('<!DOCTYPE html><script>alert(1)</script>'))).toBeNull();
+  });
+
+  it('rejects other binary formats not on the whitelist', () => {
+    expect(sniffAvatarMime(header(0x47, 0x49, 0x46, 0x38, 0x39, 0x61))).toBeNull(); // GIF89a
+    expect(sniffAvatarMime(header(0x25, 0x50, 0x44, 0x46))).toBeNull(); // %PDF
+  });
+
+  it('rejects a RIFF container that is not WebP', () => {
+    const wav = header(0x52, 0x49, 0x46, 0x46, 0x24, 0x00, 0x00, 0x00, 0x57, 0x41, 0x56, 0x45);
+    expect(sniffAvatarMime(wav)).toBeNull();
+  });
+
+  it('does not read past the end of a short header', () => {
+    expect(sniffAvatarMime(new Uint8Array([]))).toBeNull();
+    expect(sniffAvatarMime(new Uint8Array([0xff, 0xd8]))).toBeNull();
+    // RIFF present but truncated before the WEBP marker at offset 8.
+    expect(sniffAvatarMime(new Uint8Array([0x52, 0x49, 0x46, 0x46]))).toBeNull();
+  });
+});
+
+describe('avatarSizeError', () => {
+  it('accepts sizes up to the limit', () => {
+    expect(avatarSizeError(1)).toBeNull();
+    expect(avatarSizeError(MAX_AVATAR_BYTES)).toBeNull();
+  });
+
+  it('rejects an empty file', () => {
+    expect(avatarSizeError(0)).toBe('The image file is empty.');
+  });
+
+  it('rejects anything over the limit', () => {
+    expect(avatarSizeError(MAX_AVATAR_BYTES + 1)).toBe('Image must be 2 MB or smaller.');
+  });
+});
+
+describe('AVATAR_MIME_EXTENSIONS', () => {
+  it('maps each allowed type to a distinct extension', () => {
+    const extensions = Object.values(AVATAR_MIME_EXTENSIONS);
+    expect(extensions).toEqual(['png', 'jpg', 'webp']);
+    expect(new Set(extensions).size).toBe(extensions.length);
+  });
+});

--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -1,4 +1,11 @@
 import { getSupabaseClient } from '../../../../lib/supabase';
+import {
+  AVATAR_HEADER_BYTES,
+  AVATAR_MIME_EXTENSIONS,
+  AVATAR_TYPE_ERROR,
+  avatarSizeError,
+  sniffAvatarMime,
+} from '../../../../lib/imageRules';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -27,14 +34,33 @@ export async function POST(request: Request) {
     return Response.json({ error: 'image file is required.' }, { status: 400 });
   }
 
-  const ext = file instanceof File ? (file.name.split('.').pop() ?? 'jpg') : 'jpg';
-  const path = `${user.id}.${ext}`;
+  // Size first, so an oversized upload is rejected before any of it is read (GitHub #278).
+  const sizeError = avatarSizeError(file.size);
+  if (sizeError) return Response.json({ error: sizeError }, { status: 400 });
+
+  // The declared `file.type` and `file.name` are deliberately ignored — both are client input, and
+  // the bucket is public, so a .svg/.html slipping through would be served back as executable
+  // stored XSS. The magic bytes decide the format, and the format decides the key's extension.
+  const head = new Uint8Array(await file.slice(0, AVATAR_HEADER_BYTES).arrayBuffer());
+  const mime = sniffAvatarMime(head);
+  if (!mime) return Response.json({ error: AVATAR_TYPE_ERROR }, { status: 400 });
+
+  const extension = AVATAR_MIME_EXTENSIONS[mime];
+  const path = `${user.id}.${extension}`; // user.id comes from the token, so it can't traverse.
 
   const { error: uploadError } = await supabase.storage
     .from('avatars')
-    .upload(path, file, { upsert: true });
+    .upload(path, file, { upsert: true, contentType: mime });
 
   if (uploadError) return Response.json({ error: uploadError.message }, { status: 400 });
+
+  // `upsert` only overwrites the identical key, so switching format would otherwise leave the
+  // previous avatar behind — still publicly reachable. Best-effort: a failure here is not the
+  // caller's problem, the new avatar is already stored.
+  const staleKeys = Object.values(AVATAR_MIME_EXTENSIONS)
+    .filter((other) => other !== extension)
+    .map((other) => `${user.id}.${other}`);
+  await supabase.storage.from('avatars').remove(staleKeys);
 
   const { data: { publicUrl } } = supabase.storage.from('avatars').getPublicUrl(path);
 

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -9,6 +9,12 @@ import { EditableField } from '../../components/EditableField';
 import { ImageCropModal } from '../../components/ImageCropModal';
 import { MyCoursesSection } from '../../components/MyCoursesSection';
 import { useUser } from '../../components/UserProvider';
+import {
+  AVATAR_ACCEPT_ATTRIBUTE,
+  AVATAR_MIME_EXTENSIONS,
+  AVATAR_TYPE_ERROR,
+  avatarSizeError,
+} from '../../lib/imageRules';
 import { getInitials } from '../../lib/initials';
 
 type ProfileDraft = {
@@ -210,6 +216,13 @@ export default function ProfilePage() {
     const file = event.target.files?.[0];
     event.target.value = '';
     if (!file) return;
+    // The `accept` attribute is only a filter in the picker dialog; this is the message the user
+    // actually sees. The real gate is POST /api/profile/avatar, which sniffs the bytes.
+    if (!(file.type in AVATAR_MIME_EXTENSIONS)) {
+      setError(AVATAR_TYPE_ERROR);
+      return;
+    }
+    setError('');
     setPendingImage(URL.createObjectURL(file));
   }
 
@@ -220,6 +233,15 @@ export default function ProfilePage() {
 
   async function handleCropSave(croppedBlob: Blob) {
     if (!token) return;
+    // Checked on the cropped JPEG rather than on the picked file: that blob is what gets uploaded,
+    // and getCroppedImageBlob caps it at MAX_AVATAR_EDGE_PX, so a large source is fine.
+    const sizeError = avatarSizeError(croppedBlob.size);
+    if (sizeError) {
+      setError(sizeError);
+      if (pendingImage) URL.revokeObjectURL(pendingImage);
+      setPendingImage(null);
+      return;
+    }
     setUploading(true);
     setError('');
     const formData = new FormData();
@@ -373,7 +395,7 @@ export default function ProfilePage() {
               <input
                 ref={fileInputRef}
                 type="file"
-                accept="image/*"
+                accept={AVATAR_ACCEPT_ATTRIBUTE}
                 className="hidden"
                 onChange={handleAvatarChange}
               />

--- a/lib/cropImage.ts
+++ b/lib/cropImage.ts
@@ -10,17 +10,26 @@ function loadImage(src: string): Promise<HTMLImageElement> {
 }
 
 /**
+ * Longest edge of the exported avatar. Without it the export kept the crop's native resolution, so
+ * a 6000×6000 selection produced a multi-megabyte JPEG — over MAX_AVATAR_BYTES, and far more than
+ * a 96px avatar circle ever displays (GitHub #278).
+ */
+const MAX_AVATAR_EDGE_PX = 512;
+
+/**
  * Draws the selected crop region of `imageSrc` onto a canvas sized to that
- * region and exports it as a JPEG blob. The crop circle in ImageCropModal is
- * only a framing guide — react-easy-crop reports its square bounding box in
- * `pixelCrop`, which is what actually gets extracted here. Circular display
- * is handled by the existing `rounded-full` wrapper around the avatar `<img>`.
+ * region (downscaled to MAX_AVATAR_EDGE_PX) and exports it as a JPEG blob. The
+ * crop circle in ImageCropModal is only a framing guide — react-easy-crop
+ * reports its square bounding box in `pixelCrop`, which is what actually gets
+ * extracted here. Circular display is handled by the existing `rounded-full`
+ * wrapper around the avatar `<img>`.
  */
 export async function getCroppedImageBlob(imageSrc: string, pixelCrop: PixelCrop): Promise<Blob> {
   const image = await loadImage(imageSrc);
+  const scale = Math.min(1, MAX_AVATAR_EDGE_PX / Math.max(pixelCrop.width, pixelCrop.height));
   const canvas = document.createElement('canvas');
-  canvas.width = pixelCrop.width;
-  canvas.height = pixelCrop.height;
+  canvas.width = Math.round(pixelCrop.width * scale);
+  canvas.height = Math.round(pixelCrop.height * scale);
 
   const ctx = canvas.getContext('2d');
   if (!ctx) throw new Error('Canvas is not supported in this browser.');
@@ -33,8 +42,8 @@ export async function getCroppedImageBlob(imageSrc: string, pixelCrop: PixelCrop
     pixelCrop.height,
     0,
     0,
-    pixelCrop.width,
-    pixelCrop.height
+    canvas.width,
+    canvas.height
   );
 
   return new Promise((resolve, reject) => {

--- a/lib/imageRules.ts
+++ b/lib/imageRules.ts
@@ -1,0 +1,59 @@
+// Avatar upload rules (GitHub #278). The `avatars` bucket is public, so whatever lands in it is
+// served straight back from the Supabase domain — an .svg or .html carrying a <script> would be
+// stored XSS. Two consequences shape this module:
+//
+//   1. The *sniffed* magic bytes are the only source of truth. `File.name` and `File.type` are
+//      client input and are never read by the upload route: the storage key's extension and the
+//      upload's contentType both come from `sniffAvatarMime` instead.
+//   2. There is a hard byte cap, since the bucket is billed storage anyone with an account can
+//      write to.
+//
+// Shared between the route and the profile form so client and server can't drift on what "valid"
+// means, the same way lib/passwordRules.ts anchors the password rule.
+
+export type AvatarMime = 'image/png' | 'image/jpeg' | 'image/webp';
+
+/** Whitelist *and* extension source — the storage key is built from this, never from the filename. */
+export const AVATAR_MIME_EXTENSIONS: Record<AvatarMime, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+};
+
+export const MAX_AVATAR_BYTES = 2 * 1024 * 1024;
+const MAX_AVATAR_MB = MAX_AVATAR_BYTES / (1024 * 1024);
+
+/** For the file picker's `accept` attribute — a UI hint only; the route is what enforces this. */
+export const AVATAR_ACCEPT_ATTRIBUTE = 'image/png,image/jpeg,image/webp';
+
+export const AVATAR_TYPE_ERROR = 'Only PNG, JPEG or WebP images are allowed.';
+
+/** Bytes of the file header `sniffAvatarMime` needs (WebP's marker sits at offset 8). */
+export const AVATAR_HEADER_BYTES = 12;
+
+export function avatarSizeError(size: number): string | null {
+  if (size <= 0) return 'The image file is empty.';
+  if (size > MAX_AVATAR_BYTES) return `Image must be ${MAX_AVATAR_MB} MB or smaller.`;
+  return null;
+}
+
+function startsWith(head: Uint8Array, signature: number[], offset = 0): boolean {
+  if (head.length < offset + signature.length) return false;
+  return signature.every((byte, i) => head[offset + i] === byte);
+}
+
+const JPEG = [0xff, 0xd8, 0xff];
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const RIFF = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+const WEBP = [0x57, 0x45, 0x42, 0x50]; // "WEBP", at offset 8 inside a RIFF container
+
+/**
+ * Identifies the image format from its first `AVATAR_HEADER_BYTES` bytes, or null for anything not
+ * on the whitelist — including SVG and HTML, which are text and therefore match no signature.
+ */
+export function sniffAvatarMime(head: Uint8Array): AvatarMime | null {
+  if (startsWith(head, JPEG)) return 'image/jpeg';
+  if (startsWith(head, PNG)) return 'image/png';
+  if (startsWith(head, RIFF) && startsWith(head, WEBP, 8)) return 'image/webp';
+  return null;
+}


### PR DESCRIPTION
Resolve #278 

Harden avatar upload against stored XSS and unbounded storage

POST /api/profile/avatar accepted any blob: no MIME check, no size cap, and the
storage key's extension came from the client-supplied filename. Since the
avatars bucket is public, an uploaded .svg containing a <script> came back as a
public URL that executes it.

The route now derives everything from the bytes instead of from client input:

- New lib/imageRules.ts sniffs PNG/JPEG/WebP from their magic bytes (no new
  dependency) and is shared by the route and the profile form.
- file.name and file.type are no longer read. The key is `${user.id}.${ext}`
  with the extension from the sniffed format, and contentType is set explicitly.
- Size capped at 2 MB, checked before any bytes are read; getCroppedImageBlob()
  caps the export at 512px so the happy path stays well under it.
- Old avatars under a different extension are removed after upload — upsert only
  overwrites the identical key.

Tests: new __tests__/lib/imageRules.test.ts; avatar.test.ts grows 6 → 16 cases
covering SVG/HTML payloads, spoofed filenames and MIME types, and the size limit.