### PR TITLE
resolve issue #175

### DIFF
--- a/__tests__/lib/activityLogTypes.test.ts
+++ b/__tests__/lib/activityLogTypes.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeStudents, type StudentActivitySummary } from '../../lib/activityLogTypes';
+
+/**
+ * summarizeStudents is a pure helper, so this test builds its input directly instead of mocking
+ * lib/supabase — same shape as __tests__/lib/pagination.test.ts.
+ *
+ * The roster argument (GitHub #175) is what makes the All Students page show the real class:
+ * before it, a student with no session at all had no row to aggregate and simply vanished.
+ */
+function attempt(overrides: Partial<StudentActivitySummary> = {}): StudentActivitySummary {
+  return {
+    id: 'session-1',
+    activityType: 'identify-weak-user-stories',
+    activityName: 'Identify Weak User Stories',
+    level: 1,
+    dateTime: '2026-08-01T10:00:00.000Z',
+    status: 'completed',
+    passed: true,
+    score: 4,
+    maxScore: 4,
+    totalQuestions: 4,
+    answeredQuestions: 4,
+    studentId: 'student-a',
+    studentName: 'Ann Attempter',
+    ...overrides,
+  };
+}
+
+describe('summarizeStudents', () => {
+  it('keeps the attempts-only behaviour when no roster is passed', () => {
+    const rows = summarizeStudents([attempt()]);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ studentId: 'student-a', studentName: 'Ann Attempter', attempts: 1, averageScore: 100 });
+  });
+
+  it('includes roster students who have never attempted anything', () => {
+    const rows = summarizeStudents(
+      [attempt()],
+      [
+        { studentId: 'student-a', studentName: 'Ann Attempter' },
+        { studentId: 'student-z', studentName: 'Zoe Newcomer' },
+      ],
+    );
+
+    const zoe = rows.find((row) => row.studentId === 'student-z');
+    expect(zoe).toMatchObject({
+      studentName: 'Zoe Newcomer',
+      attempts: 0,
+      averageScore: null,
+      abandonedCount: 0,
+      needsAttention: false,
+    });
+  });
+
+  it('gives a student with only unfinished attempts a null average', () => {
+    const rows = summarizeStudents(
+      [attempt({ studentId: 'student-b', studentName: 'Bob Busy', status: 'in-progress', passed: false, score: 0 })],
+      [{ studentId: 'student-b', studentName: 'Bob Busy' }],
+    );
+
+    expect(rows[0]).toMatchObject({ attempts: 1, averageScore: null });
+  });
+
+  it('sorts null averages to the end in both score directions', () => {
+    const rows = summarizeStudents(
+      [attempt(), attempt({ id: 'session-2', studentId: 'student-c', studentName: 'Cal Low', score: 1 })],
+      [
+        { studentId: 'student-a', studentName: 'Ann Attempter' },
+        { studentId: 'student-c', studentName: 'Cal Low' },
+        { studentId: 'student-z', studentName: 'Zoe Newcomer' },
+      ],
+    );
+
+    // Mirrors compareByScore in app/instructor/students/page.tsx.
+    const byScore = (direction: 1 | -1) =>
+      [...rows]
+        .sort((a, b) => {
+          if (a.averageScore === null) return b.averageScore === null ? 0 : 1;
+          if (b.averageScore === null) return -1;
+          return (a.averageScore - b.averageScore) * direction;
+        })
+        .map((row) => row.studentId);
+
+    expect(byScore(1)).toEqual(['student-c', 'student-a', 'student-z']);
+    expect(byScore(-1)).toEqual(['student-a', 'student-c', 'student-z']);
+  });
+
+  it('keeps students whose attempts exist but who are missing from the roster', () => {
+    const rows = summarizeStudents([attempt()], [{ studentId: 'student-z', studentName: 'Zoe Newcomer' }]);
+
+    expect(rows.map((row) => row.studentId).sort()).toEqual(['student-a', 'student-z']);
+  });
+});

--- a/app/instructor/students/page.tsx
+++ b/app/instructor/students/page.tsx
@@ -11,7 +11,12 @@ import {
   type StudentActivitySummary,
   type StudentAggregate,
 } from '../../../lib/activityLogTypes';
-import { loadInstructorActivities, loadInstructorStudents, type InstructorActivityEntry } from '../../../lib/sessionClient';
+import {
+  loadInstructorActivities,
+  loadInstructorStudents,
+  type InstructorActivityEntry,
+  type StudentSummary,
+} from '../../../lib/sessionClient';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
 const PAGE_SIZE = 9;
@@ -32,13 +37,15 @@ function compareByScore(a: StudentAggregate, b: StudentAggregate, direction: 1 |
  * summarizeStudents aggregation, but paginated and with its own search/sort so an instructor can
  * find one specific student directly instead of scrolling.
  *
- * Only students who have attempted something appear — the roster is derived from attempts
- * (GitHub #171), so an enrolled student who never started an activity has no row to aggregate.
+ * Unlike the dashboard's preview, this page shows the *whole* class (GitHub #175): the attempt
+ * timeline is merged with the roster from GET /api/instructor/students, so a student who has
+ * never started an activity still gets a row (0 attempts, no average) instead of vanishing.
  */
 export default function AllStudentsPage() {
   const { token, profile, loading, authorized } = useRequireRole('instructor');
 
   const [entries, setEntries] = useState<StudentActivitySummary[] | null>(null);
+  const [roster, setRoster] = useState<StudentSummary[] | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const [query, setQuery] = useState('');
@@ -68,13 +75,27 @@ export default function AllStudentsPage() {
     if (!token || !profile?.user_id) return;
     let cancelled = false;
     loadInstructorStudents(token, profile.user_id).then((result) => {
-      if (cancelled || !result.ok) return;
-      // Warms the cache so repeat visits don't re-fetch the full roster.
+      if (cancelled) return;
+      // A failed roster degrades to the attempts-only list rather than blanking the page — the
+      // students with attempts are the ones an instructor is usually here for. [] keeps the
+      // loading gate below from waiting forever.
+      setRoster(result.ok ? result.data.students : []);
     });
     return () => { cancelled = true; };
   }, [token, profile?.user_id]);
 
-  const allStudents = useMemo(() => summarizeStudents(entries ?? []), [entries]);
+  // Same name composition as the dashboard's student filter, so one student reads identically
+  // on both pages whether or not they have attempted anything.
+  const rosterEntries = useMemo(
+    () =>
+      (roster ?? []).map((student) => ({
+        studentId: student.userId,
+        studentName: `${student.firstName} ${student.lastName}`.trim() || student.username,
+      })),
+    [roster],
+  );
+
+  const allStudents = useMemo(() => summarizeStudents(entries ?? [], rosterEntries), [entries, rosterEntries]);
 
   const filteredSorted = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -138,7 +159,9 @@ export default function AllStudentsPage() {
           <p className="mb-6 rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-4 text-sm font-semibold text-brand-danger-light">
             {error}
           </p>
-        ) : entries === null ? (
+        ) : entries === null || roster === null ? (
+          // Both are load-bearing: rendering on `entries` alone would show the list once without
+          // the zero-attempt students and then have it jump when the roster lands.
           <p className="mb-6 text-sm font-semibold text-gray-500">Loading…</p>
         ) : (
           <>
@@ -173,8 +196,8 @@ export default function AllStudentsPage() {
             {pageStudents.length === 0 ? (
               <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
                 {/* An empty class and a search that matched nothing are different states now that
-                    the roster is real — only students with at least one attempt appear here. */}
-                {query ? `No students match "${query}".` : 'No student has attempted an activity yet.'}
+                    the roster is real — this list is the class itself, not just who has attempted. */}
+                {query ? `No students match "${query}".` : 'No students in this class yet.'}
               </p>
             ) : (
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/lib/activityLogTypes.ts
+++ b/lib/activityLogTypes.ts
@@ -73,13 +73,27 @@ export type StudentAggregate = {
  * All Students page (GitHub #82) both answer "who", leaving "what happened" to ActivityLogTable.
  * Sorted needs-attention first (the whole point of surfacing this at all), then alphabetically,
  * so the order is stable and predictable rather than shuffling by score.
+ *
+ * Pass `roster` (GET /api/instructor/students, GitHub #175) to include students with no attempts
+ * at all: deriving the list from `entries` alone silently drops every enrolled student who never
+ * started an activity. They come out with attempts 0 and averageScore null, which compareByScore
+ * already sorts to the end in both directions. Callers that deliberately want the attempts-only
+ * view — the dashboard's roster preview — just omit it.
  */
-export function summarizeStudents(entries: StudentActivitySummary[]): StudentAggregate[] {
+export function summarizeStudents(
+  entries: StudentActivitySummary[],
+  roster: { studentId: string; studentName: string }[] = [],
+): StudentAggregate[] {
   const byStudent = new Map<string, StudentActivitySummary[]>();
+  // Names come from both sides now, and a student in `roster` may have no entry to read one from.
+  const nameById = new Map(roster.map((student) => [student.studentId, student.studentName]));
+  for (const student of roster) byStudent.set(student.studentId, []);
+
   for (const entry of entries) {
     const list = byStudent.get(entry.studentId) ?? [];
     list.push(entry);
     byStudent.set(entry.studentId, list);
+    nameById.set(entry.studentId, entry.studentName);
   }
 
   return [...byStudent.entries()]
@@ -93,7 +107,7 @@ export function summarizeStudents(entries: StudentActivitySummary[]): StudentAgg
 
       return {
         studentId,
-        studentName: list[0].studentName,
+        studentName: nameById.get(studentId) ?? 'Unknown student',
         attempts: list.length,
         averageScore,
         abandonedCount,


### PR DESCRIPTION
Resolve #175: All Students page lists the real class roster

app/instructor/students/page.tsx already read real data from
loadInstructorActivities, but that list is derived from attempts, so any
enrolled student who never started an activity had no row to aggregate and
did not appear at all.

The page already fetched GET /api/instructor/students purely to warm the
cache; that result is now kept and merged in. summarizeStudents takes an
optional roster argument — students with no attempts come out with
attempts 0 and averageScore null, which compareByScore already sorts to
the end in both score directions. Omitting the argument keeps the previous
attempts-only behaviour, so the dashboard's roster preview is unchanged.

Search, sort, SortOrder and pagination are untouched. The loading gate now
waits for both fetches so the list does not jump when the roster lands, and
the empty state reads "No students in this class yet" since it no longer
describes who has attempted something.

Adds __tests__/lib/activityLogTypes.test.ts (5 tests) covering the null
average, both sort directions, and a student with attempts but no roster row.

Note: the ?student= deep link in AC 2 no longer exists — InstructorStudentCard
links to the per-student detail page from #127 instead.