### PR TITLE
BUG solved: Hardcoded instructor signup code shipped in source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,12 @@ SUPABASE_URL="https://your-project-id.supabase.co"
 SUPABASE_ANON_KEY="your-anon-key"
 SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"
 NEXT_PUBLIC_SUPABASE_URL="https://your-project-id.supabase.co"
+
+# GitHub #280: the invite code that grants the instructor role at registration
+# (app/api/auth/register/route.ts). Generate a real random value per deployment
+# (e.g. `openssl rand -base64 24`) and set it only in that deployment's environment
+# (e.g. Vercel Environment Variables) — never commit a real value here or anywhere
+# else in the repo. Leaving this unset (or set to a placeholder starting with
+# "CHANGE-ME") makes instructor signup fail closed rather than fall back to a
+# built-in default.
+INSTRUCTOR_SIGNUP_CODE=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ There is no lint or typecheck script; `npm run build` is the type check.
 
 Copy `.env.example` to `.env.local` and fill in your Supabase credentials. Then, in the Supabase SQL editor, run `supabase/schema.sql` followed by `supabase/seed.sql` (the question bank — without it every session start returns 400), and create a **public** Storage bucket named `avatars` for profile images. (README.md's mention of a `myapp_profile` table is stale — the profile table is `"user"`.)
 
+`INSTRUCTOR_SIGNUP_CODE` (the invite code that grants the instructor role at registration, see "Auth flow" below) must be set to a real, random, per-deployment value — generate one yourself (e.g. `openssl rand -base64 24`) and set it only in each deployment's own environment (`.env.local` locally, Vercel Environment Variables in production, etc.). It must never be committed to the repo, in `.env.example` or anywhere else.
+
 `lib/supabase.ts` accepts either `SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_URL` and exposes three factories, each returning `null` when its key is missing so routes can answer 500 instead of a confusing Supabase error:
 
 - `getSupabaseClient()` — service-role key preferred, anon fallback. Used by every data route; it bypasses RLS, which is why those routes must derive `user_id` from the token themselves.
@@ -68,7 +70,7 @@ Session renewal is deliberately two-pronged and there is **no guest/placeholder 
 
 Pages gate on role via `lib/useRequireRole.ts` (`useRequireRole('student' | 'instructor')`, GitHub #82). Callers must return `null` while `!authorized` — the redirect happens in an effect, so rendering early flashes the wrong page. The two roles are asymmetric about a missing profile row (normal right after registration): `'student'` lets it through, `'instructor'` does not and redirects to `/profile`. Treat a page's required role as load-bearing — it's what keeps a student off `/instructor/*` and an instructor out of the quiz-taking flow under `/activities/*`.
 
-Instructor role assignment happens in `app/api/auth/register/route.ts`: a hardcoded `INSTRUCTOR_SIGNUP_CODE` compared **server-side only**, written into the auth user's metadata (the `"user"` profile row doesn't exist until the profile form is submitted, where `app/api/profile/route.ts` reads the role back out).
+Instructor role assignment happens in `app/api/auth/register/route.ts`: the request's `instructorCode` is compared **server-side only** against the `INSTRUCTOR_SIGNUP_CODE` environment variable, written into the auth user's metadata (the `"user"` profile row doesn't exist until the profile form is submitted, where `app/api/profile/route.ts` reads the role back out). `INSTRUCTOR_SIGNUP_CODE` must never be hardcoded or committed (GitHub #280) — an unset, empty, or `CHANGE-ME`-prefixed value makes any instructor signup attempt fail with a 500 rather than silently falling back to a built-in default.
 
 Every protected API route then repeats its own preamble: read `Authorization: Bearer …`, `supabase.auth.getUser(token)`, and derive `user_id` from the result — **never** from the body, query string, or path. The `/api/students/{studentId}/*` routes compare the path param against the token's user and 403 on mismatch (no instructor exception on any of them today).
 

--- a/__tests__/api/auth.test.ts
+++ b/__tests__/api/auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Login runs on the anon-key client, register on the service-role client.
 // The stub lives inside the factory because vi.mock is hoisted to the top of
@@ -36,47 +36,94 @@ vi.mock('../../lib/supabase', () => {
   };
 });
 
+import { getSupabaseAdminClient } from '../../lib/supabase';
 import { POST as registerPost } from '../../app/api/auth/register/route';
 import { POST as loginPost } from '../../app/api/auth/login/route';
 import { POST as refreshPost } from '../../app/api/auth/refresh/route';
 
+// GitHub #280: INSTRUCTOR_SIGNUP_CODE is a real env var now, not a hardcoded literal — tests
+// set/clear it directly rather than importing a shared constant from the route (there isn't
+// one anymore). Saved and restored around every test so one test's value can never leak into
+// the next, regardless of run order.
+const ORIGINAL_INSTRUCTOR_SIGNUP_CODE = process.env.INSTRUCTOR_SIGNUP_CODE;
+
+function registerRequest(body: Record<string, unknown>) {
+  return registerPost(new Request('http://localhost/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }));
+}
+
 describe('Auth API routes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.INSTRUCTOR_SIGNUP_CODE;
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_INSTRUCTOR_SIGNUP_CODE === undefined) delete process.env.INSTRUCTOR_SIGNUP_CODE;
+    else process.env.INSTRUCTOR_SIGNUP_CODE = ORIGINAL_INSTRUCTOR_SIGNUP_CODE;
   });
 
   it('registers a new user as a student by default', async () => {
-    const response = await registerPost(new Request('http://localhost/api/auth/register', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ email: 'new@example.com', password: 'secret123' }),
-    }));
+    const response = await registerRequest({ email: 'new@example.com', password: 'secret123' });
 
     expect(response.status).toBe(201);
     expect(await response.json()).toEqual({ user: { email: 'new@example.com', user_metadata: { role: 'student' } } });
   });
 
-  it('registers as an instructor when the signup code matches', async () => {
-    const response = await registerPost(new Request('http://localhost/api/auth/register', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      // Must match INSTRUCTOR_SIGNUP_CODE in app/api/auth/register/route.ts.
-      body: JSON.stringify({ email: 'prof@example.com', password: 'secret123', instructorCode: 'CHANGE-ME-instructor-2026' }),
-    }));
+  // GitHub #280: a plain student signup (no instructorCode) must not care whether the
+  // instructor invite code is configured at all — only an actual attempt to use one does.
+  it('registers a student successfully even when INSTRUCTOR_SIGNUP_CODE is unset', async () => {
+    expect(process.env.INSTRUCTOR_SIGNUP_CODE).toBeUndefined();
+
+    const response = await registerRequest({ email: 'new2@example.com', password: 'secret123' });
+
+    expect(response.status).toBe(201);
+    expect(await response.json()).toEqual({ user: { email: 'new2@example.com', user_metadata: { role: 'student' } } });
+  });
+
+  it('registers as an instructor when the signup code matches the configured env var', async () => {
+    process.env.INSTRUCTOR_SIGNUP_CODE = 'a-real-random-invite-code';
+
+    const response = await registerRequest({ email: 'prof@example.com', password: 'secret123', instructorCode: 'a-real-random-invite-code' });
 
     expect(response.status).toBe(201);
     expect(await response.json()).toEqual({ user: { email: 'prof@example.com', user_metadata: { role: 'instructor' } } });
   });
 
-  it('falls back to student when the signup code is wrong', async () => {
-    const response = await registerPost(new Request('http://localhost/api/auth/register', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ email: 'imposter@example.com', password: 'secret123', instructorCode: 'wrong-code' }),
-    }));
+  it('falls back to student when the signup code is wrong but the env var is configured', async () => {
+    process.env.INSTRUCTOR_SIGNUP_CODE = 'a-real-random-invite-code';
+
+    const response = await registerRequest({ email: 'imposter@example.com', password: 'secret123', instructorCode: 'wrong-code' });
 
     expect(response.status).toBe(201);
     expect(await response.json()).toEqual({ user: { email: 'imposter@example.com', user_metadata: { role: 'student' } } });
+  });
+
+  // GitHub #280's core fix: a missing INSTRUCTOR_SIGNUP_CODE must reject the instructor signup
+  // attempt outright (500, generic message) rather than silently falling back to any built-in
+  // default or comparing against undefined.
+  it('rejects an instructor signup attempt with a generic 500 when INSTRUCTOR_SIGNUP_CODE is unset', async () => {
+    expect(process.env.INSTRUCTOR_SIGNUP_CODE).toBeUndefined();
+
+    const response = await registerRequest({ email: 'prof2@example.com', password: 'secret123', instructorCode: 'anything' });
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).not.toMatch(/CHANGE-ME|instructor_signup_code/i);
+    // Never reaches Supabase at all — the misconfiguration is caught before any user is created.
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
+  });
+
+  it('rejects an instructor signup attempt when INSTRUCTOR_SIGNUP_CODE is still the leaked placeholder', async () => {
+    process.env.INSTRUCTOR_SIGNUP_CODE = 'CHANGE-ME-instructor-2026';
+
+    const response = await registerRequest({ email: 'prof3@example.com', password: 'secret123', instructorCode: 'CHANGE-ME-instructor-2026' });
+
+    expect(response.status).toBe(500);
+    expect(getSupabaseAdminClient).not.toHaveBeenCalled();
   });
 
   it('returns a 400 error for an existing user', async () => {

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,11 +1,18 @@
 import { getSupabaseAdminClient } from "../../../../lib/supabase";
 
-// GitHub #82: hardcoded rather than an environment variable (team decision — no env changes
-// for this feature). Still compared only ever on the server below, so it's exactly as
-// invisible to the browser as an env var would have been; the trade-off is that rotating it
-// now needs a code change + deploy instead of an env var edit.
-// CHANGE THIS before relying on it for real access control.
-const INSTRUCTOR_SIGNUP_CODE = "CHANGE-ME-instructor-2026";
+// GitHub #280: was a hardcoded literal here (GitHub #82's original "no env changes for this
+// feature" decision) — a real access-control secret sitting in plaintext in version control,
+// rotatable only by a code change + deploy. Read from the environment instead, exactly like
+// every Supabase credential in lib/supabase.ts; see isConfiguredInstructorCode below for what
+// happens when it's missing.
+function isConfiguredInstructorCode(value: string | undefined): value is string {
+  if (!value) return false;
+  const trimmed = value.trim();
+  // Rejects the leaked default (and any other CHANGE-ME-style placeholder someone pastes in)
+  // even if it's somehow set as the env var itself — a safety net behind the "don't hardcode
+  // it" fix, not a replacement for it.
+  return trimmed.length > 0 && !trimmed.toUpperCase().startsWith("CHANGE-ME");
+}
 
 export async function POST(request: Request) {
   try {
@@ -24,12 +31,35 @@ export async function POST(request: Request) {
     }
 
     // GitHub #82: the only check that matters, and it only ever runs here on the server —
-    // correct code grants 'instructor', anything else (wrong code, no code) silently stays
-    // 'student' — cannot be read or bypassed from client-side JavaScript. The role travels in
-    // the auth user's metadata because the "user" profile row (where role actually lives, see
-    // supabase/schema.sql) isn't created until the student fills in the profile form later;
-    // app/api/profile/route.ts reads it back from there at that point.
-    const role = instructorCode === INSTRUCTOR_SIGNUP_CODE ? "instructor" : "student";
+    // correct code grants 'instructor', wrong code silently stays 'student' — cannot be read or
+    // bypassed from client-side JavaScript. The role travels in the auth user's metadata
+    // because the "user" profile row (where role actually lives, see supabase/schema.sql) isn't
+    // created until the student fills in the profile form later; app/api/profile/route.ts reads
+    // it back from there at that point.
+    //
+    // No instructorCode at all is the ordinary student signup path and must not be affected by
+    // whether instructor signup happens to be configured — only an actual attempt to claim the
+    // instructor role (a non-empty instructorCode) needs a configured secret to check it
+    // against. GitHub #280: a missing/placeholder INSTRUCTOR_SIGNUP_CODE must never silently
+    // fall back to granting (or to comparing against) a built-in default — that attempt is
+    // rejected outright instead.
+    let role: "student" | "instructor" = "student";
+
+    if (instructorCode) {
+      const configuredCode = process.env.INSTRUCTOR_SIGNUP_CODE;
+
+      if (!isConfiguredInstructorCode(configuredCode)) {
+        console.error(
+          "INSTRUCTOR_SIGNUP_CODE not configured — rejecting instructor signup attempt.",
+        );
+        return Response.json(
+          { error: "Registration is temporarily unavailable. Please try again later." },
+          { status: 500 },
+        );
+      }
+
+      role = instructorCode === configuredCode ? "instructor" : "student";
+    }
 
     // Registration goes through the admin API, so the service role key is
     // mandatory here — the anon key cannot create users.


### PR DESCRIPTION
Fix: remove hardcoded instructor signup code from source

INSTRUCTOR_SIGNUP_CODE was a plaintext literal in the repo, so any
deployment still running the default was self-registrable as an
instructor by anyone with read access to the code.

Moves the instructor signup invite code out of source and into an environment variable, and fails closed instead of falling back to a built-in default when it's missing.

What changed

app/api/auth/register/route.ts — removed the hardcoded INSTRUCTOR_SIGNUP_CODE constant. The code entered at signup is now compared against process.env.INSTRUCTOR_SIGNUP_CODE, still server-side only. A plain student signup (no invite code) is unaffected either way. An actual instructor-signup attempt, when the env var is unset, empty, or still a CHANGE-ME-style placeholder, is rejected with a generic 500 and a specific server-side log line — never silently compared against a default.
.env.example — added INSTRUCTOR_SIGNUP_CODE= as a documented, valueless placeholder.
CLAUDE.md — documented that this variable is required per-deployment and must never be committed.
__tests__/api/auth.test.ts — replaced the hardcoded-literal test fixtures with process.env.INSTRUCTOR_SIGNUP_CODE set/restored per test; added coverage for the missing-env-var and placeholder-value rejection paths, and confirmed the admin client is never touched when the attempt is rejected.
