### PR TITLE
added mockup for leaderboard part 1

### DIFF
--- a/app/leaderboard/layout.tsx
+++ b/app/leaderboard/layout.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: 'Leaderboard',
+};
+
+export default function LeaderboardLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { AppShell } from '../../components/AppShell';
+import { LeaderboardCourseSwitcher } from '../../components/LeaderboardCourseSwitcher';
+import { LeaderboardSkeleton } from '../../components/LeaderboardSkeleton';
+import { LeaderboardTable, YourPositionStrip } from '../../components/LeaderboardTable';
+import { Pagination } from '../../components/Pagination';
+import { getMockCourses, getMockLeaderboard } from '../../lib/mockLeaderboard';
+import type { LeaderboardEntry } from '../../lib/leaderboardTypes';
+import { useRequireRole } from '../../lib/useRequireRole';
+
+const PAGE_SIZE = 10; // keep in sync with ROW_COUNT in components/LeaderboardSkeleton.tsx
+
+// Phase 1 only: lib/mockLeaderboard.ts answers instantly, so without a delay the skeleton would
+// never render and nobody could tell whether the page jumps when data lands. Delete this along
+// with the mock when the real fetch replaces it.
+const MOCK_LOAD_DELAY_MS = 600;
+
+/**
+ * The course leaderboard: where a student stands against their classmates.
+ *
+ * Phase 1 — the data is hardcoded (lib/mockLeaderboard.ts) and rankChange is part of that mock.
+ * The real version reads GET /api/courses/{courseId}/leaderboard and derives rankChange on the
+ * client from lib/previousRankStore.ts; nothing else on this page should need to change.
+ *
+ * Split into an inner component because useSearchParams() forces the nearest Suspense boundary
+ * to render client-side — without one, `npm run build` fails prerendering this route.
+ */
+function LeaderboardContent() {
+  // Also redirects an instructor account away: a leaderboard ranks students against each other,
+  // which is not a view an instructor account belongs in (same reasoning as /activities).
+  const { profile, loading, authorized } = useRequireRole('student');
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const courses = useMemo(() => getMockCourses(), []);
+  const courseIdParam = searchParams.get('courseId');
+  // An unknown ?courseId= falls back to the first course rather than showing an empty page for
+  // a course the student isn't in — the switcher then re-syncs the URL below.
+  const selectedCourseId =
+    courses.find((course) => course.courseId === courseIdParam)?.courseId ?? courses[0]?.courseId ?? null;
+
+  const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
+  const [page, setPage] = useState(1);
+
+  const studentId = profile?.user_id;
+
+  useEffect(() => {
+    if (!selectedCourseId) {
+      setEntries([]);
+      return;
+    }
+
+    let cancelled = false;
+    setEntries(null);
+    setPage(1);
+
+    const timer = setTimeout(() => {
+      if (!cancelled) setEntries(getMockLeaderboard(selectedCourseId, studentId));
+    }, MOCK_LOAD_DELAY_MS);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [selectedCourseId, studentId]);
+
+  function handleSelectCourse(courseId: string) {
+    router.replace(`/leaderboard?courseId=${encodeURIComponent(courseId)}`, { scroll: false });
+  }
+
+  const rows = entries ?? [];
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageEntries = rows.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const me = rows.find((entry) => entry.studentId === studentId) ?? null;
+  const meOnPage = pageEntries.some((entry) => entry.studentId === studentId);
+
+  // The redirect in useRequireRole runs in an effect, so rendering before it lands would flash
+  // this page at an instructor.
+  if (loading || !authorized) return null;
+
+  return (
+    <AppShell active="leaderboard">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">Leaderboard</h1>
+        <p className="mb-6 text-sm font-semibold text-gray-500">
+          Ranked by cumulative score — your best result at each difficulty level of every activity,
+          added up.
+        </p>
+
+        {courses.length === 0 ? (
+          <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-8 text-center">
+            <p className="text-sm font-bold text-brand-navy">You&apos;re not in a course yet.</p>
+            <p className="mt-1.5 text-sm font-semibold text-gray-500">
+              A leaderboard ranks you against your classmates, so it needs a course first.
+            </p>
+            <Link
+              href="/courses"
+              className="mt-4 inline-flex rounded-brand-md bg-brand-purple px-4 py-2 text-sm font-extrabold text-white hover:bg-brand-purple-dark"
+            >
+              Browse courses
+            </Link>
+          </div>
+        ) : (
+          <>
+            <LeaderboardCourseSwitcher
+              courses={courses}
+              selectedCourseId={selectedCourseId}
+              onSelect={handleSelectCourse}
+            />
+
+            {entries === null ? (
+              <LeaderboardSkeleton />
+            ) : (
+              <>
+                <LeaderboardTable entries={pageEntries} currentStudentId={studentId} />
+
+                {me && !meOnPage ? <YourPositionStrip entry={me} /> : null}
+
+                <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+                  <span className="text-xs font-semibold text-gray-500">
+                    {rows.length === 0
+                      ? '0 students'
+                      : `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(currentPage * PAGE_SIZE, rows.length)} of ${rows.length} students`}
+                  </span>
+
+                  <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setPage} />
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}
+
+export default function LeaderboardPage() {
+  return (
+    <Suspense fallback={null}>
+      <LeaderboardContent />
+    </Suspense>
+  );
+}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -4,8 +4,8 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { getHighestTitleOverall } from '../lib/activityStore';
-import { getInitials } from '../lib/initials';
 import { loadStudentScore } from '../lib/sessionClient';
+import { Avatar } from './Avatar';
 import { LLMProviderSettingsModal } from './LLMProviderSettingsModal';
 import { useUser } from './UserProvider';
 
@@ -13,6 +13,7 @@ type NavKey =
   | 'dashboard'
   | 'activities'
   | 'courses'
+  | 'leaderboard'
   | 'profile'
   | 'instructor'
   | 'instructor-questions'
@@ -22,10 +23,15 @@ type NavKey =
 // GitHub #242 (UI-2): 'courses' here is the student-facing browse/join page (app/courses/page.tsx)
 // — a distinct NavKey/route from the instructor's 'instructor-courses' (create/manage), same
 // split as every other instructor-vs-student pair in this sidebar.
+//
+// 'leaderboard' is student-only and has no instructor counterpart: it ranks a course's students
+// against each other, which is not a view an instructor account has a place in. It sits next to
+// 'courses' because it is scoped to one course at a time.
 const STUDENT_NAV_ITEMS: { key: NavKey; label: string; href: string }[] = [
   { key: 'dashboard', label: 'Dashboard', href: '/dashboard' },
   { key: 'activities', label: 'Activities', href: '/activities' },
   { key: 'courses', label: 'Courses', href: '/courses' },
+  { key: 'leaderboard', label: 'Leaderboard', href: '/leaderboard' },
   { key: 'profile', label: 'Profile', href: '/profile' },
 ];
 
@@ -108,6 +114,18 @@ function GraduationCapIcon() {
   );
 }
 
+function TrophyIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M8 4h8v6a4 4 0 0 1-8 0V4Z" />
+      <path d="M8 6H5v1.5A3.5 3.5 0 0 0 8.5 11" />
+      <path d="M16 6h3v1.5a3.5 3.5 0 0 1-3.5 3.5" />
+      <path d="M12 14v4" />
+      <path d="M9 21h6" />
+    </svg>
+  );
+}
+
 function GearIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2}>
@@ -147,6 +165,7 @@ const NAV_ICONS: Record<NavKey, () => JSX.Element> = {
   dashboard: GridIcon,
   activities: ListIcon,
   courses: GraduationCapIcon,
+  leaderboard: TrophyIcon,
   profile: UserIcon,
   instructor: UsersIcon,
   'instructor-courses': GraduationCapIcon,
@@ -257,17 +276,18 @@ export function AppShell({
             covering both "still fetching" and "authenticated but no profile row yet", neither
             of which should imply an unauthenticated fallback identity.
           */}
-          <div
-            className={`mx-auto mb-2 flex h-16 w-16 items-center justify-center overflow-hidden rounded-full border-[3px] border-brand-gold bg-brand-navy-2 font-extrabold text-brand-gold transition-opacity duration-300 ${
+          {/* Passing no name at all while the profile is loading is what keeps the circle empty:
+              Avatar only falls back to initials when it has something to build them from. */}
+          <Avatar
+            avatarUrl={profile?.avatar_url}
+            firstName={profile?.first_name}
+            lastName={profile?.last_name}
+            fallbackName={profile?.username}
+            size="lg"
+            className={`mx-auto mb-2 transition-opacity duration-300 ${
               profile ? 'opacity-100' : 'animate-pulse opacity-60'
             }`}
-          >
-            {profile?.avatar_url ? (
-              <img src={profile.avatar_url} alt="" className="h-full w-full object-cover" />
-            ) : profile ? (
-              <span>{getInitials(profile.first_name, profile.last_name, profile.username)}</span>
-            ) : null}
-          </div>
+          />
           <div
             className={`text-sm font-extrabold text-white transition-opacity duration-300 ${profile ? 'opacity-100' : 'opacity-0'}`}
           >

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -1,0 +1,57 @@
+import { getInitials } from '../lib/initials';
+
+/**
+ * The round avatar-or-initials circle used on the app's dark surfaces. Extracted because the
+ * same markup had already been copy-pasted into AppShell.tsx and StudentDetailHeader.tsx, and
+ * the leaderboard would have been a third copy.
+ *
+ * Deliberately NOT used by app/profile/page.tsx: that one is a <button> wrapping an upload flow
+ * with a hover overlay and a light-surface border, not a display avatar — folding it in here
+ * would mean a `tone` prop plus an `as` prop to serve one call site.
+ *
+ * Sizes are a fixed set rather than a free className so the call sites can't drift back into
+ * three slightly different circles. className is still open for per-site extras (AppShell's
+ * loading pulse), not for overriding the shape.
+ */
+const SIZES = {
+  sm: 'h-9 w-9 text-[11px] border-2',
+  md: 'h-14 w-14 text-lg border-[3px]',
+  lg: 'h-16 w-16 text-base border-[3px]',
+} as const;
+
+export function Avatar({
+  avatarUrl,
+  firstName,
+  lastName,
+  fallbackName,
+  size = 'md',
+  className = '',
+}: {
+  avatarUrl?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  /** Used for initials when first/last name aren't available — typically the username. */
+  fallbackName?: string | null;
+  size?: keyof typeof SIZES;
+  className?: string;
+}) {
+  // With no url and no name at all, the circle stays empty rather than falling back to
+  // getInitials' "?" placeholder. That is what lets AppShell render this while the profile is
+  // still loading: its comment there is explicit that there must be no guest/"?" identity, and
+  // an empty circle reads the same as the loading state it already had.
+  const hasName = Boolean(firstName || lastName || fallbackName);
+
+  return (
+    <span
+      className={`flex flex-none items-center justify-center overflow-hidden rounded-full border-brand-gold bg-brand-navy-2 font-extrabold text-brand-gold ${SIZES[size]} ${className}`}
+    >
+      {avatarUrl ? (
+        // alt="" — the username is always rendered next to the avatar, so announcing it twice
+        // would just be noise for a screen reader.
+        <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
+      ) : hasName ? (
+        <span>{getInitials(firstName, lastName, fallbackName)}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/components/LeaderboardCourseSwitcher.tsx
+++ b/components/LeaderboardCourseSwitcher.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import type { LeaderboardCourse } from '../lib/leaderboardTypes';
+
+// Above this many courses the pill row wraps into an unreadable block, so it becomes a select.
+// Same threshold reasoning as ActivityFilters' choice of control per filter.
+const MAX_PILLS = 4;
+
+/**
+ * Picks which course's ranking is shown. The selection lives in the URL (?courseId=), not in
+ * component state — the page owns that, this component only reports the change — so a
+ * leaderboard view stays linkable and survives a reload.
+ */
+export function LeaderboardCourseSwitcher({
+  courses,
+  selectedCourseId,
+  onSelect,
+}: {
+  courses: LeaderboardCourse[];
+  selectedCourseId: string | null;
+  onSelect: (courseId: string) => void;
+}) {
+  // One course is not a choice — the heading already says which one it is.
+  if (courses.length <= 1) return null;
+
+  if (courses.length > MAX_PILLS) {
+    return (
+      <label className="mb-5 block">
+        <span className="mb-1.5 block text-xs font-bold uppercase tracking-wide text-gray-500">Course</span>
+        <select
+          value={selectedCourseId ?? ''}
+          onChange={(event) => onSelect(event.target.value)}
+          className="w-full max-w-xs rounded-brand-md border border-gray-300 bg-white px-3 py-2 text-sm font-bold text-brand-navy focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-purple"
+        >
+          {courses.map((course) => (
+            <option key={course.courseId} value={course.courseId}>
+              {course.courseName}
+            </option>
+          ))}
+        </select>
+      </label>
+    );
+  }
+
+  return (
+    <div className="mb-5 flex flex-wrap gap-2" role="group" aria-label="Course">
+      {courses.map((course) => {
+        const isSelected = course.courseId === selectedCourseId;
+        return (
+          <button
+            key={course.courseId}
+            type="button"
+            onClick={() => onSelect(course.courseId)}
+            aria-pressed={isSelected}
+            className={`rounded-full border px-3.5 py-1.5 text-xs font-extrabold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-purple ${
+              isSelected
+                ? 'border-brand-purple bg-brand-purple text-white'
+                : 'border-gray-300 bg-white text-gray-600 hover:border-brand-purple hover:text-brand-purple'
+            }`}
+          >
+            {course.courseName}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/components/LeaderboardSkeleton.tsx
+++ b/components/LeaderboardSkeleton.tsx
@@ -1,0 +1,67 @@
+const ROW_COUNT = 10; // matches PAGE_SIZE in app/leaderboard/page.tsx
+
+/**
+ * Loading placeholder for the leaderboard table, mirroring its real row height and column widths
+ * so the page doesn't jump when the data lands — same job as MasteryProgressSkeleton and
+ * ActivityCardSkeleton do for their sections.
+ *
+ * Light-on-dark shimmer, unlike those two: this skeleton stands in for a table on brand-navy-2,
+ * not for tiles on the white <main>, so the dark-on-light gradient they use would be invisible.
+ */
+export function LeaderboardSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Loading leaderboard"
+      className="overflow-hidden rounded-brand-lg border border-brand-navy-border"
+    >
+      <div className="flex items-center gap-4 bg-brand-navy px-4 py-3">
+        <span className="skeleton-block h-3 w-10 rounded-full" />
+        <span className="skeleton-block h-3 w-9 rounded-full" />
+        <span className="skeleton-block h-3 w-20 rounded-full" />
+        <span className="skeleton-block ml-auto h-3 w-14 rounded-full" />
+        <span className="skeleton-block h-3 w-14 rounded-full" />
+      </div>
+
+      {Array.from({ length: ROW_COUNT }, (_, row) => (
+        <div
+          key={row}
+          className="flex items-center gap-4 border-t border-brand-navy-border bg-brand-navy-2 px-4 py-3.5"
+        >
+          <span className="skeleton-block h-8 w-8 flex-none rounded-full" />
+          <span className="skeleton-block h-9 w-9 flex-none rounded-full" />
+          <span className="skeleton-block h-3.5 w-28 rounded-full" />
+          <span className="skeleton-block ml-auto h-3.5 w-12 rounded-full" />
+          <span className="skeleton-block h-3.5 w-8 rounded-full" />
+        </div>
+      ))}
+
+      <style jsx>{`
+        .skeleton-block {
+          background: linear-gradient(
+            90deg,
+            rgba(255, 255, 255, 0.06) 25%,
+            rgba(255, 255, 255, 0.14) 37%,
+            rgba(255, 255, 255, 0.06) 63%
+          );
+          background-size: 400% 100%;
+          animation: skeleton-shimmer 1.6s ease-in-out infinite;
+        }
+        @keyframes skeleton-shimmer {
+          0% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .skeleton-block {
+            animation: none;
+            background: rgba(255, 255, 255, 0.09);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/components/LeaderboardTable.tsx
+++ b/components/LeaderboardTable.tsx
@@ -1,0 +1,142 @@
+import Link from 'next/link';
+import { Avatar } from './Avatar';
+import { RankChangeIndicator } from './RankChangeIndicator';
+import type { LeaderboardEntry } from '../lib/leaderboardTypes';
+
+// The photo column has no header — a label above a 36px circle is noise, and the username
+// beside it already names the row.
+const COLUMNS = ['Rank', '', 'Username', 'Points', 'Change'];
+
+// CLAUDE.md reserves brand-gold for "rewards/XP/achievements", which is exactly the podium.
+// Silver has no token, so second place borrows the muted ink; third takes teal rather than an
+// invented bronze — adding a one-off hex here would be the first violation of the token rule.
+const RANK_CLASSES: Record<number, string> = {
+  1: 'bg-brand-gold/25 text-brand-gold',
+  2: 'bg-brand-ink-muted/25 text-brand-ink',
+  3: 'bg-brand-teal/20 text-brand-teal',
+};
+
+const RANK_DEFAULT = 'text-brand-ink-muted';
+
+/**
+ * One row. Exported so the "Your position" strip below the table and the dashboard preview can
+ * render the identical cells rather than re-implementing them — the two views disagreeing about
+ * what a rank or a point total looks like is exactly the drift ActivityLogRow avoids by being
+ * shared between the log page and the dashboard.
+ */
+export function LeaderboardRow({
+  entry,
+  isCurrentUser,
+}: {
+  entry: LeaderboardEntry;
+  isCurrentUser: boolean;
+}) {
+  return (
+    <tr
+      className={`border-t border-brand-navy-border text-brand-ink ${
+        isCurrentUser ? 'bg-brand-purple/15' : 'bg-brand-navy-2'
+      }`}
+    >
+      <td className={`py-3.5 pr-2 ${isCurrentUser ? 'border-l-4 border-l-brand-purple pl-3' : 'pl-4'}`}>
+        <span
+          className={`inline-flex h-8 min-w-8 items-center justify-center rounded-full px-2 text-xs font-extrabold tabular-nums ${
+            RANK_CLASSES[entry.rank] ?? RANK_DEFAULT
+          }`}
+        >
+          {entry.rank}
+        </span>
+      </td>
+      <td className="py-3.5 pl-1 pr-2">
+        <Avatar avatarUrl={entry.avatarUrl} fallbackName={entry.username} size="sm" />
+      </td>
+      <td className="px-4 py-3.5">
+        <Link
+          href={`/students/${encodeURIComponent(entry.studentId)}`}
+          className="font-extrabold text-white underline-offset-2 hover:text-brand-purple hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-teal"
+        >
+          {entry.username}
+        </Link>
+        {isCurrentUser ? <span className="ml-2 text-xs font-extrabold text-brand-purple">You</span> : null}
+      </td>
+      <td className="whitespace-nowrap px-4 py-3.5 font-bold tabular-nums">{entry.points.toLocaleString()}</td>
+      <td className="px-4 py-3.5">
+        <RankChangeIndicator change={entry.rankChange} />
+      </td>
+    </tr>
+  );
+}
+
+/**
+ * The course leaderboard: rank, photo, username, points, and how far the student moved since
+ * they last looked. Same dark-table shell as ActivityLogTable so the two read as one system.
+ *
+ * currentStudentId is what makes a row "yours" — passing it is what renders the purple accent
+ * and the "You" tag. Omitted (e.g. before the profile has loaded) simply means no row is marked.
+ */
+export function LeaderboardTable({
+  entries,
+  currentStudentId,
+}: {
+  entries: LeaderboardEntry[];
+  currentStudentId?: string;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-brand-lg border border-brand-navy-border">
+      <table className="w-full min-w-[560px] text-sm">
+        <thead>
+          <tr className="bg-brand-navy text-brand-ink-muted">
+            {COLUMNS.map((column, index) => (
+              <th
+                key={column || `col-${index}`}
+                className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide"
+              >
+                {column}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {entries.length === 0 ? (
+            <tr>
+              <td
+                colSpan={COLUMNS.length}
+                className="bg-brand-navy-2 px-4 py-10 text-center text-sm font-semibold text-brand-ink-muted"
+              >
+                No one in this course has completed an activity yet.
+              </td>
+            </tr>
+          ) : (
+            entries.map((entry) => (
+              <LeaderboardRow
+                key={entry.studentId}
+                entry={entry}
+                isCurrentUser={entry.studentId === currentStudentId}
+              />
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/**
+ * The signed-in student's own row, repeated below the table when they are not on the page being
+ * viewed. A sticky row inside the table would have to fight the overflow-x-auto wrapper for its
+ * positioning context; a separate strip gets the same "I can always see where I stand" without
+ * that, and reuses LeaderboardRow so the cells cannot drift.
+ */
+export function YourPositionStrip({ entry }: { entry: LeaderboardEntry }) {
+  return (
+    <div className="mt-3 overflow-x-auto rounded-brand-lg border border-brand-purple/50">
+      <table className="w-full min-w-[560px] text-sm">
+        <caption className="bg-brand-navy px-4 py-2 text-left text-xs font-bold uppercase tracking-wide text-brand-ink-muted">
+          Your position
+        </caption>
+        <tbody>
+          <LeaderboardRow entry={entry} isCurrentUser />
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/components/RankChangeIndicator.tsx
+++ b/components/RankChangeIndicator.tsx
@@ -1,0 +1,60 @@
+import type { LeaderboardEntry } from '../lib/leaderboardTypes';
+
+function ArrowIcon({ direction }: { direction: 'up' | 'down' }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className="h-3.5 w-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {direction === 'up' ? <path d="M12 19V5M5 12l7-7 7 7" /> : <path d="M12 5v14M5 12l7 7 7-7" />}
+    </svg>
+  );
+}
+
+/**
+ * How many ranks a student moved since they last looked at this leaderboard.
+ *
+ * Four states, not three: null is "no previous ranking on record" (first visit, or the store was
+ * cleared on logout) and is deliberately rendered the same as "unchanged" rather than as a fake
+ * zero — the difference is in the tooltip and the screen-reader text, since a grey dash is the
+ * honest visual for both "you didn't move" and "we don't know yet".
+ *
+ * The arrow itself is aria-hidden; the sr-only text is what a screen reader announces, because
+ * "▲ 3" on its own says nothing about direction out loud.
+ */
+export function RankChangeIndicator({ change }: { change: LeaderboardEntry['rankChange'] }) {
+  if (change === null || change === 0) {
+    const label = change === null ? 'No previous ranking yet' : 'Unchanged';
+    return (
+      <span className="inline-flex items-center text-brand-ink-muted" title={label}>
+        <span aria-hidden="true" className="text-sm font-extrabold">
+          –
+        </span>
+        <span className="sr-only">{label}</span>
+      </span>
+    );
+  }
+
+  const movedUp = change > 0;
+  const places = Math.abs(change);
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-xs font-extrabold tabular-nums ${
+        movedUp ? 'text-brand-green' : 'text-brand-danger'
+      }`}
+    >
+      <ArrowIcon direction={movedUp ? 'up' : 'down'} />
+      <span aria-hidden="true">{places}</span>
+      <span className="sr-only">
+        {movedUp ? 'Up' : 'Down'} {places} {places === 1 ? 'rank' : 'ranks'}
+      </span>
+    </span>
+  );
+}

--- a/components/StudentDetailHeader.tsx
+++ b/components/StudentDetailHeader.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { getInitials } from '../lib/initials';
+import { Avatar } from './Avatar';
 
 /** GitHub #127: header for the student detail page — name, avatar, "Needs attention" badge, back link. */
 export function StudentDetailHeader({
@@ -19,9 +19,9 @@ export function StudentDetailHeader({
 
       <div className="mb-7 flex flex-wrap items-start justify-between gap-4">
         <div className="flex items-center gap-3.5">
-          <div className="flex h-14 w-14 flex-none items-center justify-center rounded-full border-[3px] border-brand-gold bg-brand-navy-2 text-lg font-extrabold text-brand-gold">
-            {getInitials(null, null, studentName)}
-          </div>
+          {/* No avatarUrl to pass: this page's data is still lib/mockStudentAttempts.ts, which
+              carries no photo — initials only, exactly as before. */}
+          <Avatar fallbackName={studentName} size="md" />
           <div>
             <div className="flex flex-wrap items-center gap-2.5">
               <h1 className="text-2xl font-extrabold text-brand-navy">{studentName}</h1>

--- a/lib/leaderboardTypes.ts
+++ b/lib/leaderboardTypes.ts
@@ -1,0 +1,38 @@
+// Row shapes for the course leaderboard, shared by the UI and — once the real route exists —
+// by GET /api/courses/{courseId}/leaderboard. Imports nothing, so a server route can use these
+// without pulling in a 'use client' module; same reason lib/sessionTypes.ts is its own file.
+//
+// No REQ id to cite yet: docs/requirements/requirements.md has no leaderboard requirement at all
+// (its gamification chapter is entirely single-player, and line 207 argues against making the app
+// feel like a game). Proposed ids once the spec catches up: REQ-GAM-DL-3 / BL-2 / PL-3.
+
+/** One student's line in a course leaderboard, already ranked by the server. */
+export type LeaderboardEntry = {
+  /**
+   * Standard competition ranking: ties share a rank and the next rank skips (1, 2, 2, 4).
+   * Assigned server-side so the client never re-ranks and two requests can't disagree
+   * about who is second.
+   */
+  rank: number;
+  studentId: string;
+  username: string;
+  /** Public Supabase Storage URL from "user".avatar_url, or null — render initials instead. */
+  avatarUrl: string | null;
+  /** Cumulative score, same definition as computeStudentScore (lib/scoreQueries.ts). */
+  points: number;
+  /**
+   * Ranks gained since this student last viewed the leaderboard: positive = moved up,
+   * negative = moved down, 0 = unchanged, null = no previous ranking on record.
+   *
+   * Derived on the client from lib/previousRankStore.ts, not from the server — there is no
+   * historical snapshot in the database. It therefore means "since your last visit on this
+   * device", not "since yesterday". See that store's header for the limits.
+   */
+  rankChange: number | null;
+};
+
+/** A course the signed-in student can view a leaderboard for. */
+export type LeaderboardCourse = {
+  courseId: string;
+  courseName: string;
+};

--- a/lib/mockLeaderboard.ts
+++ b/lib/mockLeaderboard.ts
@@ -1,0 +1,93 @@
+// Hardcoded leaderboard data for the Phase-1 UI. This is the ONLY fake data source behind
+// /leaderboard, the dashboard preview and /students/[id], so replacing it with the real
+// GET /api/courses/{courseId}/leaderboard is a single-import swap.
+//
+// DELETE THIS FILE once that route lands. lib/mockStudentAttempts.ts is the cautionary tale:
+// it still drives app/instructor/students/[id]/page.tsx with fabricated data long after the
+// feature was "done", and nothing in the UI admits it.
+//
+// What a real endpoint has to return for the UI to keep working unchanged:
+//   LeaderboardEntry[], already sorted by rank ascending, with standard competition ranking on
+//   ties (1, 2, 2, 4) and a deterministic secondary sort (username) so two requests can't
+//   disagree about who is second. rankChange is NOT part of the response — the client derives it
+//   from lib/previousRankStore.ts and overwrites whatever is here.
+//
+// The rows below deliberately cover every case the UI has to render: a two-way tie, students
+// with and without an avatar, all four rankChange states (up / down / unchanged / unknown),
+// a zero-point student who is enrolled but has never finished an activity, and enough rows to
+// force a second page.
+
+import type { LeaderboardCourse, LeaderboardEntry } from './leaderboardTypes';
+
+/**
+ * A tiny inline SVG avatar, so the <img> branch is actually exercised offline — real avatars are
+ * public Supabase Storage URLs (see app/api/profile/avatar/route.ts) which don't exist in a
+ * fresh dev database.
+ */
+function mockAvatar(background: string, initials: string): string {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="${background}"/><text x="32" y="42" font-family="Arial" font-size="26" font-weight="bold" fill="#ffffff" text-anchor="middle">${initials}</text></svg>`;
+  return `data:image/svg+xml;utf8,${encodeURIComponent(svg)}`;
+}
+
+const REQUIREMENTS_ENGINEERING: LeaderboardEntry[] = [
+  { rank: 1, studentId: 'mock-stu-01', username: 'mkellner', avatarUrl: mockAvatar('#7c4dff', 'MK'), points: 1450, rankChange: 2 },
+  { rank: 2, studentId: 'mock-stu-02', username: 'anne_b', avatarUrl: null, points: 1320, rankChange: -1 },
+  { rank: 3, studentId: 'mock-stu-03', username: 'philipp', avatarUrl: mockAvatar('#2dd4bf', 'PH'), points: 1180, rankChange: 0 },
+  // Two-way tie: same points, same rank, and rank 5 is skipped.
+  { rank: 4, studentId: 'mock-stu-04', username: 'brockenbrough', avatarUrl: null, points: 1050, rankChange: 5 },
+  { rank: 4, studentId: 'mock-stu-05', username: 'jvandermeer', avatarUrl: mockAvatar('#ffd666', 'JV'), points: 1050, rankChange: null },
+  { rank: 6, studentId: 'mock-stu-06', username: 'sofia_r', avatarUrl: null, points: 980, rankChange: -3 },
+  { rank: 7, studentId: 'mock-stu-07', username: 'tobias.w', avatarUrl: null, points: 910, rankChange: 1 },
+  { rank: 8, studentId: 'mock-stu-08', username: 'nadia_k', avatarUrl: mockAvatar('#4ade80', 'NK'), points: 870, rankChange: 0 },
+  { rank: 9, studentId: 'mock-stu-09', username: 'lars', avatarUrl: null, points: 720, rankChange: -2 },
+  { rank: 10, studentId: 'mock-stu-10', username: 'emilia_h', avatarUrl: null, points: 690, rankChange: null },
+  // From here on it is page 2 at PAGE_SIZE 10 — the signed-in student sits down here on purpose,
+  // so the "Your position" strip under the table is visible on first load.
+  { rank: 11, studentId: 'mock-stu-11', username: 'dmitri_s', avatarUrl: null, points: 540, rankChange: 4 },
+  { rank: 12, studentId: 'mock-stu-12', username: 'you', avatarUrl: null, points: 410, rankChange: -6 },
+  { rank: 13, studentId: 'mock-stu-13', username: 'carla_m', avatarUrl: null, points: 275, rankChange: 0 },
+  // Enrolled but has never completed an activity. The real query must include this student
+  // (roster from student_course, not from who has attempted something) rather than hide them.
+  { rank: 14, studentId: 'mock-stu-14', username: 'newcomer', avatarUrl: null, points: 0, rankChange: null },
+];
+
+const SOFTWARE_ARCHITECTURE: LeaderboardEntry[] = [
+  { rank: 1, studentId: 'mock-stu-06', username: 'sofia_r', avatarUrl: null, points: 620, rankChange: 3 },
+  { rank: 2, studentId: 'mock-stu-12', username: 'you', avatarUrl: null, points: 480, rankChange: 1 },
+  { rank: 3, studentId: 'mock-stu-01', username: 'mkellner', avatarUrl: mockAvatar('#7c4dff', 'MK'), points: 300, rankChange: -2 },
+];
+
+/** A course with a roster but no completed activity yet — exercises the table's empty state. */
+const EMPTY_COURSE: LeaderboardEntry[] = [];
+
+const BY_COURSE: Record<string, LeaderboardEntry[]> = {
+  'mock-course-re': REQUIREMENTS_ENGINEERING,
+  'mock-course-sa': SOFTWARE_ARCHITECTURE,
+  'mock-course-empty': EMPTY_COURSE,
+};
+
+/** The courses the signed-in student is enrolled in. Real source later: lib/studentCourseClient.ts. */
+export function getMockCourses(): LeaderboardCourse[] {
+  return [
+    { courseId: 'mock-course-re', courseName: 'Requirements Engineering' },
+    { courseId: 'mock-course-sa', courseName: 'Software Architecture' },
+    { courseId: 'mock-course-empty', courseName: 'Testing & QA' },
+  ];
+}
+
+/**
+ * One course's ranking.
+ *
+ * currentStudentId is a mock-only affordance: the signed-in account's real Supabase uuid can
+ * never match a hardcoded id, so without it the "You" highlight and the "Your position" strip
+ * would be unreachable in Phase 1. It rewrites the placeholder row's id to the real one. The
+ * API-backed version takes no such parameter — the server returns real ids that already match.
+ */
+export function getMockLeaderboard(courseId: string, currentStudentId?: string): LeaderboardEntry[] {
+  const entries = BY_COURSE[courseId] ?? [];
+  if (!currentStudentId) return entries;
+
+  return entries.map((entry) =>
+    entry.studentId === 'mock-stu-12' ? { ...entry, studentId: currentStudentId } : entry,
+  );
+}


### PR DESCRIPTION
resolve issue #299

Add the course leaderboard as a UI mockup with hardcoded data.

New /leaderboard page, student-only (instructors are redirected away and
get no nav entry). The table shows rank, photo, username, points and how
many ranks the student moved since their last visit, with the username
linking to that student's profile. Ranks 1-3 use the gold/podium
treatment; the signed-in student's own row is highlighted, and repeats
below the table as a "Your position" strip when they are not on the page
being viewed.

Supporting pieces:
- RankChangeIndicator: green up / red down / grey unchanged, plus a
  fourth state for "no previous ranking on record", which is rendered
  like unchanged but reads differently to a screen reader.
- Avatar: extracted from AppShell and StudentDetailHeader, which had the
  same circle-with-initials markup copy-pasted. The profile page's
  version is deliberately left alone - it is an upload button with a
  hover overlay, not a display avatar.
- Course switcher, keeping the selection in ?courseId= so a view stays
  linkable, plus pagination and a loading skeleton.

All data comes from lib/mockLeaderboard.ts. No API route, no query, no
schema change - the rows there cover every case the UI has to render
(a tie, students with and without a photo, all four rank-change states,
a zero-point student, and enough rows for a second page). That file is
to be deleted once GET /api/courses/{courseId}/leaderboard exists; its
header documents the shape that route has to return.

Note the username links point at /students/[id], which does not exist
yet and currently 404s - that page is the next story.