### PR TITLE
edited Mockup for leaderboard

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { AppShell } from "../../components/AppShell";
 import { ActivityLogRow } from "../../components/ActivityLogRow";
+import { LeaderboardPreview } from "../../components/LeaderboardPreview";
 import { ACTIVITIES, Difficulty } from "../../lib/activityContent";
 import { toActivityLogEntry } from "../../lib/activityLogTypes";
 import { ActivityState, getActivityState } from "../../lib/activityStore";
@@ -248,6 +249,8 @@ export default function DashboardPage() {
           </Link>
         </div>
       )}
+
+      <LeaderboardPreview studentId={profile?.user_id} />
 
       <h3 className="mb-4 text-lg font-extrabold text-[#1B1642]">
         Mastery titles

--- a/components/LeaderboardPreview.tsx
+++ b/components/LeaderboardPreview.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import Link from 'next/link';
+import { useMemo } from 'react';
+import { Avatar } from './Avatar';
+import { LeaderboardRankBadge } from './LeaderboardRankBadge';
+import { RankChangeIndicator } from './RankChangeIndicator';
+import { getMockCourses, getMockLeaderboard } from '../lib/mockLeaderboard';
+import type { LeaderboardEntry } from '../lib/leaderboardTypes';
+
+const TOP_COUNT = 5;
+
+function PreviewRow({ entry, isCurrentUser }: { entry: LeaderboardEntry; isCurrentUser: boolean }) {
+  return (
+    <div
+      className={`flex items-center gap-3 rounded-brand-md px-2 py-2 ${
+        isCurrentUser ? 'bg-brand-purple/20' : ''
+      }`}
+    >
+      <LeaderboardRankBadge rank={entry.rank} />
+      <Avatar avatarUrl={entry.avatarUrl} fallbackName={entry.username} size="sm" />
+      <Link
+        href={`/students/${encodeURIComponent(entry.studentId)}`}
+        className="min-w-0 flex-1 truncate text-sm font-extrabold text-white underline-offset-2 hover:text-brand-purple hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-teal"
+      >
+        {entry.username}
+        {isCurrentUser ? <span className="ml-2 text-xs font-extrabold text-brand-purple">You</span> : null}
+      </Link>
+      <span className="whitespace-nowrap text-sm font-bold tabular-nums text-brand-ink">
+        {entry.points.toLocaleString()}
+      </span>
+      <span className="w-10 flex-none text-right">
+        <RankChangeIndicator change={entry.rankChange} />
+      </span>
+    </div>
+  );
+}
+
+/**
+ * The dashboard's glance at the course leaderboard: the top five, plus the student's own row
+ * appended when they didn't make it, so the panel always answers "where am I?" without a click.
+ *
+ * Deliberately not LeaderboardTable at a smaller size. This sits in a ~600px dashboard column
+ * next to the mastery cards, where five table columns with headers would be cramped; a stacked
+ * flex row reads better at that width. What the two views DO share is every piece that carries
+ * meaning — LeaderboardRankBadge, Avatar and RankChangeIndicator — so the podium colours, the
+ * initials fallback and the arrow semantics cannot drift between them. Only the layout differs.
+ *
+ * Phase 1: reads lib/mockLeaderboard.ts synchronously, and picks the student's first course
+ * because a "primary course" doesn't exist yet. The real version fetches
+ * GET /api/courses/{courseId}/leaderboard and will need an answer for which course a student
+ * enrolled in several should see here — likely their most recently active one.
+ */
+export function LeaderboardPreview({ studentId }: { studentId?: string }) {
+  const course = useMemo(() => getMockCourses()[0] ?? null, []);
+  const entries = useMemo(
+    () => (course ? getMockLeaderboard(course.courseId, studentId) : []),
+    [course, studentId],
+  );
+
+  const top = entries.slice(0, TOP_COUNT);
+  const me = entries.find((entry) => entry.studentId === studentId) ?? null;
+  const meInTop = top.some((entry) => entry.studentId === studentId);
+
+  return (
+    <section className="mb-7 rounded-brand-lg bg-brand-navy p-6 text-brand-ink">
+      <div className="mb-4 flex flex-wrap items-baseline justify-between gap-2">
+        <h3 className="text-xl font-extrabold text-white">Leaderboard</h3>
+        {course ? (
+          <span className="text-xs font-bold uppercase tracking-wide text-brand-ink-muted">
+            {course.courseName}
+          </span>
+        ) : null}
+      </div>
+
+      {!course ? (
+        <p className="mb-4 text-sm font-semibold text-brand-ink-muted">
+          Join a course to see how you compare with your classmates.
+        </p>
+      ) : entries.length === 0 ? (
+        <p className="mb-4 text-sm font-semibold text-brand-ink-muted">
+          No one in this course has completed an activity yet — be the first.
+        </p>
+      ) : (
+        <div className="mb-4">
+          {top.map((entry) => (
+            <PreviewRow
+              key={entry.studentId}
+              entry={entry}
+              isCurrentUser={entry.studentId === studentId}
+            />
+          ))}
+
+          {/* Only when the student is outside the top five. The ellipsis makes the jump in rank
+              explicit, so an appended row can't be misread as sixth place. */}
+          {me && !meInTop ? (
+            <>
+              <div aria-hidden="true" className="px-2 py-1 text-center text-xs font-bold text-brand-ink-muted">
+                ⋯
+              </div>
+              <PreviewRow entry={me} isCurrentUser />
+            </>
+          ) : null}
+        </div>
+      )}
+
+      <Link
+        href={course ? `/leaderboard?courseId=${encodeURIComponent(course.courseId)}` : '/courses'}
+        className="block w-full rounded-brand-md border border-brand-teal py-2.5 text-center text-sm font-extrabold text-brand-teal transition hover:bg-brand-teal/10"
+      >
+        {course ? 'View full leaderboard →' : 'Browse courses'}
+      </Link>
+    </section>
+  );
+}

--- a/components/LeaderboardRankBadge.tsx
+++ b/components/LeaderboardRankBadge.tsx
@@ -1,0 +1,30 @@
+// CLAUDE.md reserves brand-gold for "rewards/XP/achievements", which is exactly the podium.
+// Silver has no token, so second place borrows the muted ink; third takes teal rather than an
+// invented bronze — a one-off hex here would be the first break in the token rule.
+const RANK_CLASSES: Record<number, string> = {
+  1: 'bg-brand-gold/25 text-brand-gold',
+  2: 'bg-brand-ink-muted/25 text-brand-ink',
+  3: 'bg-brand-teal/20 text-brand-teal',
+};
+
+const RANK_DEFAULT = 'text-brand-ink-muted';
+
+/**
+ * A student's position, as the pill both leaderboard views render.
+ *
+ * Its own component rather than a constant shared between LeaderboardTable and
+ * LeaderboardPreview: the podium colouring is the one piece of the row those two views can't
+ * inherit from a shared row component (the table's row is a <tr>, the preview's is a flex div),
+ * so it is also the one piece most likely to drift if each kept its own copy.
+ */
+export function LeaderboardRankBadge({ rank }: { rank: number }) {
+  return (
+    <span
+      className={`inline-flex h-8 min-w-8 flex-none items-center justify-center rounded-full px-2 text-xs font-extrabold tabular-nums ${
+        RANK_CLASSES[rank] ?? RANK_DEFAULT
+      }`}
+    >
+      {rank}
+    </span>
+  );
+}

--- a/components/LeaderboardTable.tsx
+++ b/components/LeaderboardTable.tsx
@@ -1,22 +1,12 @@
 import Link from 'next/link';
 import { Avatar } from './Avatar';
+import { LeaderboardRankBadge } from './LeaderboardRankBadge';
 import { RankChangeIndicator } from './RankChangeIndicator';
 import type { LeaderboardEntry } from '../lib/leaderboardTypes';
 
 // The photo column has no header — a label above a 36px circle is noise, and the username
 // beside it already names the row.
 const COLUMNS = ['Rank', '', 'Username', 'Points', 'Change'];
-
-// CLAUDE.md reserves brand-gold for "rewards/XP/achievements", which is exactly the podium.
-// Silver has no token, so second place borrows the muted ink; third takes teal rather than an
-// invented bronze — adding a one-off hex here would be the first violation of the token rule.
-const RANK_CLASSES: Record<number, string> = {
-  1: 'bg-brand-gold/25 text-brand-gold',
-  2: 'bg-brand-ink-muted/25 text-brand-ink',
-  3: 'bg-brand-teal/20 text-brand-teal',
-};
-
-const RANK_DEFAULT = 'text-brand-ink-muted';
 
 /**
  * One row. Exported so the "Your position" strip below the table and the dashboard preview can
@@ -38,13 +28,7 @@ export function LeaderboardRow({
       }`}
     >
       <td className={`py-3.5 pr-2 ${isCurrentUser ? 'border-l-4 border-l-brand-purple pl-3' : 'pl-4'}`}>
-        <span
-          className={`inline-flex h-8 min-w-8 items-center justify-center rounded-full px-2 text-xs font-extrabold tabular-nums ${
-            RANK_CLASSES[entry.rank] ?? RANK_DEFAULT
-          }`}
-        >
-          {entry.rank}
-        </span>
+        <LeaderboardRankBadge rank={entry.rank} />
       </td>
       <td className="py-3.5 pl-1 pr-2">
         <Avatar avatarUrl={entry.avatarUrl} fallbackName={entry.username} size="sm" />


### PR DESCRIPTION
resolve #300

Add a leaderboard preview to the student dashboard.

A compact panel between the "In progress" card and the mastery titles,
showing the top five of the student's course plus their own row appended
when they didn't make it, so the dashboard always answers "where do I
stand?" without a click through to the full page. An ellipsis separates
the appended row, so it can't be misread as sixth place. The footer links
to /leaderboard with the course already selected.

Not a smaller LeaderboardTable: that component's row is a <tr>, and five
table columns with headers don't fit the ~600px dashboard column, so the
preview lays its rows out as flex instead. What the two views do share is
every piece that carries meaning - Avatar, RankChangeIndicator, and the
podium colouring, which moves out of LeaderboardTable into a new
LeaderboardRankBadge for exactly that reason. It was the one part of a
row the two layouts couldn't inherit from a shared component, and so the
one most likely to drift if each kept its own copy. Only the layout
differs between them now.

Still reading lib/mockLeaderboard.ts, synchronously - the artificial
delay on the full page exists to make its skeleton reviewable, which
would just be a flicker here.

Open question left in a comment for when this hits the real API: the
preview picks the student's first course because a "primary course"
doesn't exist yet. A student enrolled in several probably wants their
most recently active one.