### PR TITLE
finished Mock up Dashboard

### DIFF
--- a/app/students/[id]/layout.tsx
+++ b/app/students/[id]/layout.tsx
@@ -1,0 +1,7 @@
+export const metadata = {
+  title: 'Student profile',
+};
+
+export default function StudentProfileLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/app/students/[id]/page.tsx
+++ b/app/students/[id]/page.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useMemo, useState } from 'react';
+import { AppShell } from '../../../components/AppShell';
+import { Avatar } from '../../../components/Avatar';
+import { EditableField } from '../../../components/EditableField';
+import { MasteryTitleCard } from '../../../components/MasteryTitleCard';
+import { StatTile } from '../../../components/StatTile';
+import { useUser } from '../../../components/UserProvider';
+import { buildMasteryTitleEntries, totalLevelsPassed } from '../../../lib/masteryTitles';
+import { getMockPublicProfile } from '../../../lib/mockLeaderboard';
+import type { PublicStudentProfile, PublicStudentTitle } from '../../../lib/leaderboardTypes';
+import { loadStudentScore, loadStudentTitles } from '../../../lib/sessionClient';
+import { useRequireRole } from '../../../lib/useRequireRole';
+
+/**
+ * A classmate's profile, reached by clicking a username on the leaderboard or the dashboard
+ * preview. Read-only — there is nothing on this page a viewer can change.
+ *
+ * PRIVACY CONTRACT. Shown: username, avatar, biography, cumulative score, earned mastery titles.
+ * Deliberately NOT shown: real name, age, semester, email, course list, individual answers,
+ * attempt history. US-5's GET /api/students/{id}/public-profile must return only the fields
+ * above — this page not rendering a field is not a substitute for the route not sending it, and
+ * a route that over-returns leaks the data into the network tab regardless of the markup.
+ *
+ * Phase 1: data comes from lib/mockLeaderboard.ts. The one place this page will change when the
+ * real route lands is where `profile` is resolved below.
+ */
+export default function StudentProfilePage({ params }: { params: { id: string } }) {
+  return <StudentProfileContent studentId={params.id} />;
+}
+
+function NotFoundCard() {
+  return (
+    <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-8 text-center">
+      <p className="text-sm font-extrabold text-brand-navy">Student not found.</p>
+      <p className="mx-auto mt-1.5 max-w-sm text-sm font-semibold text-gray-500">
+        This profile doesn&apos;t exist, or the student is no longer in your course.
+      </p>
+      {/* No Retry button, unlike the failed-fetch cards elsewhere: an unknown id will not
+          resolve on a second attempt, so offering one would only waste a click. */}
+      <Link
+        href="/leaderboard"
+        className="mt-4 inline-flex rounded-brand-md bg-brand-purple px-4 py-2 text-sm font-extrabold text-white hover:bg-brand-purple-dark"
+      >
+        Back to Leaderboard
+      </Link>
+    </div>
+  );
+}
+
+function StudentProfileContent({ studentId }: { studentId: string }) {
+  // Instructors are redirected away: this page exists so students can compare themselves with
+  // classmates, and an instructor already has the far richer /instructor/students/{id} view.
+  const { loading, authorized } = useRequireRole('student');
+  const { token, profile: ownProfile } = useUser();
+
+  const isSelf = Boolean(ownProfile) && studentId === ownProfile?.user_id;
+
+  /**
+   * Score and mastery titles for your own profile, from the two self-only routes that already
+   * exist. Without this the self view would claim a score of 0 while the sidebar shows the real
+   * number — the mock has no entry to fall back on here, since the id is a real uuid (below).
+   *
+   * Nothing equivalent runs for a peer: /score and /titles hard-403 on a foreign id by design.
+   * US-5's public-profile route is what will serve those two numbers for someone else.
+   */
+  const [ownScore, setOwnScore] = useState(0);
+  const [ownTitles, setOwnTitles] = useState<PublicStudentTitle[]>([]);
+
+  useEffect(() => {
+    if (!isSelf || !token || !ownProfile) return;
+    let cancelled = false;
+
+    Promise.all([
+      loadStudentScore(token, ownProfile.user_id),
+      loadStudentTitles(token, ownProfile.user_id),
+    ]).then(([scoreResult, titlesResult]) => {
+      if (cancelled) return;
+      if (scoreResult.ok) setOwnScore(scoreResult.data.score);
+      if (titlesResult.ok) setOwnTitles(titlesResult.data.titles);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isSelf, token, ownProfile]);
+
+  /**
+   * The self case is resolved before the mock lookup, and not just as a display nicety: the
+   * leaderboard substitutes the signed-in student's real Supabase uuid into their own row
+   * (getMockLeaderboard), so clicking it arrives here with an id no hardcoded mock entry can
+   * match. Reading from useUser() instead means your own profile shows real data even in Phase 1.
+   */
+  const profile: PublicStudentProfile | null = useMemo(() => {
+    if (isSelf && ownProfile) {
+      return {
+        studentId: ownProfile.user_id,
+        username: ownProfile.username,
+        avatarUrl: ownProfile.avatar_url,
+        biography: ownProfile.biography,
+        score: ownScore,
+        titles: ownTitles,
+      };
+    }
+    return getMockPublicProfile(studentId);
+  }, [isSelf, ownProfile, ownScore, ownTitles, studentId]);
+
+  const masteryEntries = useMemo(
+    () => (profile ? buildMasteryTitleEntries(profile.titles) : []),
+    [profile],
+  );
+  // "Earned" is the word in the story: a stranger's unreached levels aren't interesting, unlike
+  // on your own profile, where MasteryProgressSection deliberately shows all three as a to-do.
+  const earnedEntries = masteryEntries.filter((entry) => entry.currentLevel !== null);
+
+  // The redirect in useRequireRole runs in an effect, so rendering before it lands would flash
+  // this page at an instructor.
+  if (loading || !authorized) return null;
+
+  return (
+    <AppShell active="leaderboard">
+      <div className="mx-auto max-w-2xl">
+        <Link
+          href="/leaderboard"
+          className="mb-5 inline-flex items-center gap-1 text-sm font-bold text-gray-500 hover:text-brand-navy"
+        >
+          ← Back to Leaderboard
+        </Link>
+
+        {!profile ? (
+          <NotFoundCard />
+        ) : (
+          <>
+            <div className="flex flex-wrap items-center gap-4">
+              <Avatar avatarUrl={profile.avatarUrl} fallbackName={profile.username} size="xl" />
+              <div className="min-w-0">
+                <h1 className="break-words text-2xl font-extrabold text-brand-navy">{profile.username}</h1>
+                {isSelf ? (
+                  <p className="mt-1 text-sm font-semibold text-gray-500">
+                    This is you —{' '}
+                    <Link href="/profile" className="font-extrabold text-brand-purple hover:underline">
+                      edit your profile
+                    </Link>
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            <div className="mt-6 grid grid-cols-2 gap-3">
+              <StatTile value={profile.score} label="Cumulative score" />
+              <StatTile value={totalLevelsPassed(masteryEntries)} label="Levels passed" />
+            </div>
+
+            {/* editing={false} makes EditableField a plain read-only label/value block, including
+                its own empty-value copy — no second way of rendering a biography. */}
+            <div className="mt-6">
+              <EditableField
+                label="Biography"
+                value={profile.biography}
+                editing={false}
+                emptyText="No biography yet."
+              />
+            </div>
+
+            <div className="mt-8 border-t border-gray-100 pt-6">
+              <p className="text-xs font-bold uppercase tracking-widest text-gray-400">Mastery titles</p>
+              {earnedEntries.length === 0 ? (
+                <p className="mt-3 text-sm font-semibold text-gray-500">
+                  {isSelf
+                    ? 'No mastery titles yet — pass a level to earn your first.'
+                    : 'No mastery titles yet.'}
+                </p>
+              ) : (
+                <div className="mt-3 space-y-4">
+                  {earnedEntries.map((entry) => (
+                    <MasteryTitleCard key={entry.activityType} entry={entry} />
+                  ))}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/components/Avatar.tsx
+++ b/components/Avatar.tsx
@@ -17,6 +17,9 @@ const SIZES = {
   sm: 'h-9 w-9 text-[11px] border-2',
   md: 'h-14 w-14 text-lg border-[3px]',
   lg: 'h-16 w-16 text-base border-[3px]',
+  // Matches the 24x24 avatar app/profile/page.tsx uses for the signed-in student, so a peer's
+  // profile header sits at the same scale as your own.
+  xl: 'h-24 w-24 text-2xl border-4',
 } as const;
 
 export function Avatar({

--- a/components/CompletedSessionsSummary.tsx
+++ b/components/CompletedSessionsSummary.tsx
@@ -1,11 +1,4 @@
-function StatTile({ value, label }: { value: number; label: string }) {
-  return (
-    <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-4 text-center">
-      <div className="text-2xl font-extrabold tabular-nums text-brand-navy">{value.toLocaleString()}</div>
-      <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">{label}</div>
-    </div>
-  );
-}
+import { StatTile } from './StatTile';
 
 /**
  * GitHub #39: the student's standing at a glance — cumulative score plus how many sessions

--- a/components/StatTile.tsx
+++ b/components/StatTile.tsx
@@ -1,0 +1,16 @@
+/**
+ * One "where this student stands" number with its label.
+ *
+ * Lifted out of CompletedSessionsSummary so the public profile page can show a different subset
+ * of tiles without either duplicating the markup or inheriting that component's fixed three —
+ * one of which is "Sessions completed", a number a peer has no business seeing (see the privacy
+ * contract in app/students/[id]/page.tsx).
+ */
+export function StatTile({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-4 text-center">
+      <div className="text-2xl font-extrabold tabular-nums text-brand-navy">{value.toLocaleString()}</div>
+      <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">{label}</div>
+    </div>
+  );
+}

--- a/lib/leaderboardTypes.ts
+++ b/lib/leaderboardTypes.ts
@@ -36,3 +36,39 @@ export type LeaderboardCourse = {
   courseId: string;
   courseName: string;
 };
+
+/**
+ * One mastery title, in exactly the shape GET /api/students/{id}/titles already returns.
+ *
+ * Re-declared here rather than imported from lib/sessionClient.ts, which is 'use client' — this
+ * file has to stay importable from a server route. lib/masteryTitles.ts's StudentTitle is the
+ * same three fields, so buildMasteryTitleEntries takes this without a cast.
+ */
+export type PublicStudentTitle = {
+  activityType: string;
+  difficultyLevel: number | null;
+  title: string | null;
+};
+
+/**
+ * Everything a student may see about a classmate, and nothing else.
+ *
+ * This type is the privacy contract in code form: US-5's
+ * GET /api/students/{id}/public-profile must return these fields and no others. Notably absent,
+ * and deliberately so, are first_name/last_name, age, semester, email, the student's courses,
+ * and anything about individual answers or attempts — all of which exist on the "user" row or a
+ * join away from it, and none of which a peer has a reason to see.
+ *
+ * titles stays in the raw API shape rather than a pre-built MasteryTitleEntry[] so that
+ * lib/masteryTitles.ts remains the single place that reconciles titles against ACTIVITIES.
+ */
+export type PublicStudentProfile = {
+  studentId: string;
+  username: string;
+  avatarUrl: string | null;
+  /** May be empty — "user".biography is NOT NULL but nothing forces it non-blank. */
+  biography: string;
+  /** Cumulative score, same definition as computeStudentScore (lib/scoreQueries.ts). */
+  score: number;
+  titles: PublicStudentTitle[];
+};

--- a/lib/mockLeaderboard.ts
+++ b/lib/mockLeaderboard.ts
@@ -17,7 +17,13 @@
 // a zero-point student who is enrolled but has never finished an activity, and enough rows to
 // force a second page.
 
-import type { LeaderboardCourse, LeaderboardEntry } from './leaderboardTypes';
+import { ACTIVITIES } from './activityContent';
+import type {
+  LeaderboardCourse,
+  LeaderboardEntry,
+  PublicStudentProfile,
+  PublicStudentTitle,
+} from './leaderboardTypes';
 
 /**
  * A tiny inline SVG avatar, so the <img> branch is actually exercised offline — real avatars are
@@ -51,10 +57,14 @@ const REQUIREMENTS_ENGINEERING: LeaderboardEntry[] = [
   { rank: 14, studentId: 'mock-stu-14', username: 'newcomer', avatarUrl: null, points: 0, rankChange: null },
 ];
 
+// A student's points are their cumulative score across every activity type (REQ-GAM-DL-1), not
+// something earned per course — so a student in two courses carries the SAME number into both
+// leaderboards, and only the field of competitors changes. These three rows therefore repeat the
+// points from the course above rather than inventing second, smaller totals.
 const SOFTWARE_ARCHITECTURE: LeaderboardEntry[] = [
-  { rank: 1, studentId: 'mock-stu-06', username: 'sofia_r', avatarUrl: null, points: 620, rankChange: 3 },
-  { rank: 2, studentId: 'mock-stu-12', username: 'you', avatarUrl: null, points: 480, rankChange: 1 },
-  { rank: 3, studentId: 'mock-stu-01', username: 'mkellner', avatarUrl: mockAvatar('#7c4dff', 'MK'), points: 300, rankChange: -2 },
+  { rank: 1, studentId: 'mock-stu-01', username: 'mkellner', avatarUrl: mockAvatar('#7c4dff', 'MK'), points: 1450, rankChange: -2 },
+  { rank: 2, studentId: 'mock-stu-06', username: 'sofia_r', avatarUrl: null, points: 980, rankChange: 3 },
+  { rank: 3, studentId: 'mock-stu-12', username: 'you', avatarUrl: null, points: 410, rankChange: 1 },
 ];
 
 /** A course with a roster but no completed activity yet — exercises the table's empty state. */
@@ -90,4 +100,90 @@ export function getMockLeaderboard(courseId: string, currentStudentId?: string):
   return entries.map((entry) =>
     entry.studentId === 'mock-stu-12' ? { ...entry, studentId: currentStudentId } : entry,
   );
+}
+
+/**
+ * Levels passed per activity type, in the fixed ACTIVITIES order, turned into the title rows
+ * GET /api/students/{id}/titles would return. null means the activity type was never passed, and
+ * such an entry is left out entirely — the real route only returns rows for activity types the
+ * student has actually passed (REQ-GAM-BL-1.1), and buildMasteryTitleEntries fills in the rest.
+ *
+ * Title names come from ACTIVITIES rather than being typed out here, so the mock can't drift
+ * from the strings the rest of the app shows.
+ */
+function titlesFor(levels: (number | null)[]): PublicStudentTitle[] {
+  return ACTIVITIES.flatMap((activity, index) => {
+    const level = levels[index] ?? null;
+    if (level === null) return [];
+    return [
+      {
+        activityType: activity.activityType,
+        difficultyLevel: level,
+        title: activity.titles[level as 1 | 2 | 3],
+      },
+    ];
+  });
+}
+
+/**
+ * The parts of a public profile that aren't already on the leaderboard row. username, avatarUrl
+ * and score are NOT repeated here — getMockPublicProfile reads them off the leaderboard entry so
+ * a profile can't contradict the table it was reached from.
+ *
+ * Deliberate edge cases: 'mock-stu-04' has an empty biography, and 'mock-stu-14' has passed
+ * nothing at all, so the page's "no biography" and "no mastery titles yet" states are both
+ * reachable by clicking a real row.
+ */
+const PROFILE_BIOS_AND_LEVELS: Record<string, { biography: string; levels: (number | null)[] }> = {
+  'mock-stu-01': { biography: 'Fifth semester, mostly interested in how requirements go wrong before anyone writes code.', levels: [3, 3, 2] },
+  'mock-stu-02': { biography: 'Trying to get through all three activities before the exam.', levels: [3, 2, 2] },
+  'mock-stu-03': { biography: 'Working student, practising in the evenings.', levels: [2, 3, 1] },
+  'mock-stu-04': { biography: '', levels: [2, 2, 2] },
+  'mock-stu-05': { biography: 'Exchange semester. Requirements engineering is new to me.', levels: [3, 1, 2] },
+  'mock-stu-06': { biography: 'I like the acceptance-criteria activities best.', levels: [2, 2, 1] },
+  'mock-stu-07': { biography: 'Second attempt at this course. Going better this time.', levels: [2, 1, 2] },
+  'mock-stu-08': { biography: 'Aiming for all three master titles.', levels: [2, 2, null] },
+  'mock-stu-09': { biography: 'Just here to pass.', levels: [1, 2, 1] },
+  'mock-stu-10': { biography: 'Interested in the AI feedback side of the app.', levels: [2, 1, 1] },
+  'mock-stu-11': { biography: 'Part-time student, slow but steady.', levels: [1, 1, 1] },
+  // Reachable only if someone else views this row — the signed-in student's own click is
+  // answered by the page's "this is you" branch, which uses their real profile instead.
+  'mock-stu-12': { biography: 'Placeholder biography for the signed-in student.', levels: [1, 1, null] },
+  'mock-stu-13': { biography: 'Started late in the semester.', levels: [1, null, null] },
+  'mock-stu-14': { biography: 'Just joined the course.', levels: [null, null, null] },
+};
+
+/** Every leaderboard row across all courses, first match wins — a student's identity and score
+ *  are the same wherever they appear (see the SOFTWARE_ARCHITECTURE comment above). */
+function findLeaderboardEntry(studentId: string): LeaderboardEntry | null {
+  for (const entries of Object.values(BY_COURSE)) {
+    const match = entries.find((entry) => entry.studentId === studentId);
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * One student's public profile, or null when no such student exists — which is what drives the
+ * page's "Student not found" state.
+ *
+ * Never called with the signed-in student's own id in practice: getMockLeaderboard rewrites that
+ * row's id to their real Supabase uuid, and the page answers that case from useUser() before it
+ * gets here. The real GET /api/students/{id}/public-profile has no such split — it returns real
+ * ids throughout, and the page's own-profile branch becomes a pure display choice rather than a
+ * workaround for hardcoded ids.
+ */
+export function getMockPublicProfile(studentId: string): PublicStudentProfile | null {
+  const extras = PROFILE_BIOS_AND_LEVELS[studentId];
+  const entry = findLeaderboardEntry(studentId);
+  if (!extras || !entry) return null;
+
+  return {
+    studentId,
+    username: entry.username,
+    avatarUrl: entry.avatarUrl,
+    biography: extras.biography,
+    score: entry.points,
+    titles: titlesFor(extras.levels),
+  };
 }


### PR DESCRIPTION
resolve #301

Add the public student profile page the leaderboard has been linking to.

/students/[id] is read-only and reached by clicking a username on the
leaderboard or the dashboard preview - both have emitted that link since
#299/#300, and until now it 404'd. Shows a large avatar, the username,
the biography, cumulative score, levels passed, and the mastery titles
the student has actually earned. Unknown ids get a "Student not found"
card rather than a crash, deliberately without a Retry button: unlike a
failed fetch, an unknown id will not resolve on a second attempt.

The page header states the privacy contract, and lib/leaderboardTypes.ts
encodes it as PublicStudentProfile: username, avatar, biography, score
and earned titles are in; real name, age, semester, email, course list,
individual answers and attempt history are out. US-5's
GET /api/students/{id}/public-profile has to honour that list - the page
not rendering a field is no substitute for the route not sending it.

Viewing your own profile is resolved before the mock lookup, because the
leaderboard rewrites your own row's id to your real Supabase uuid and no
hardcoded entry can match it. That branch reads useUser() for identity
and fetches /score and /titles, which already work for your own id, so
the page can't claim a score of 0 while the sidebar shows the real one.
Peers get neither call - both routes 403 on a foreign id by design.

Reuses MasteryTitleCard, buildMasteryTitleEntries and EditableField with
editing={false} for the read-only biography. MasteryProgressSection
looks reusable (it takes studentId as a prop) but is not: it calls those
same self-only routes, so rendering it for a classmate yields a
"Forbidden." box. Two smaller extractions support the page - Avatar
gains an xl size, and StatTile moves out of CompletedSessionsSummary,
whose fixed third tile is "Sessions completed", a number this page has
no business showing.

Also corrects mock data from #299: the same students carried different
point totals in the two courses. Cumulative score is global across all
activity types, not earned per course, so a student in two courses
brings the same number into both leaderboards and only the field of
competitors changes. The profile would otherwise have contradicted the
table it was opened from. Related: the mock now reads username, avatar
and score off the leaderboard row instead of repeating them, so the two
cannot drift, and title names come from ACTIVITIES rather than string
literals.