### PR TITLE
Add acceptance-criteria statistics cards

### DIFF
--- a/app/instructor/page.tsx
+++ b/app/instructor/page.tsx
@@ -6,6 +6,7 @@ import { Suspense, useEffect, useMemo, useState } from 'react';
 import { AcSubmissionDetails } from '../../components/AcSubmissionDetails';
 import { AppShell } from '../../components/AppShell';
 import { ActivityLogTable } from '../../components/ActivityLogTable';
+import { InstructorAcceptanceCriteriaStats } from '../../components/InstructorAcceptanceCriteriaStats';
 import { InstructorActivityStats } from '../../components/InstructorActivityStats';
 import {
   InstructorFilters,
@@ -17,7 +18,11 @@ import { InstructorDashboardSkeleton } from '../../components/InstructorDashboar
 import { InstructorRoster } from '../../components/InstructorRoster';
 import { Pagination } from '../../components/Pagination';
 import { QuizAttemptDetails } from '../../components/QuizAttemptDetails';
-import { loadInstructorACSubmissions } from '../../lib/acceptanceCriteriaClient';
+import {
+  loadAcceptanceCriteriaStatistics,
+  loadInstructorACSubmissions,
+  type AcceptanceCriteriaStatistics,
+} from '../../lib/acceptanceCriteriaClient';
 import { summarizeStudents, toAcSubmissionRow, toQuizAttemptRow, type ActivityRow } from '../../lib/activityLogTypes';
 import { loadInstructorActivities, loadInstructorStudents, type StudentSummary } from '../../lib/sessionClient';
 import { useRequireRole } from '../../lib/useRequireRole';
@@ -42,6 +47,7 @@ function InstructorDashboardContent() {
 
   const [entries, setEntries] = useState<ActivityRow[] | null>(null);
   const [allStudents, setAllStudents] = useState<StudentSummary[] | null>(null);
+  const [acStatistics, setAcStatistics] = useState<AcceptanceCriteriaStatistics | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [refreshing, setRefreshing] = useState(false);
 
@@ -66,23 +72,28 @@ function InstructorDashboardContent() {
     if (!token || !profile?.user_id) return;
     let cancelled = false;
 
-    Promise.all([loadInstructorActivities(token, profile.user_id), loadInstructorACSubmissions(token)]).then(
-      ([activitiesResult, submissionsResult]) => {
-        if (cancelled) return;
-        if (!activitiesResult.ok) {
-          setError(activitiesResult.error);
-          return;
-        }
-        if (!submissionsResult.ok) {
-          setError(submissionsResult.error);
-          return;
-        }
-        setEntries([
-          ...activitiesResult.data.sessions.map(toQuizAttemptRow),
-          ...submissionsResult.data.submissions.map(toAcSubmissionRow),
-        ]);
-      },
-    );
+    Promise.all([
+      loadInstructorActivities(token, profile.user_id),
+      loadInstructorACSubmissions(token),
+      loadAcceptanceCriteriaStatistics(token),
+    ]).then(([activitiesResult, submissionsResult, statisticsResult]) => {
+      if (cancelled) return;
+      if (!activitiesResult.ok) {
+        setError(activitiesResult.error);
+        return;
+      }
+      if (!submissionsResult.ok) {
+        setError(submissionsResult.error);
+        return;
+      }
+      setEntries([
+        ...activitiesResult.data.sessions.map(toQuizAttemptRow),
+        ...submissionsResult.data.submissions.map(toAcSubmissionRow),
+      ]);
+      // A failed statistics fetch costs the stats card, not the whole dashboard — see
+      // InstructorAcceptanceCriteriaStats, which renders placeholders for a null value.
+      if (statisticsResult.ok) setAcStatistics(statisticsResult.data.statistics);
+    });
 
     return () => {
       cancelled = true;
@@ -95,7 +106,8 @@ function InstructorDashboardContent() {
     Promise.all([
       loadInstructorActivities(token, profile.user_id, { forceRefresh: true }),
       loadInstructorACSubmissions(token),
-    ]).then(([activitiesResult, submissionsResult]) => {
+      loadAcceptanceCriteriaStatistics(token),
+    ]).then(([activitiesResult, submissionsResult, statisticsResult]) => {
       setRefreshing(false);
       if (!activitiesResult.ok) {
         setError(activitiesResult.error);
@@ -109,6 +121,7 @@ function InstructorDashboardContent() {
         ...activitiesResult.data.sessions.map(toQuizAttemptRow),
         ...submissionsResult.data.submissions.map(toAcSubmissionRow),
       ]);
+      if (statisticsResult.ok) setAcStatistics(statisticsResult.data.statistics);
       setError(null);
     });
   }
@@ -216,6 +229,10 @@ function InstructorDashboardContent() {
         ) : (
           <>
             <InstructorActivityStats entries={entries} />
+            <InstructorAcceptanceCriteriaStats
+              statistics={acStatistics}
+              totalStudents={allStudents === null ? null : allStudents.length}
+            />
 
             <div className="mb-3 flex items-center justify-between gap-2">
               <h2 className="text-xs font-extrabold uppercase tracking-wide text-gray-400">Students</h2>

--- a/components/InstructorAcceptanceCriteriaStats.tsx
+++ b/components/InstructorAcceptanceCriteriaStats.tsx
@@ -1,0 +1,58 @@
+import type { AcceptanceCriteriaStatistics } from '../lib/acceptanceCriteriaClient';
+
+/**
+ * Class-wide stats for the write-acceptance-criteria activity (GitHub #155), mirroring
+ * InstructorActivityStats's two-metric-per-card layout: average score and participation.
+ *
+ * statistics arrives already aggregated (GET /api/instructor/acceptance-criteria/statistics,
+ * lib/acceptanceCriteriaStatisticsQueries.ts) — this component only formats it, the same
+ * division of responsibility as InstructorActivityStats keeps with its own class-average math
+ * (which it can do client-side only because it's a cheap reduce over an already-fetched list;
+ * this activity's full submission list isn't fetched here at all).
+ *
+ * totalStudents is passed in rather than fetched again — the roster count app/instructor/
+ * page.tsx already loads for the student list below.
+ */
+export function InstructorAcceptanceCriteriaStats({
+  statistics,
+  totalStudents,
+}: {
+  statistics: AcceptanceCriteriaStatistics | null;
+  totalStudents: number | null;
+}) {
+  // Dash while unknown, never a flash of 0 — same convention as AppShell.tsx's score pill.
+  const averageLabel = statistics?.averageScore == null ? '—' : `${statistics.averageScore.toFixed(1)}/10`;
+  const participationLabel =
+    statistics === null || totalStudents === null
+      ? '—'
+      : `${statistics.studentsAttempted} of ${totalStudents}`;
+
+  // byUserStory is already sorted lowest-average-first with null-average (never-attempted)
+  // entries last (lib/acceptanceCriteriaStatisticsQueries.ts), so the first graded entry here
+  // is exactly the one that needs attention.
+  const needsAttention = statistics?.byUserStory.find((story) => story.averageScore !== null) ?? null;
+
+  return (
+    <div className="mb-6">
+      <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-5">
+        <p className="text-sm font-extrabold text-brand-navy">Write Acceptance Criteria</p>
+        <div className="mt-3 flex gap-8">
+          <div>
+            <div className="text-xl font-extrabold tabular-nums text-brand-navy">{averageLabel}</div>
+            <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">Average score</div>
+          </div>
+          <div>
+            <div className="text-xl font-extrabold tabular-nums text-brand-teal-dark">{participationLabel}</div>
+            <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">Participation</div>
+          </div>
+        </div>
+      </div>
+
+      {needsAttention ? (
+        <p className="mt-2 truncate rounded-brand-md border border-brand-danger/40 bg-brand-danger/10 px-3 py-1.5 text-xs font-bold text-brand-danger-light">
+          Needs attention: {needsAttention.storyText}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/lib/acceptanceCriteriaClient.ts
+++ b/lib/acceptanceCriteriaClient.ts
@@ -14,6 +14,12 @@ import type {
 import type { SessionRecord } from "./sessionTypes";
 import { toInstant } from "./dateTime";
 
+// Already the shape the route returns (camelCase, pre-aggregated) — re-exported here so this
+// file stays the one import components need, the same role sessionClient.ts's re-export of
+// SessionRecord plays for lib/sessionTypes.ts.
+import type { AcceptanceCriteriaStatistics } from "./acceptanceCriteriaStatisticsQueries";
+export type { AcceptanceCriteriaStatistics } from "./acceptanceCriteriaStatisticsQueries";
+
 export type ApiResult<T> =
   | { ok: true; data: T }
   | { ok: false; status: number; error: string };
@@ -154,6 +160,23 @@ export function loadInstructorACSubmissions(
 
     return { ok: true as const, data: { submissions } };
   });
+}
+
+/**
+ * GET /api/instructor/acceptance-criteria/statistics — class-wide aggregates for the
+ * write-acceptance-criteria activity (GitHub #152, #155). Already pre-aggregated server-side
+ * (lib/acceptanceCriteriaStatisticsQueries.ts); this is a plain pass-through, not a cache — the
+ * same "always fresh" treatment loadInstructorACSubmissions above gets, since a newly graded
+ * submission should move the average right away.
+ */
+export function loadAcceptanceCriteriaStatistics(
+  token: string,
+): Promise<ApiResult<{ statistics: AcceptanceCriteriaStatistics }>> {
+  return request<{ statistics: AcceptanceCriteriaStatistics }>(
+    "/api/instructor/acceptance-criteria/statistics",
+    { method: "GET" },
+    token,
+  );
 }
 
 export type SubmitAcceptanceCriteriaResult = AcceptanceCriteriaResult & {


### PR DESCRIPTION
As a professor, I want class-wide stats at a glance, so that I know how the class is doing without reading every submission.

Description: components/InstructorAcceptanceCriteriaStats.tsx, mirroring InstructorActivityStats.tsx's two-metric-per-card layout: average score (X.X/10) and participation (studentsAttempted of total students, reusing the count already fetched for the roster). A third, smaller callout surfaces the lowest-averageScore entry from byUserStory (excluding never-attempted null stories) as "Needs attention: <title>." Placed at the top of the Review page, same position InstructorActivityStats occupies on /instructor.

Acceptance Criteria:

Renders — placeholders while stats is null, never a flash of 0 — matches AppShell.tsx's score-pill convention.
"Needs attention" callout is omitted (not shown with misleading data) if no story has any graded submission yet.
Receives already-fetched stats as a prop — does not re-aggregate the full submissions list client-side.
Average shown as X.X/10, one decimal, matching the route's rounding.
brand-* tokens and Tailwind utilities only — no raw hex, no inline styles.

Resolve #155 