### PR TITLE
Fix submission crash and blank page when LLM call fails on retry

### DIFF
--- a/app/activities/write-acceptance-criteria/play/page.tsx
+++ b/app/activities/write-acceptance-criteria/play/page.tsx
@@ -74,6 +74,12 @@ export default function WriteAcceptanceCriteriaPlayPage() {
     setNextPosition(result.data.nextPosition);
     setAnsweredCount(result.data.answeredCount);
     setOutcome(null);
+
+    // All stories answered but session not formally completed yet (e.g. LLM error interrupted
+    // the last submission before completeAcSession ran). Show summary instead of blank page.
+    if (result.data.nextPosition === null) {
+      setShowSummary(true);
+    }
   }, [token, router, showSummary]);
 
   useEffect(() => {

--- a/app/api/activities/write-acceptance-criteria/submissions/route.ts
+++ b/app/api/activities/write-acceptance-criteria/submissions/route.ts
@@ -149,10 +149,17 @@ export async function POST(request: Request) {
   if (storyError) return Response.json({ error: storyError.message }, { status: 500 });
   if (!story) return Response.json({ error: "User story not found." }, { status: 404 });
 
+  const creatorId = (story as UserStoryRow).creator_id;
+  if (!creatorId)
+    return Response.json(
+      { error: "The instructor who created this prompt has not configured an LLM provider." },
+      { status: 500 },
+    );
+
   const { data: config, error: configError } = await supabase
     .from("instructor_llm_config")
     .select("provider, api_key, model")
-    .eq("user_id", (story as UserStoryRow).creator_id)
+    .eq("user_id", creatorId)
     .order("updated_at", { ascending: false })
     .limit(1)
     .maybeSingle();


### PR DESCRIPTION
- Null-check creator_id before querying instructor_llm_config to avoid UUID error on seeded stories without an instructor
- Show summary screen when syncFromServer detects all stories are answered but session was not formally completed (e.g. after LLM error on last story)

Resolves #312
