### PR TITLE
Client/Data: Move leaderboard cache from persistent to session-scoped…

### DIFF
--- a/lib/leaderboardStore.ts
+++ b/lib/leaderboardStore.ts
@@ -5,6 +5,11 @@
 //
 // Holds other students' usernames and photos, exactly why instructorStudentsStore is cleared on
 // logout — clearCachedLeaderboard is registered in lib/clientCaches.ts for the same reason.
+//
+// Deliberately sessionStorage, not localStorage (GitHub #329): unlike the other eight caches in
+// CLAUDE.md's "Client-side caching" list, a stale leaderboard entry must not survive an app
+// restart — reopening the tab always gets exactly one fresh fetch, since sessionStorage starts
+// empty for a new tab/window regardless of what a previous session left behind.
 import type { LeaderboardEntry } from './leaderboardTypes';
 
 const STORAGE_KEY = 'rc_leaderboard_v1';
@@ -14,7 +19,7 @@ type LeaderboardStore = Partial<Record<string, LeaderboardEntry[]>>;
 function readStore(): LeaderboardStore {
   if (typeof window === 'undefined') return {};
   try {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
     return raw ? (JSON.parse(raw) as LeaderboardStore) : {};
   } catch {
     return {};
@@ -23,7 +28,7 @@ function readStore(): LeaderboardStore {
 
 function writeStore(store: LeaderboardStore) {
   if (typeof window === 'undefined') return;
-  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(store));
 }
 
 export function getCachedLeaderboard(courseId: string): LeaderboardEntry[] | null {
@@ -45,5 +50,5 @@ export function setCachedLeaderboard(courseId: string, entries: LeaderboardEntry
  */
 export function clearCachedLeaderboard(): void {
   if (typeof window === 'undefined') return;
-  window.localStorage.removeItem(STORAGE_KEY);
+  window.sessionStorage.removeItem(STORAGE_KEY);
 }

--- a/lib/studentCourseClient.ts
+++ b/lib/studentCourseClient.ts
@@ -83,7 +83,7 @@ type LeaderboardRow = {
  * returned entries have actually rendered, or the "since your last visit" delta would compare a
  * fetch against itself. See that function's own comment.
  *
- * Cached in localStorage (lib/leaderboardStore.ts) keyed by courseId, the same shape as
+ * Cached in sessionStorage (lib/leaderboardStore.ts) keyed by courseId, the same shape as
  * loadStudentScore: a plain call is served from the cache when present, forceRefresh bypasses it
  * and re-caches the server's answer. Nothing on this device learns when another student's score
  * changes their own leaderboard, the same staleness loadInstructorActivities documents — callers


### PR DESCRIPTION
… storage

As a developer, I want the leaderboard cache to be scoped to the browser session instead of persisting indefinitely, so a stale entry can't survive across app restarts.

Today lib/leaderboardStore.ts is localStorage-backed and persists indefinitely; it only clears on logout, on the student's own score changing, or the manual Refresh button.
Change: move to (or add) a session-scoped layer (e.g. sessionStorage, or an in-memory "fetched this session" flag) so reopening the tab/app always triggers exactly one fresh fetch, regardless of what's still in localStorage.
This is a deliberate behavior change, not a bug fix.

-Resolve #329 