### PR TITLE
Leaderboard fetches once per app session, not per view

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -13,8 +13,9 @@ import {
 import { Pagination } from "../../components/Pagination";
 import {
   loadCourseLeaderboard,
-  loadJoinableCourses,
+  loadMyLeaderboardCourses,
 } from "../../lib/studentCourseClient";
+import { getCachedLeaderboard } from "../../lib/leaderboardStore";
 import { recordLeaderboardRanks } from "../../lib/previousRankStore";
 import type {
   LeaderboardCourse,
@@ -54,25 +55,21 @@ function LeaderboardContent() {
 
   const studentId = profile?.user_id;
 
-  // The course list a student can see a leaderboard for is exactly "my courses" — the same
-  // alreadyMember filter components/MyCoursesSection.tsx already applies to
-  // loadJoinableCourses's response, since that's the only real "which courses is this student
-  // in" source that exists (GET /api/courses, not a dedicated "my courses" route).
+  // The course list a student can see a leaderboard for is exactly "my courses" — cached
+  // session-scoped via loadMyLeaderboardCourses (GitHub #328) so revisiting this page within the
+  // same app session doesn't re-fetch it, the same way loadCourseLeaderboard already caches the
+  // entries themselves.
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
 
-    loadJoinableCourses(token).then((result) => {
+    loadMyLeaderboardCourses(token).then((result) => {
       if (cancelled) return;
       if (!result.ok) {
         setCoursesFailed(true);
         return;
       }
-      setCourses(
-        result.data.courses
-          .filter((course) => course.alreadyMember)
-          .map((course) => ({ courseId: course.id, courseName: course.name })),
-      );
+      setCourses(result.data.courses);
     });
 
     return () => {
@@ -96,7 +93,12 @@ function LeaderboardContent() {
     }
 
     let cancelled = false;
-    setEntries(null);
+    // Skip the null reset (and the resulting skeleton) when this course's leaderboard is
+    // already cached this session — loadCourseLeaderboard below will resolve it from cache
+    // essentially instantly, so there is nothing to show a loading state for (GitHub #328).
+    if (getCachedLeaderboard(selectedCourseId) === null) {
+      setEntries(null);
+    }
     setEntriesFailed(false);
     setPage(1);
 
@@ -133,17 +135,22 @@ function LeaderboardContent() {
   function handleRefresh() {
     if (!token || !selectedCourseId || refreshing) return;
     setRefreshing(true);
-    loadCourseLeaderboard(token, selectedCourseId, { forceRefresh: true }).then(
-      (result) => {
-        setRefreshing(false);
-        if (!result.ok) {
-          setEntriesFailed(true);
-          return;
-        }
-        setEntriesFailed(false);
-        setEntries(result.data.entries);
-      },
-    );
+    // Forces both caches this page reads: the course list (membership can have changed since
+    // this session started) and the selected course's entries — the one on-demand escape hatch
+    // for both of the session caches GitHub #328 introduced.
+    Promise.all([
+      loadMyLeaderboardCourses(token, { forceRefresh: true }),
+      loadCourseLeaderboard(token, selectedCourseId, { forceRefresh: true }),
+    ]).then(([coursesResult, entriesResult]) => {
+      setRefreshing(false);
+      if (coursesResult.ok) setCourses(coursesResult.data.courses);
+      if (!entriesResult.ok) {
+        setEntriesFailed(true);
+        return;
+      }
+      setEntriesFailed(false);
+      setEntries(entriesResult.data.entries);
+    });
   }
 
   const rows = entries ?? [];

--- a/components/LeaderboardPreview.tsx
+++ b/components/LeaderboardPreview.tsx
@@ -6,7 +6,7 @@ import { Avatar } from './Avatar';
 import { LeaderboardRankBadge } from './LeaderboardRankBadge';
 import { RankChangeIndicator } from './RankChangeIndicator';
 import { StreakBadge } from './StreakBadge';
-import { loadCourseLeaderboard, loadJoinableCourses } from '../lib/studentCourseClient';
+import { loadCourseLeaderboard, loadMyLeaderboardCourses } from '../lib/studentCourseClient';
 import { recordLeaderboardRanks } from '../lib/previousRankStore';
 import type { LeaderboardCourse, LeaderboardEntry } from '../lib/leaderboardTypes';
 
@@ -65,14 +65,13 @@ export function LeaderboardPreview({ token, studentId }: { token: string; studen
   useEffect(() => {
     let cancelled = false;
 
-    loadJoinableCourses(token).then((result) => {
+    loadMyLeaderboardCourses(token).then((result) => {
       if (cancelled) return;
       if (!result.ok) {
         setCourse(null);
         return;
       }
-      const mine = result.data.courses.find((c) => c.alreadyMember);
-      setCourse(mine ? { courseId: mine.id, courseName: mine.name } : null);
+      setCourse(result.data.courses[0] ?? null);
     });
 
     return () => {

--- a/lib/clientCaches.ts
+++ b/lib/clientCaches.ts
@@ -20,6 +20,7 @@ import { clearCachedInstructorActivities } from './instructorActivityStore';
 import { clearCachedInstructorQuestions } from './instructorQuestionsStore';
 import { clearCachedInstructorStudents } from './instructorStudentsStore';
 import { clearCachedLeaderboard } from './leaderboardStore';
+import { clearCachedLeaderboardCourses } from './leaderboardCoursesStore';
 import { clearCachedLlmConfig } from './instructorLlmConfigStore';
 import { clearCachedScore } from './scoreStore';
 import { clearPreviousRanks } from './previousRankStore';
@@ -48,5 +49,6 @@ export function clearAllClientCaches(): void {
   clearCachedAcceptanceCriteriaSubmissions();
   clearCachedLlmConfig();
   clearCachedLeaderboard();
+  clearCachedLeaderboardCourses();
   clearPreviousRanks();
 }

--- a/lib/leaderboardCoursesStore.ts
+++ b/lib/leaderboardCoursesStore.ts
@@ -1,0 +1,34 @@
+// Session cache for "which courses can this student see a leaderboard for" (GitHub #328) — the
+// alreadyMember-filtered slice of GET /api/courses, in the LeaderboardCourse shape both
+// app/leaderboard/page.tsx and components/LeaderboardPreview.tsx need to pick a courseId before
+// they can even ask lib/leaderboardStore.ts for entries.
+//
+// Deliberately a separate cache from lib/leaderboardStore.ts's entries, and NOT layered onto the
+// underlying loadJoinableCourses (lib/studentCourseClient.ts) call itself — that call also backs
+// app/courses/page.tsx (browse/join) and components/MyCoursesSection.tsx, both of which must see
+// a just-created or just-joined course immediately, not after a stale session cache expires.
+// Session-scoped like leaderboardStore for the same reason: a stale entry must not survive an
+// app restart.
+import type { LeaderboardCourse } from './leaderboardTypes';
+
+const STORAGE_KEY = 'rc_leaderboard_courses_v1';
+
+export function getCachedLeaderboardCourses(): LeaderboardCourse[] | null {
+  if (typeof window === 'undefined') return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as LeaderboardCourse[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setCachedLeaderboardCourses(courses: LeaderboardCourse[]): void {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(courses));
+}
+
+export function clearCachedLeaderboardCourses(): void {
+  if (typeof window === 'undefined') return;
+  window.sessionStorage.removeItem(STORAGE_KEY);
+}

--- a/lib/studentCourseClient.ts
+++ b/lib/studentCourseClient.ts
@@ -5,9 +5,10 @@
 // app/courses/page.tsx, components/StudentCourseCard.tsx, and components/MyCoursesSection.tsx.
 
 import type { CourseMeta, JoinableCourse } from './courseTypes';
-import type { LeaderboardEntry } from './leaderboardTypes';
+import type { LeaderboardCourse, LeaderboardEntry } from './leaderboardTypes';
 import { toInstant } from './dateTime';
 import { getCachedLeaderboard, setCachedLeaderboard } from './leaderboardStore';
+import { getCachedLeaderboardCourses, setCachedLeaderboardCourses } from './leaderboardCoursesStore';
 import { getPreviousRanks, withRankChange } from './previousRankStore';
 
 export type ApiResult<T> = { ok: true; data: T } | { ok: false; status: number; error: string };
@@ -61,6 +62,36 @@ export async function loadJoinableCourses(token: string): Promise<ApiResult<{ co
  */
 export function joinCourseByCode(token: string, code: string): Promise<ApiResult<{ course: CourseMeta; alreadyMember: boolean }>> {
   return request<{ course: CourseMeta; alreadyMember: boolean }>('/api/courses/join', postJson({ code }), token);
+}
+
+/**
+ * The alreadyMember-filtered slice of loadJoinableCourses that app/leaderboard/page.tsx and
+ * components/LeaderboardPreview.tsx use to pick a courseId, cached session-scoped
+ * (lib/leaderboardCoursesStore.ts, GitHub #328) so revisiting either view doesn't re-run this
+ * network call — same cache-first/forceRefresh shape as loadCourseLeaderboard below. Distinct
+ * from loadJoinableCourses itself, which stays uncached: app/courses/page.tsx and
+ * MyCoursesSection need a just-joined course to show up without waiting for a fresh session.
+ */
+export function loadMyLeaderboardCourses(
+  token: string,
+  options: { forceRefresh?: boolean } = {},
+): Promise<ApiResult<{ courses: LeaderboardCourse[] }>> {
+  if (!options.forceRefresh) {
+    const cached = getCachedLeaderboardCourses();
+    if (cached !== null) {
+      return Promise.resolve({ ok: true, data: { courses: cached } });
+    }
+  }
+
+  return loadJoinableCourses(token).then((result) => {
+    if (!result.ok) return result;
+
+    const courses = result.data.courses
+      .filter((course) => course.alreadyMember)
+      .map((course) => ({ courseId: course.id, courseName: course.name }));
+    setCachedLeaderboardCourses(courses);
+    return { ok: true as const, data: { courses } };
+  });
 }
 
 /** The wire shape of GET /api/courses/{courseId}/leaderboard — no rankChange; see below. */


### PR DESCRIPTION
As a student, I want the leaderboard to load fresh the first time I open it after starting the app, and then stay stable on every later visit until I reopen the app, so navigating back to it repeatedly doesn't flicker or feel slow.

First leaderboard view after opening the app/tab shows a real loading state and fetch.
Every subsequent view in the same session reuses that result instantly, no spinner.
The existing manual "Refresh" button still forces a fresh fetch on demand.
Resolve #328 