### PR TITLE
Louis

### DIFF
--- a/__tests__/api/instructor-courses-delete.test.ts
+++ b/__tests__/api/instructor-courses-delete.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        if (isDelete) state.deletes.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { DELETE } from '../../app/api/instructor/courses/[id]/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function courseRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    course_id: 'course-1',
+    course_name: 'Software Requirements',
+    course_code: 'ABCDEF',
+    creator_id: 'instructor-1',
+    created_at: '2026-08-11T10:00:00',
+    ...overrides,
+  };
+}
+
+/** Two enrolled students, in the shape loadEnrolledStudents selects them. */
+function roster() {
+  return [
+    { user_id: 'student-1', student: { first_name: 'Ada', last_name: 'Lovelace', username: 'ada' } },
+    { user_id: 'student-2', student: { first_name: null, last_name: null, username: 'grace' } },
+  ];
+}
+
+function deleteRequest(token: string | null = 'valid-token') {
+  return new Request('http://localhost/api/instructor/courses/course-1', {
+    method: 'DELETE',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+const params = { params: { id: 'course-1' } };
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.deletes = [];
+});
+
+describe('DELETE /api/instructor/courses/[id]', () => {
+  it('returns 401 without a token', async () => {
+    const res = await DELETE(deleteRequest(null), params);
+    expect(res.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('course');
+  });
+
+  it('returns 404 when the course does not exist', async () => {
+    queueRole('instructor');
+    queue('course', { data: null, error: null });
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(404);
+    expect(h.state.deletes).toEqual([]);
+  });
+
+  it('returns 403 with an empty body when the caller does not own the course', async () => {
+    queueRole('instructor');
+    queue('course', { data: courseRow({ creator_id: 'someone-else' }), error: null });
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.deletes).toEqual([]);
+  });
+
+  it('deletes the course and reports how many students were unenrolled', async () => {
+    queueRole('instructor');
+    queue('course', { data: courseRow(), error: null }); // findOwnedCourse
+    queue('student_course', { data: roster(), error: null }); // count before the cascade
+    queue('course', { data: null, error: null }); // the delete itself
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toEqual({ courseId: 'course-1', unenrolledCount: 2 });
+
+    // One statement only: student_course is never deleted from explicitly, because
+    // fk_student_course_course cascades (see deleteCourse in lib/courseQueries.ts).
+    expect(h.state.deletes).toEqual([{ table: 'course', column: 'course_id', value: 'course-1' }]);
+  });
+
+  it('deletes a course with nobody enrolled, reporting a count of 0', async () => {
+    queueRole('instructor');
+    queue('course', { data: courseRow(), error: null });
+    queue('student_course', { data: [], error: null });
+    queue('course', { data: null, error: null });
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ courseId: 'course-1', unenrolledCount: 0 });
+  });
+
+  it('returns 500 and deletes nothing when the roster query fails', async () => {
+    queueRole('instructor');
+    queue('course', { data: courseRow(), error: null });
+    queue('student_course', { data: null, error: { message: 'Roster failure' } });
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('Roster failure');
+    // The count is what the confirmation was based on — a course must not be deleted when the
+    // number of students it affects could not be established.
+    expect(h.state.deletes).toEqual([]);
+  });
+
+  it('returns 500 when the delete fails', async () => {
+    queueRole('instructor');
+    queue('course', { data: courseRow(), error: null });
+    queue('student_course', { data: roster(), error: null });
+    queue('course', { data: null, error: { message: 'DB failure' } });
+
+    const res = await DELETE(deleteRequest(), params);
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('DB failure');
+  });
+});

--- a/app/api/instructor/courses/[id]/route.ts
+++ b/app/api/instructor/courses/[id]/route.ts
@@ -1,6 +1,6 @@
 import { getSupabaseClient } from '../../../../../lib/supabase';
 import { requireInstructor } from '../../../../../lib/instructorAuth';
-import { findOwnedCourse, loadEnrolledStudents, updateCourseName } from '../../../../../lib/courseQueries';
+import { deleteCourse, findOwnedCourse, loadEnrolledStudents, updateCourseName } from '../../../../../lib/courseQueries';
 import { loadStudentActivityForIds } from '../../../../../lib/sessionQueries';
 import { summarizeStudents, toStudentActivitySummary } from '../../../../../lib/activityLogTypes';
 
@@ -135,4 +135,43 @@ export async function PATCH(request: Request, { params }: { params: { id: string
     { course: { id: updated.course_id, name: updated.course_name, code: updated.course_code, createdAt: updated.created_at } },
     { status: 200 },
   );
+}
+
+/**
+ * DELETE /api/instructor/courses/{id} — deletes a course and, by cascade, every enrollment in it
+ * (GitHub #326/#327).
+ *
+ * What survives, deliberately: the students' own session_log rows, and with them their scores,
+ * titles, streaks and activity log. session_log has no course_id — a session belongs to a
+ * (user_id, activity_type) pair — so "this course's history" isn't a thing that could be deleted
+ * even if it should be, and deleting the enrolled students' sessions outright would wipe their
+ * progress in every *other* course too. See deleteCourse's docblock (lib/courseQueries.ts) and
+ * #327's own "keep session rows, only remove enrollment and visibility" recommendation.
+ *
+ * What that costs: GET /api/instructor/courses/{id}/export (REQ-PL-3.4.3) derives its roster from
+ * student_course at request time, so the CSV report for this course is gone for good even though
+ * every attempt it would have listed still exists. The confirmation dialog
+ * (components/DeleteCourseModal.tsx) says so before the instructor commits.
+ *
+ * unenrolledCount is counted *before* the delete — afterwards the cascade has already removed
+ * the rows there would be to count.
+ *
+ * - 401/403/404/403(not owner) — see authorizeCourse
+ * - 200 { courseId, unenrolledCount }
+ * - 500 on a roster or delete failure
+ */
+export async function DELETE(request: Request, { params }: { params: { id: string } }) {
+  const authz = await authorizeCourse(request, params.id);
+  if (!authz.ok) return authz.response;
+  const { supabase } = authz;
+
+  const { students, error: rosterError } = await loadEnrolledStudents(supabase, params.id);
+  if (rosterError || !students) {
+    return Response.json({ error: rosterError?.message ?? 'Could not load roster.' }, { status: 500 });
+  }
+
+  const { error } = await deleteCourse(supabase, params.id);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ courseId: params.id, unenrolledCount: students.length }, { status: 200 });
 }

--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { AppShell } from '../../../../components/AppShell';
 import { AddStudentForm } from '../../../../components/AddStudentForm';
 import { CopyCodeButton } from '../../../../components/CopyCodeButton';
 import { CourseStudentList } from '../../../../components/CourseStudentList';
+import { DeleteCourseModal } from '../../../../components/DeleteCourseModal';
 import { EditCourseModal } from '../../../../components/EditCourseModal';
 import { exportCourseReport, loadCourse, removeStudentFromCourse, type CourseDetail, type CourseStudent } from '../../../../lib/courseClient';
 import { useRequireRole } from '../../../../lib/useRequireRole';
@@ -29,6 +31,17 @@ function DownloadIcon() {
   );
 }
 
+function TrashIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M3 6h18" />
+      <path d="M8 6V4h8v2" />
+      <path d="M19 6l-1 14H6L5 6" />
+      <path d="M10 11v6M14 11v6" />
+    </svg>
+  );
+}
+
 /**
  * GitHub #241 follow-up: one course's detail view — code + roster management. Fully real
  * (lib/courseClient.ts, REQ-DL-5): GET /api/instructor/courses/{id} already embeds the roster
@@ -38,11 +51,13 @@ export default function CourseDetailPage({ params }: { params: { id: string } })
   // Same guard as every other /instructor/* page (GitHub #82/#169) — a student hitting this
   // URL directly is redirected, never shown the roster or edit/remove controls.
   const { token, profile, loading, authorized } = useRequireRole('instructor');
+  const router = useRouter();
 
   const [course, setCourse] = useState<CourseDetail | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
   const [editModalOpen, setEditModalOpen] = useState(false);
+  const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [error, setError] = useState('');
   const [exporting, setExporting] = useState(false);
 
@@ -139,6 +154,19 @@ export default function CourseDetailPage({ params }: { params: { id: string } })
                 >
                   <EditIcon />
                 </button>
+                {/*
+                  Labelled, unlike the icon-only Edit button next to it: this is the one
+                  irreversible action on the page, and an unlabelled trash can is exactly the
+                  control someone clicks to find out what it does.
+                */}
+                <button
+                  type="button"
+                  onClick={() => setDeleteModalOpen(true)}
+                  className="inline-flex items-center gap-2 rounded-full border border-brand-danger/40 bg-white px-4 py-2 text-sm font-extrabold text-brand-danger transition hover:border-brand-danger"
+                >
+                  <TrashIcon />
+                  Delete course
+                </button>
               </div>
             </div>
 
@@ -171,6 +199,18 @@ export default function CourseDetailPage({ params }: { params: { id: string } })
           token={token}
           onClose={() => setEditModalOpen(false)}
           onSaved={(updated) => setCourse((current) => (current ? { ...current, name: updated.name, code: updated.code } : current))}
+        />
+      ) : null}
+
+      {deleteModalOpen && course ? (
+        <DeleteCourseModal
+          course={course}
+          token={token}
+          onClose={() => setDeleteModalOpen(false)}
+          // Back to the list rather than staying on a page whose course no longer exists. The
+          // list refetches on mount (its effect depends on token/retryCount), so the deleted
+          // course is gone from it without any cache to invalidate.
+          onDeleted={() => router.push('/instructor/courses')}
         />
       ) : null}
     </AppShell>

--- a/components/CourseScopeSelect.tsx
+++ b/components/CourseScopeSelect.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import type { CourseSummary } from '../lib/courseClient';
+
+/**
+ * Picks which course an instructor screen is showing (GitHub #275, REQ-PL-3.3).
+ *
+ * REQ-PL-3.3 asks for a class *code* to be entered. The code stayed what it is — the thing a
+ * student types to join — because course ownership is already in the schema (course.creator_id,
+ * REQ-DL-5): the instructor's own courses can simply be listed, so there is nothing for them to
+ * remember or retype.
+ *
+ * A plain <select> rather than the pill row components/LeaderboardCourseSwitcher.tsx falls back
+ * from: an instructor's course count grows every semester, so the control that survives ten
+ * courses is the only one worth having here.
+ *
+ * The selection itself lives in the URL (?courseId=), not in this component — see
+ * lib/useCourseScope.ts. This only reports the change.
+ */
+export function CourseScopeSelect({
+  courses,
+  selectedCourseId,
+  onSelect,
+}: {
+  courses: CourseSummary[];
+  selectedCourseId: string | null;
+  onSelect: (courseId: string) => void;
+}) {
+  // One course is not a choice — showing a select with a single locked option is noise, and the
+  // page heading already says which class this is.
+  if (courses.length <= 1) return null;
+
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-gray-400">Course</span>
+      <select
+        value={selectedCourseId ?? ''}
+        onChange={(event) => onSelect(event.target.value)}
+        className="block w-full max-w-xs rounded-brand-md border border-gray-300 bg-white px-3.5 py-2 text-sm font-bold text-gray-600 outline-none transition focus:border-brand-purple"
+      >
+        {courses.map((course) => (
+          <option key={course.id} value={course.id}>
+            {course.name} ({course.studentCount})
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+/**
+ * What an instructor screen shows instead of an empty table when they have no courses yet.
+ * Distinct from "this course has no activity": nothing on these pages can work without a course,
+ * so the only useful thing to render is the way to create one.
+ */
+export function NoCoursesNotice() {
+  return (
+    <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center">
+      <p className="mb-1.5 text-sm font-extrabold text-brand-navy">No courses yet</p>
+      <p className="mb-4 text-sm font-semibold text-gray-500">
+        Student activity is shown per course. Create one, then share its code so students can join.
+      </p>
+      <a
+        href="/instructor/courses"
+        className="inline-block rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+      >
+        Create a course
+      </a>
+    </div>
+  );
+}

--- a/components/DeleteCourseModal.tsx
+++ b/components/DeleteCourseModal.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { deleteCourse, type CourseDetail } from '../lib/courseClient';
+
+const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * GitHub #326: the confirmation in front of deleting a course. Structurally the same modal as
+ * components/EditCourseModal.tsx — mount-is-open, focus trap, Escape to close, backdrop click to
+ * close, focus returned on close — since that is the popup convention every dialog in this
+ * project repeats independently rather than through a shared base component.
+ *
+ * Not a window.confirm() (which is what handleRemove on the same page still uses for removing a
+ * single student): the acceptance criterion is that the dialog states the enrolled student count
+ * *before* the instructor commits, and a native confirm can neither be styled to read as
+ * destructive nor be trusted to survive a popup blocker.
+ *
+ * Two deliberate deviations from EditCourseModal:
+ * - initial focus lands on Cancel, not on the destructive button, so Enter right after opening
+ *   cannot delete a course;
+ * - the confirm button is brand-danger rather than brand-purple, the only place on this page
+ *   that colour is used for an action rather than an error message.
+ *
+ * The count comes from the roster the detail page already has in state, so opening this costs no
+ * extra request. It can in principle be seconds stale (a student joining with the code in the
+ * meantime); that's acceptable for a warning — the route re-counts server-side and returns the
+ * number it actually unenrolled.
+ */
+export function DeleteCourseModal({
+  course,
+  token,
+  onClose,
+  onDeleted,
+}: {
+  course: CourseDetail;
+  token: string;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const panelRef = useRef<HTMLDivElement>(null);
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null;
+    cancelButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        return;
+      }
+
+      if (event.key !== 'Tab' || !panelRef.current) return;
+
+      const focusable = panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+      if (focusable.length === 0) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function close() {
+    // A delete in flight must not be dismissed out from under itself — the request would still
+    // land, and the page would keep rendering a course that no longer exists.
+    if (submitting) return;
+    onClose();
+    previouslyFocusedRef.current?.focus();
+  }
+
+  async function handleDelete() {
+    if (submitting) return;
+
+    setSubmitting(true);
+    setError('');
+
+    const result = await deleteCourse(token, course.id);
+
+    if (!result.ok) {
+      setSubmitting(false);
+      setError(result.error);
+      return;
+    }
+
+    // No setSubmitting(false) on success: onDeleted navigates away, and re-enabling the button
+    // first would flash a live "Delete course" on a course that is already gone.
+    onDeleted();
+  }
+
+  const studentCount = course.students.length;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) close();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-course-title"
+        className="w-full max-w-md rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
+      >
+        <div className="mb-5 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wide text-brand-danger">Courses</p>
+            <h2 id="delete-course-title" className="mt-1 text-xl font-extrabold text-white">
+              Delete Course
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-full border border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted transition hover:text-white"
+          >
+            <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        <p className="text-sm font-semibold text-brand-ink">
+          Delete <span className="font-extrabold text-white">{course.name}</span>?
+        </p>
+
+        <p className="mt-3 text-sm font-semibold text-brand-ink-muted">
+          {studentCount === 0 ? (
+            'No students are enrolled.'
+          ) : (
+            <>
+              <span className="font-extrabold text-brand-danger">
+                {studentCount} student{studentCount === 1 ? '' : 's'} will be unenrolled.
+              </span>{' '}
+            </>
+          )}
+          The course, its join code and its CSV export are gone for good.
+        </p>
+
+        <p className="mt-3 text-sm font-semibold text-brand-ink-muted">
+          Students keep their own attempt history and scores.
+        </p>
+
+        {error ? <p className="mt-3 text-xs font-bold text-brand-danger">{error}</p> : null}
+
+        <div className="mt-6 flex justify-end gap-3">
+          <button
+            ref={cancelButtonRef}
+            type="button"
+            onClick={close}
+            disabled={submitting}
+            className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleDelete}
+            disabled={submitting}
+            className="rounded-brand-md bg-brand-danger px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-danger/90 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {submitting ? 'Deleting…' : 'Delete course'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/clientStorage.ts
+++ b/lib/clientStorage.ts
@@ -1,0 +1,53 @@
+// The read/write pair every localStorage-backed cache in lib/ used to carry its own byte-identical
+// copy of. Extracted for one specific reason (GitHub #275): only the *read* side had a try/catch.
+//
+// setItem throws QuotaExceededError once the origin's ~5 MB budget is full, and a class-sized
+// instructor payload gets there. That throw happened inside a .then() with no .catch() on it, so
+// the rejection surfaced nowhere and the page it belonged to sat on "Loading…" forever — a
+// full cache presenting as a hung request. A cache that cannot store today's value must degrade
+// to "no cache", never break the fetch that produced it.
+//
+// Every store keeps its own STORAGE_KEY, its own typed getters/setters and its own clear function;
+// this only owns the three lines of window access underneath them.
+
+/**
+ * The parsed store at `key`, or an empty object when there is nothing there, the value is
+ * unparseable, or we are rendering on the server. Never throws.
+ */
+export function readJsonStore<T extends object>(key: string): T {
+  if (typeof window === 'undefined') return {} as T;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : ({} as T);
+  } catch {
+    return {} as T;
+  }
+}
+
+/**
+ * Persists `store` at `key`, silently doing nothing if it cannot.
+ *
+ * Swallowing the failure is deliberate: every caller is a cache write that happens *after* the
+ * real data has already been handed to the caller, so a full or unavailable localStorage costs a
+ * cache hit next time and nothing else. Making it throw would turn a storage problem into a
+ * failed page load.
+ */
+export function writeJsonStore(key: string, store: unknown): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(store));
+  } catch {
+    // Quota exceeded, or storage disabled (private mode / blocked cookies). Nothing to do —
+    // the next read simply misses and goes to the network.
+  }
+}
+
+/** Drops the whole store at `key` — what each cache's clear…() calls on logout. */
+export function clearJsonStore(key: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.removeItem(key);
+  } catch {
+    // Same reasoning as writeJsonStore: storage being unavailable is not an error worth raising.
+  }
+}

--- a/lib/courseClient.ts
+++ b/lib/courseClient.ts
@@ -103,6 +103,24 @@ export async function updateCourse(token: string, courseId: string, updates: { n
   return { ok: true, data: { course: { ...result.data.course, createdAt: toInstant(result.data.course.createdAt) } } };
 }
 
+/**
+ * Deletes a course and every enrollment in it (DELETE /api/instructor/courses/{id}, GitHub #327).
+ *
+ * unenrolledCount is how many students the cascade actually removed, counted server-side just
+ * before the delete — the dialog that asks for confirmation shows its own, possibly seconds-old
+ * count from the roster already in hand, so this is the authoritative number, not that one.
+ *
+ * The students' attempt history and scores are untouched; only the course, its join code and its
+ * CSV export go away. See the route's docblock for why that split is the way it is.
+ */
+export function deleteCourse(token: string, courseId: string): Promise<ApiResult<{ courseId: string; unenrolledCount: number }>> {
+  return request<{ courseId: string; unenrolledCount: number }>(
+    `/api/instructor/courses/${encodeURIComponent(courseId)}`,
+    { method: 'DELETE' },
+    token,
+  );
+}
+
 /** Enrolls a student in a course (POST /api/instructor/courses/{id}/students). */
 export function addStudentToCourse(token: string, courseId: string, studentId: string): Promise<ApiResult<{ student: CourseStudent }>> {
   return request<{ student: CourseStudent }>(

--- a/lib/courseQueries.ts
+++ b/lib/courseQueries.ts
@@ -334,3 +334,24 @@ export async function isEnrolledInAnyCourse(supabase: SupabaseClient, userId: st
 
   return { enrolled: (data ?? []).length > 0, error: null };
 }
+
+/**
+ * Deletes a course (GitHub #327). One statement, not two: student_course is the only table in
+ * the schema with a foreign key to course, and fk_student_course_course carries ON DELETE
+ * CASCADE, so every enrollment goes with it inside the same transaction — there is no way to
+ * leave an orphaned student_course row behind.
+ *
+ * Nothing else is touched, because nothing else *can* be: session_log has no course_id at all
+ * (a session belongs to a (user_id, activity_type) pair), and neither does question, whose
+ * user_id names its author rather than a course. A student's attempt history, score, title and
+ * streak therefore survive the deletion of a course they were in — which is what #327's own
+ * "keep session rows, only remove enrollment and visibility" recommendation asks for.
+ *
+ * Not idempotent the way unenrollStudent is: callers run findOwnedCourse first, so a second
+ * delete of the same course is a 404 there rather than a silent no-op here.
+ */
+export async function deleteCourse(supabase: SupabaseClient, courseId: string) {
+  const { error } = await supabase.from('course').delete().eq('course_id', courseId);
+
+  return { error };
+}

--- a/lib/courseScope.ts
+++ b/lib/courseScope.ts
@@ -1,0 +1,92 @@
+// GitHub #275 / REQ-PL-3.3: "Instructor should be able to enter a class code to restrict the
+// students that are displayed." The class-wide instructor reads used to answer with every student
+// in the system, which with three professors means each of them sees the other two's students,
+// names and scores. This resolves ?courseId= to the set of students an instructor is allowed to
+// see, so those routes can scope their query instead.
+//
+// REQ-PL-3.3 says "enter a class code", but course ownership is already in the schema
+// (course.creator_id, REQ-DL-5), so the UI picks from the instructor's own courses and passes the
+// course id. course_code stays what it is: the thing a *student* types to join.
+
+import type { SupabaseClient } from './sessionQueries';
+import { findOwnedCourse, loadEnrolledStudents } from './courseQueries';
+
+export type CourseScopeResult =
+  | { status: 'ok'; studentIds: string[] }
+  | { status: 'not_found' }
+  | { status: 'forbidden' }
+  | { status: 'error'; error: { message: string } };
+
+/**
+ * The students of one course, but only if the calling instructor owns it.
+ *
+ * Ownership comes from findOwnedCourse (lib/courseQueries.ts) so the 404-then-403 distinction is
+ * made in exactly one place: a course that doesn't exist is a missing resource, a course that
+ * exists but belongs to someone else must not be distinguishable from one that does — hence the
+ * bodiless 403 the caller is expected to send, matching requireInstructor's convention.
+ *
+ * An owned course with nobody enrolled resolves to `{ status: 'ok', studentIds: [] }`, not an
+ * error: a course created five minutes ago is a normal state. Callers must short-circuit on the
+ * empty list rather than passing it to .in(...) — see fetchAllRowsByIds in lib/supabasePaging.ts.
+ *
+ * Takes the Supabase client as an argument, like requireInstructor, so its test can build a local
+ * fake instead of mocking the module (the __tests__/lib/ convention).
+ */
+export async function resolveCourseScope(
+  supabase: SupabaseClient,
+  courseId: string,
+  instructorId: string,
+): Promise<CourseScopeResult> {
+  const found = await findOwnedCourse(supabase, courseId, instructorId);
+  if (found.status !== 'ok') return found;
+
+  const { students, error } = await loadEnrolledStudents(supabase, courseId);
+  if (error) return { status: 'error', error };
+
+  return { status: 'ok', studentIds: (students ?? []).map((student) => student.id) };
+}
+
+export type RequireCourseScopeResult =
+  | { ok: true; courseId: string; studentIds: string[] }
+  | { ok: false; status: 400 | 403 | 404 | 500; error: string };
+
+/**
+ * The route-level wrapper: reads ?courseId= off the request, then resolveCourseScope.
+ *
+ * Every scoped instructor route repeats the same four failure branches, so they live here rather
+ * than being copy-pasted four times — the one thing that must not drift between them is *which*
+ * status a wrong course gets, since that is what keeps one professor from probing for another's
+ * course ids.
+ *
+ * Run this only after requireInstructor: it assumes instructorId is already a confirmed
+ * instructor, and checks ownership of the course, not the caller's role.
+ */
+export async function requireCourseScope(
+  supabase: SupabaseClient,
+  request: Request,
+  instructorId: string,
+): Promise<RequireCourseScopeResult> {
+  const courseId = new URL(request.url).searchParams.get('courseId');
+  if (!courseId || courseId.trim() === '') {
+    return { ok: false, status: 400, error: 'courseId is required.' };
+  }
+
+  const scope = await resolveCourseScope(supabase, courseId, instructorId);
+
+  if (scope.status === 'error') return { ok: false, status: 500, error: scope.error.message };
+  if (scope.status === 'not_found') return { ok: false, status: 404, error: 'Course not found.' };
+  if (scope.status === 'forbidden') return { ok: false, status: 403, error: 'Forbidden' };
+
+  return { ok: true, courseId, studentIds: scope.studentIds };
+}
+
+/**
+ * The response for a failed requireCourseScope. 403 carries no body at all, matching
+ * requireInstructor and findOwnedCourse (GitHub #169's acceptance criteria); everything else
+ * keeps the { error } shape the rest of the API uses.
+ */
+export function courseScopeErrorResponse(result: Extract<RequireCourseScopeResult, { ok: false }>): Response {
+  return result.status === 403
+    ? new Response(null, { status: 403 })
+    : Response.json({ error: result.error }, { status: result.status });
+}

--- a/lib/supabasePaging.ts
+++ b/lib/supabasePaging.ts
@@ -1,0 +1,93 @@
+/**
+ * Two guards against the failure mode a class-sized read runs into (GitHub #275, REQ-PL-3.4.4:
+ * "at least 3 classes with 150 students per class").
+ *
+ * PostgREST caps a response at a server-configured maximum — 1000 rows by default — and says so
+ * only in the Content-Range header, not in `error`. A query without .range() therefore *silently*
+ * returns a prefix of the result set, and everything computed from it (class average, pass rate,
+ * needsAttention, questionCount) is quietly wrong rather than failing loudly. One course of 150
+ * students already clears that cap on session_to_question alone.
+ *
+ * Kept free of any Supabase import so it stays a pure helper testable without a client, the same
+ * reason requireInstructor (lib/instructorAuth.ts) takes its client as an argument.
+ */
+
+/** PostgREST's default max-rows. Pages are requested at exactly this size. */
+export const SUPABASE_MAX_ROWS = 1000;
+
+/**
+ * How many ids go into one .in(...) filter. PostgREST receives that list as a GET query string,
+ * so ~1000 UUIDs is a ~37 KB URL — past what proxies accept (HTTP 414). 200 keeps a chunk near
+ * 7 KB while still being one round trip per 200 sessions rather than per session.
+ */
+export const MAX_IN_LIST = 200;
+
+type QueryResult<T, E> = { data: T[] | null; error: E | null };
+
+/**
+ * Runs `page` repeatedly with widening .range() bounds until a short page comes back, and
+ * concatenates the results.
+ *
+ * `page` is a factory, not a query: a PostgREST builder is single-use, so each iteration has to
+ * build a fresh one. Callers pass `(from, to) => supabase.from(...).select(...).range(from, to)`.
+ *
+ * A short page (fewer rows than pageSize) is the only termination signal PostgREST offers without
+ * asking for an exact count, and it costs no extra request in the common case where everything
+ * fits in one page.
+ */
+export async function fetchAllRows<T, E>(
+  page: (from: number, to: number) => PromiseLike<QueryResult<T, E>>,
+  pageSize: number = SUPABASE_MAX_ROWS,
+): Promise<QueryResult<T, E>> {
+  const rows: T[] = [];
+
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await page(from, from + pageSize - 1);
+    if (error) return { data: null, error };
+
+    const batch = data ?? [];
+    rows.push(...batch);
+
+    if (batch.length < pageSize) return { data: rows, error: null };
+  }
+}
+
+/**
+ * Splits a list into chunks of at most `size`, for feeding .in(...) without blowing the URL up.
+ * An empty input yields no chunks at all — callers must not issue a query for it, since
+ * .in('col', []) is not something to rely on PostgREST for.
+ */
+export function chunked<T>(items: T[], size: number = MAX_IN_LIST): T[][] {
+  if (size < 1) throw new Error('chunked: size must be at least 1');
+
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+}
+
+/**
+ * chunked + fetchAllRows together: runs one paged read per chunk of ids and flattens the result.
+ * Chunks run sequentially rather than in parallel — a class-wide read is already the heaviest
+ * query in the app, and firing N of them at once is how a shared Supabase project starts
+ * rate-limiting everyone else.
+ */
+export async function fetchAllRowsByIds<T, E, Id>(
+  ids: Id[],
+  page: (chunk: Id[], from: number, to: number) => PromiseLike<QueryResult<T, E>>,
+  options: { chunkSize?: number; pageSize?: number } = {},
+): Promise<QueryResult<T, E>> {
+  const rows: T[] = [];
+
+  for (const chunk of chunked(ids, options.chunkSize)) {
+    const { data, error } = await fetchAllRows<T, E>(
+      (from, to) => page(chunk, from, to),
+      options.pageSize,
+    );
+    if (error) return { data: null, error };
+    rows.push(...(data ?? []));
+  }
+
+  return { data: rows, error: null };
+}


### PR DESCRIPTION
Resolve issue #326 and #327

Adds DELETE /api/instructor/courses/{id} and the UI that calls it. The route
reuses the existing authorizeCourse() helper for the 404-then-403 ownership
check, counts the roster before deleting, and returns { courseId,
unenrolledCount }.

Deleting a course removes every student_course row with it via the existing
ON DELETE CASCADE — no schema change. Session history is untouched: session_log
has no course_id, so students keep their scores, titles and streaks. Only the
course, its join code and its CSV export are lost.

The entry point is a red "Delete course" button on the course detail page,
opening a confirmation modal that states how many students will be unenrolled
before the instructor commits.