### PR TITLE
Add self-service course unenrollment endpoint (#325)

### DIFF
--- a/__tests__/api/courses-enrollment.test.ts
+++ b/__tests__/api/courses-enrollment.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Harness copied from __tests__/api/courses-leaderboard.test.ts, extended with `delete` the same
+// way __tests__/api/instructor-courses-unenroll.test.ts's builder is, since this route both
+// checks membership (a select) and then deletes the enrollment.
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        if (isDelete) state.deletes.push({ table, column, value });
+        return builder;
+      },
+      in: () => builder,
+      limit: () => builder,
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'student-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { DELETE } from '../../app/api/courses/[courseId]/enrollment/route';
+
+const COURSE_ID = 'course-1';
+
+function req(token: string | null = 'valid-token') {
+  return new Request(`http://localhost/api/courses/${COURSE_ID}/enrollment`, {
+    method: 'DELETE',
+    headers: token ? { Authorization: `Bearer ${token}` } : {},
+  });
+}
+
+const ctx = { params: { courseId: COURSE_ID } };
+
+describe('DELETE /api/courses/{courseId}/enrollment', () => {
+  beforeEach(() => {
+    h.state.queues = {};
+    h.state.tables = [];
+    h.state.deletes = [];
+  });
+
+  it('returns 401 without a token, before touching any table', async () => {
+    const response = await DELETE(req(null), ctx);
+    expect(response.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    const response = await DELETE(req('bad-token'), ctx);
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 404 for an unknown course, without checking enrollment', async () => {
+    queue('course', { data: null, error: null });
+
+    const response = await DELETE(req(), ctx);
+
+    expect(response.status).toBe(404);
+    expect(h.state.tables).not.toContain('student_course');
+  });
+
+  it('returns 404 when the caller is not enrolled in an existing course', async () => {
+    queue('course', { data: { course_id: COURSE_ID }, error: null });
+    queue('student_course', { data: [], error: null }); // membership check: no matching row
+
+    const response = await DELETE(req(), ctx);
+
+    expect(response.status).toBe(404);
+    expect(h.state.deletes).toEqual([]);
+  });
+
+  it('removes the caller\'s own enrollment and returns the courseId', async () => {
+    queue('course', { data: { course_id: COURSE_ID }, error: null });
+    queue('student_course', { data: [{ course_id: COURSE_ID }], error: null }); // membership check
+    queue('student_course', { data: null, error: null }); // delete
+
+    const response = await DELETE(req(), ctx);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ courseId: COURSE_ID });
+    expect(h.state.deletes).toEqual([
+      { table: 'student_course', column: 'course_id', value: COURSE_ID },
+      { table: 'student_course', column: 'user_id', value: 'student-1' },
+    ]);
+  });
+
+  it('returns 500 when the course lookup fails', async () => {
+    queue('course', { data: null, error: { message: 'db down' } });
+
+    const response = await DELETE(req(), ctx);
+    expect(response.status).toBe(500);
+  });
+
+  it('returns 500 when the membership check fails', async () => {
+    queue('course', { data: { course_id: COURSE_ID }, error: null });
+    queue('student_course', { data: null, error: { message: 'db down' } });
+
+    const response = await DELETE(req(), ctx);
+    expect(response.status).toBe(500);
+  });
+
+  it('returns 500 when the delete fails', async () => {
+    queue('course', { data: { course_id: COURSE_ID }, error: null });
+    queue('student_course', { data: [{ course_id: COURSE_ID }], error: null });
+    queue('student_course', { data: null, error: { message: 'DB failure' } });
+
+    const response = await DELETE(req(), ctx);
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe('DB failure');
+  });
+});

--- a/__tests__/lib/acSessionCache.test.ts
+++ b/__tests__/lib/acSessionCache.test.ts
@@ -43,7 +43,9 @@ function jsonResponse(body: unknown, status = 200) {
 }
 
 beforeEach(() => {
-  vi.stubGlobal('window', { localStorage: makeLocalStorageMock() });
+  // sessionStorage too: clearAllClientCaches also clears lib/leaderboardStore.ts and
+  // lib/leaderboardCoursesStore.ts, both sessionStorage-backed (GitHub #328/#329).
+  vi.stubGlobal('window', { localStorage: makeLocalStorageMock(), sessionStorage: makeLocalStorageMock() });
 });
 
 afterEach(() => {

--- a/app/api/courses/[courseId]/enrollment/route.ts
+++ b/app/api/courses/[courseId]/enrollment/route.ts
@@ -1,0 +1,61 @@
+import { getSupabaseClient } from '../../../../../lib/supabase';
+import { isEnrolledInAnyCourse, unenrollStudent } from '../../../../../lib/courseQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * DELETE /api/courses/{courseId}/enrollment — a student leaves a course on their own initiative
+ * (GitHub #325), the self-service counterpart to
+ * DELETE /api/instructor/courses/{id}/students/{studentId}. studentId always comes from the
+ * bearer token, never the path or body — a student can only ever remove their own enrollment.
+ * Reuses unenrollStudent (lib/courseQueries.ts) unchanged: that helper already only cares about
+ * (courseId, studentId), not who is calling it.
+ *
+ * Unlike the instructor-driven route, this one is NOT idempotent on "never enrolled": deleting an
+ * enrollment that doesn't exist for the caller 404s rather than silently succeeding. That route's
+ * idempotency is about tolerating a stale double-click on a remove button an instructor might
+ * click twice; here, "isn't enrolled" instead means the resource this path names — this caller's
+ * membership in this course — never existed, which membership check the leaderboard route
+ * (GET /api/courses/{courseId}/leaderboard) already runs via the same isEnrolledInAnyCourse
+ * helper, kept identical here so "enrolled" can't drift between the two routes.
+ *
+ * - 401 missing/invalid bearer token
+ * - 404 unknown course
+ * - 404 course exists but the caller isn't enrolled in it
+ * - 200 { courseId }
+ * - 500 Supabase not configured, course lookup, membership check, or delete failure
+ */
+export async function DELETE(request: Request, { params }: { params: { courseId: string } }) {
+  const token = getToken(request);
+  if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser(token);
+  if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
+
+  const { data: course, error: courseError } = await supabase
+    .from('course')
+    .select('course_id')
+    .eq('course_id', params.courseId)
+    .maybeSingle();
+
+  if (courseError) return Response.json({ error: courseError.message }, { status: 500 });
+  if (!course) return Response.json({ error: 'Course not found.' }, { status: 404 });
+
+  const { enrolled, error: membershipError } = await isEnrolledInAnyCourse(supabase, user.id, [params.courseId]);
+  if (membershipError) return Response.json({ error: membershipError.message }, { status: 500 });
+  if (!enrolled) return Response.json({ error: 'You are not enrolled in this course.' }, { status: 404 });
+
+  const { error } = await unenrollStudent(supabase, { courseId: params.courseId, studentId: user.id });
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ courseId: params.courseId }, { status: 200 });
+}


### PR DESCRIPTION
DELETE /api/courses/{courseId}/enrollment lets a student remove their own enrollment
Also fixes on (#328/#329).
Resolve #325 