### PR TITLE
added button for leaving courses

### DIFF
--- a/components/MyCoursesSection.tsx
+++ b/components/MyCoursesSection.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-import { loadJoinableCourses } from '../lib/studentCourseClient';
+import { leaveCourse, loadJoinableCourses } from '../lib/studentCourseClient';
 import type { JoinableCourse } from '../lib/courseTypes';
 
 /**
@@ -15,9 +15,19 @@ import type { JoinableCourse } from '../lib/courseTypes';
  * Real now (lib/studentCourseClient.ts, REQ-DL-5) — filters on course.alreadyMember, which the
  * server already scopes to the caller's own token, rather than a client-side studentId
  * comparison against an embedded roster.
+ *
+ * Leave action (GitHub #324): window.confirm() rather than a dedicated modal, the same
+ * lightweight convention components/ResumeOrAbandonPrompt.tsx already uses for a single-course,
+ * self-only consequence — no roster/enrollment-count context to show, unlike
+ * components/DeleteCourseModal.tsx's instructor-facing delete. On success the course is dropped
+ * from local state immediately (no re-fetch needed, mirrors app/courses/page.tsx's handleJoined),
+ * and leaveCourse itself clears the session-cached leaderboard course list/entries so the
+ * dashboard and leaderboard pick up the change on next visit too.
  */
 export function MyCoursesSection({ token }: { token: string }) {
   const [courses, setCourses] = useState<JoinableCourse[] | null>(null);
+  const [leavingId, setLeavingId] = useState<string | null>(null);
+  const [error, setError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -31,6 +41,24 @@ export function MyCoursesSection({ token }: { token: string }) {
       cancelled = true;
     };
   }, [token]);
+
+  async function handleLeave(course: JoinableCourse) {
+    if (leavingId) return;
+    if (!confirm(`Leave ${course.name}? You can rejoin later with the course code.`)) return;
+
+    setError('');
+    setLeavingId(course.id);
+
+    const result = await leaveCourse(token, course.id);
+
+    setLeavingId(null);
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    setCourses((current) => current?.filter((c) => c.id !== course.id) ?? current);
+  }
 
   return (
     <div className="mt-8 border-t border-gray-100 pt-6">
@@ -48,13 +76,28 @@ export function MyCoursesSection({ token }: { token: string }) {
       ) : (
         <ul className="mt-3 space-y-2">
           {courses.map((course) => (
-            <li key={course.id} className="rounded-xl border border-gray-200 bg-white px-4 py-2.5">
-              <p className="truncate text-sm font-bold text-brand-navy">{course.name}</p>
-              <p className="text-xs font-semibold text-gray-500">{course.professorName}</p>
+            <li
+              key={course.id}
+              className="flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white px-4 py-2.5"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-bold text-brand-navy">{course.name}</p>
+                <p className="text-xs font-semibold text-gray-500">{course.professorName}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => handleLeave(course)}
+                disabled={leavingId === course.id}
+                className="flex-none text-xs font-extrabold text-brand-danger hover:underline disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {leavingId === course.id ? 'Leaving…' : 'Leave'}
+              </button>
             </li>
           ))}
         </ul>
       )}
+
+      {error ? <p className="mt-3 text-xs font-bold text-brand-danger">{error}</p> : null}
     </div>
   );
 }

--- a/lib/studentCourseClient.ts
+++ b/lib/studentCourseClient.ts
@@ -7,8 +7,8 @@
 import type { CourseMeta, JoinableCourse } from './courseTypes';
 import type { LeaderboardCourse, LeaderboardEntry } from './leaderboardTypes';
 import { toInstant } from './dateTime';
-import { getCachedLeaderboard, setCachedLeaderboard } from './leaderboardStore';
-import { getCachedLeaderboardCourses, setCachedLeaderboardCourses } from './leaderboardCoursesStore';
+import { clearCachedLeaderboard, getCachedLeaderboard, setCachedLeaderboard } from './leaderboardStore';
+import { clearCachedLeaderboardCourses, getCachedLeaderboardCourses, setCachedLeaderboardCourses } from './leaderboardCoursesStore';
 import { getPreviousRanks, withRankChange } from './previousRankStore';
 
 export type ApiResult<T> = { ok: true; data: T } | { ok: false; status: number; error: string };
@@ -62,6 +62,28 @@ export async function loadJoinableCourses(token: string): Promise<ApiResult<{ co
  */
 export function joinCourseByCode(token: string, code: string): Promise<ApiResult<{ course: CourseMeta; alreadyMember: boolean }>> {
   return request<{ course: CourseMeta; alreadyMember: boolean }>('/api/courses/join', postJson({ code }), token);
+}
+
+/**
+ * DELETE /api/courses/{courseId}/enrollment — a student leaves a course they're enrolled in
+ * (GitHub #324/#325). On success, clears both session caches this page family reads
+ * (lib/leaderboardCoursesStore.ts and lib/leaderboardStore.ts) so the left course stops showing
+ * up on the dashboard/leaderboard immediately, the same invalidation
+ * app/activities/[slug]/play/page.tsx's handleFinishSummary already runs when the student's own
+ * score changes — a membership change is just as stale-cache-worthy as a score change.
+ */
+export function leaveCourse(token: string, courseId: string): Promise<ApiResult<{ courseId: string }>> {
+  return request<{ courseId: string }>(
+    `/api/courses/${encodeURIComponent(courseId)}/enrollment`,
+    { method: 'DELETE' },
+    token,
+  ).then((result) => {
+    if (result.ok) {
+      clearCachedLeaderboardCourses();
+      clearCachedLeaderboard();
+    }
+    return result;
+  });
 }
 
 /**


### PR DESCRIPTION
As a student, I want a "Leave course" action on my course list, so that a course I joined by mistake or no longer need stops showing up on my dashboard and leaderboard.

"Leave course" button on /courses or /profile's MyCoursesSection, with a confirmation step.
The course disappears from my dashboard/leaderboard immediately after confirming.
Resolve #324 