### PR TITLE
API: Auto-advance difficulty level after a passed session

### DIFF
--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -108,9 +108,19 @@ function req(body?: object, token: string | null = 'valid-token') {
   });
 }
 
+/**
+ * Queues the two session_log reads that precede every fresh-draw path: no session in progress
+ * (findInProgressSession), and no prior passed sessions (findStartDifficultyLevel), so the draw
+ * starts at level 1.
+ */
+function queueFreshSessionStart() {
+  queue('session_log', { data: null, error: null }); // findInProgressSession: none in progress
+  queue('session_log', { data: [], error: null });   // findStartDifficultyLevel: no prior sessions -> level 1
+}
+
 /** Queues a full happy-path draw: no running session, big enough pool, insert, links, reload. */
 function queueHappyPath() {
-  queue('session_log', { data: null, error: null });                   // no session in progress
+  queueFreshSessionStart();
   queue('question', { data: pool, error: null });                      // question bank
   queue('session_log', { data: sessionRow, error: null });             // insert
   queue('session_to_question', { data: null, error: null });           // insert links
@@ -150,7 +160,7 @@ describe('POST /api/sessions', () => {
 
   // AC 5
   it('returns 400 when fewer than 4 questions exist for type and difficulty level', async () => {
-    queue('session_log', { data: null, error: null });
+    queueFreshSessionStart();
     queue('question', { data: pool.slice(0, 3), error: null });
 
     const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
@@ -200,6 +210,44 @@ describe('POST /api/sessions', () => {
     links.forEach((l) => expect(pool.map((q) => q.question_id)).toContain(l.question_id));
   });
 
+  it('starts the next session at the next difficulty level once the current one is passed', async () => {
+    queue('session_log', { data: null, error: null }); // no session in progress
+    queue('session_log', {
+      data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, passed: true }],
+      error: null,
+    }); // prior passed level-1 session
+    queue('question', { data: pool, error: null });
+    queue('session_log', { data: { ...sessionRow, difficulty_level: 2 }, error: null }); // insert
+    queue('session_to_question', { data: null, error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
+    expect(response.status).toBe(201);
+
+    const sessionInsert = h.state.inserts.find((i) => i.table === 'session_log')!
+      .payload as Record<string, unknown>;
+    expect(sessionInsert).toMatchObject({ difficulty_level: 2 });
+  });
+
+  it('caps the next session at MAX_DIFFICULTY_LEVEL once the top level is already passed', async () => {
+    queue('session_log', { data: null, error: null }); // no session in progress
+    queue('session_log', {
+      data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 3, passed: true }],
+      error: null,
+    }); // prior passed level-3 (top) session
+    queue('question', { data: pool, error: null });
+    queue('session_log', { data: { ...sessionRow, difficulty_level: 3 }, error: null }); // insert
+    queue('session_to_question', { data: null, error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
+    expect(response.status).toBe(201);
+
+    const sessionInsert = h.state.inserts.find((i) => i.table === 'session_log')!
+      .payload as Record<string, unknown>;
+    expect(sessionInsert).toMatchObject({ difficulty_level: 3 });
+  });
+
   it('never exposes is_correct in the response', async () => {
     queueHappyPath();
 
@@ -246,7 +294,7 @@ describe('POST /api/sessions', () => {
   });
 
   it('returns the winning session when a parallel request hit the unique index', async () => {
-    queue('session_log', { data: null, error: null });
+    queueFreshSessionStart();
     queue('question', { data: pool, error: null });
     queue('session_log', { data: null, error: { code: '23505', message: 'duplicate key' } });
     queue('session_log', { data: sessionRow, error: null });
@@ -262,7 +310,7 @@ describe('POST /api/sessions', () => {
 
   // session_log.user_id references "user"(user_id) — an auth account alone is not enough.
   it('returns 409 when the student has no profile row yet', async () => {
-    queue('session_log', { data: null, error: null });
+    queueFreshSessionStart();
     queue('question', { data: pool, error: null });
     queue('session_log', {
       data: null,
@@ -278,7 +326,7 @@ describe('POST /api/sessions', () => {
   // GitHub #124: session_log's other foreign keys (activity_type from #123, badge) must not be
   // misreported as the profile case just because they share the 23503 code.
   it('returns 500, not the profile message, for an unrelated foreign key violation', async () => {
-    queue('session_log', { data: null, error: null });
+    queueFreshSessionStart();
     queue('question', { data: pool, error: null });
     queue('session_log', {
       data: null,
@@ -294,7 +342,7 @@ describe('POST /api/sessions', () => {
   });
 
   it('removes the session when its questions could not be stored', async () => {
-    queue('session_log', { data: null, error: null });
+    queueFreshSessionStart();
     queue('question', { data: pool, error: null });
     queue('session_log', { data: sessionRow, error: null });
     queue('session_to_question', { data: null, error: { message: 'insert failed' } });

--- a/__tests__/lib/activityCardStatus.test.ts
+++ b/__tests__/lib/activityCardStatus.test.ts
@@ -3,7 +3,7 @@ import { activityCardStatusLabel, deriveActivityCardStatus } from '../../lib/act
 
 describe('deriveActivityCardStatus', () => {
   it('reports a running session with its progress', () => {
-    expect(deriveActivityCardStatus({ answeredCount: 1, questionCount: 4 }, null)).toEqual({
+    expect(deriveActivityCardStatus({ answeredCount: 1, questionCount: 4 }, null, false)).toEqual({
       kind: 'in-progress',
       answered: 1,
       total: 4,
@@ -11,7 +11,7 @@ describe('deriveActivityCardStatus', () => {
   });
 
   it('reports the best score once the activity has been finished at least once', () => {
-    expect(deriveActivityCardStatus(null, { score: 45, maxScore: 100 })).toEqual({
+    expect(deriveActivityCardStatus(null, { score: 45, maxScore: 100 }, false)).toEqual({
       kind: 'best-score',
       score: 45,
       maxScore: 100,
@@ -19,13 +19,13 @@ describe('deriveActivityCardStatus', () => {
   });
 
   it('reports the empty state only when there is genuinely no history', () => {
-    expect(deriveActivityCardStatus(null, null)).toEqual({ kind: 'not-attempted' });
+    expect(deriveActivityCardStatus(null, null, false)).toEqual({ kind: 'not-attempted' });
   });
 
   it('prefers a running session over a best score', () => {
     // The next click resumes the session, so that is the useful thing to show — even for a
     // student who has already passed this activity before.
-    expect(deriveActivityCardStatus({ answeredCount: 2, questionCount: 4 }, { score: 100, maxScore: 100 })).toEqual({
+    expect(deriveActivityCardStatus({ answeredCount: 2, questionCount: 4 }, { score: 100, maxScore: 100 }, false)).toEqual({
       kind: 'in-progress',
       answered: 2,
       total: 4,
@@ -33,9 +33,23 @@ describe('deriveActivityCardStatus', () => {
   });
 
   it('falls back to the standard session length rather than showing "of 0"', () => {
-    expect(deriveActivityCardStatus({ answeredCount: 0, questionCount: 0 }, null)).toEqual({
+    expect(deriveActivityCardStatus({ answeredCount: 0, questionCount: 0 }, null, false)).toEqual({
       kind: 'in-progress',
       answered: 0,
+      total: 4,
+    });
+  });
+
+  it('reports mastered once every level has been passed, even over a plain best score', () => {
+    expect(deriveActivityCardStatus(null, { score: 100, maxScore: 100 }, true)).toEqual({ kind: 'mastered' });
+  });
+
+  it('prefers a running session over mastered', () => {
+    // Resuming the session is still the useful next click, even after every level is passed —
+    // same reasoning as preferring a running session over a plain best score.
+    expect(deriveActivityCardStatus({ answeredCount: 1, questionCount: 4 }, { score: 100, maxScore: 100 }, true)).toEqual({
+      kind: 'in-progress',
+      answered: 1,
       total: 4,
     });
   });
@@ -57,11 +71,16 @@ describe('activityCardStatusLabel', () => {
     expect(activityCardStatusLabel({ kind: 'best-score', score: 90, maxScore: 100 })).toBe('Best score: 90 / 100');
   });
 
+  it('announces that every level has been completed', () => {
+    expect(activityCardStatusLabel({ kind: 'mastered' })).toBe('All levels completed!');
+  });
+
   it('never produces the mastery title placeholder', () => {
     const labels = [
       activityCardStatusLabel({ kind: 'not-attempted' }),
       activityCardStatusLabel({ kind: 'in-progress', answered: 0, total: 4 }),
       activityCardStatusLabel({ kind: 'best-score', score: 0, maxScore: 100 }),
+      activityCardStatusLabel({ kind: 'mastered' }),
     ];
     expect(labels.some((label) => label.toLowerCase().includes('not yet started'))).toBe(false);
   });

--- a/app/activities/[slug]/page.tsx
+++ b/app/activities/[slug]/page.tsx
@@ -159,9 +159,9 @@ export default function ActivityDetailPage({
   const session = current?.session ?? null;
   const totalQuestions = current?.questions.length ?? 0;
   const answeredCount = current?.answers.length ?? 0;
-  // Every new session is currently drawn at START_DIFFICULTY_LEVEL (see POST /api/sessions) —
-  // real level progression isn't implemented server-side yet, so this always matches what
-  // clicking Start would actually produce, and the running session's own level once one exists.
+  // POST /api/sessions now computes the actual starting level from pass history server-side; this
+  // fallback only covers the moment before a session exists, when there's nothing to read a level
+  // from yet, so it shows the easy-level default rather than guessing what Start would produce.
   const displayLevel = session?.difficulty_level ?? START_DIFFICULTY_LEVEL;
 
   return (

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -4,19 +4,29 @@ import { useEffect, useState } from 'react';
 import { AppShell } from '../../components/AppShell';
 import { ActivityCard, type ActivityCardData } from '../../components/ActivityCard';
 import { ActivityCardSkeleton } from '../../components/ActivityCardSkeleton';
-import { deriveActivityCardStatus, type ActivityCardStatus } from '../../lib/activityCardStatus';
+import { deriveActivityCardStatus } from '../../lib/activityCardStatus';
 import { ACTIVITIES, Difficulty } from '../../lib/activityContent';
 import { loadCompletedAttempts, loadSessions, loadStudentTitles, type StudentTitle } from '../../lib/sessionClient';
-import { START_DIFFICULTY_LEVEL } from '../../lib/sessionRules';
+import { MAX_DIFFICULTY_LEVEL, nextDifficultyLevel } from '../../lib/sessionRules';
 import { useRequireRole } from '../../lib/useRequireRole';
 
 type CardData = {
   activity: ActivityCardData;
   /** The activity_type this card's title is looked up by; null for Type B, which has none. */
   activityType: string | null;
-  level: Difficulty;
-  status: ActivityCardStatus;
+  running: { difficulty_level: number; answeredCount: number; questionCount: number } | null;
+  best: { score: number; maxScore: number } | null;
 };
+
+/**
+ * This student's titles entry for one activity, or null when they haven't attempted it
+ * (GET /api/students/{id}/titles only returns a row per activity type actually attempted —
+ * lib/titleQueries.ts) or this card has no activityType at all (Type B).
+ */
+function titleEntryFor(titles: StudentTitle[] | null, activityType: string | null): StudentTitle | null {
+  if (!titles || !activityType) return null;
+  return titles.find((candidate) => candidate.activityType === activityType) ?? null;
+}
 
 /**
  * The student's earned title for one activity, or null when they haven't passed a level yet.
@@ -26,9 +36,7 @@ type CardData = {
  * (lib/titleQueries.ts), and rendering that next to a real score is exactly what GitHub #272
  * reported. difficultyLevel === null is the same fact without the string matching.
  */
-function earnedTitle(titles: StudentTitle[] | null, activityType: string | null): string | null {
-  if (!titles || !activityType) return null;
-  const entry = titles.find((candidate) => candidate.activityType === activityType);
+function earnedTitle(entry: StudentTitle | null): string | null {
   if (!entry || entry.difficultyLevel === null) return null;
   return entry.title;
 }
@@ -48,10 +56,12 @@ export default function ActivitiesPage() {
   // Every value on a Type A card is server-derived now (GitHub #272): the running session comes
   // from loadSessions('in-progress') — which already carries answeredCount/questionCount, so the
   // card can say how far along it is — and the best score from loadCompletedAttempts, fetched in
-  // parallel, once per activity. The title arrives from loadStudentTitles in the effect below.
-  // Nothing here reads lib/activityStore.ts any more: nothing writes to that mock since the play
-  // flow moved to the API, so its level was frozen at 1 and its title at "Not yet started"
-  // forever — the actual bug behind #272, not just its wording.
+  // parallel, once per activity. Raw here (running/best), not the rendered level/status/title:
+  // those also depend on titles, which loads in the separate effect below, so they're derived at
+  // render time instead (see the JSX map) rather than getting stuck at whatever titles held the
+  // moment this effect last ran. Nothing here reads lib/activityStore.ts any more: nothing writes
+  // to that mock since the play flow moved to the API, so its level was frozen at 1 and its title
+  // at "Not yet started" forever — the actual bug behind #272, not just its wording.
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
@@ -89,11 +99,8 @@ export default function ActivitiesPage() {
         return {
           activity,
           activityType: activity.activityType,
-          // Same derivation as app/activities/[slug]/page.tsx's displayLevel, so the card and the
-          // page it links to can't disagree: the running session's level, else the level clicking
-          // Start would actually produce. (Server-side level progression doesn't exist yet.)
-          level: (running?.difficulty_level ?? START_DIFFICULTY_LEVEL) as Difficulty,
-          status: deriveActivityCardStatus(running, best ? { score: best.score, maxScore: best.maxScore } : null),
+          running,
+          best: best ? { score: best.score, maxScore: best.maxScore } : null,
         };
       });
 
@@ -148,15 +155,27 @@ export default function ActivitiesPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          {cards?.map((card) => (
-            <ActivityCard
-              key={card.activity.slug}
-              activity={card.activity}
-              level={card.level}
-              title={earnedTitle(titles, card.activityType)}
-              status={card.status}
-            />
-          ))}
+          {cards?.map((card) => {
+            const titleEntry = titleEntryFor(titles, card.activityType);
+            const highestPassedLevel = titleEntry?.difficultyLevel ?? null;
+            const isMastered = highestPassedLevel === MAX_DIFFICULTY_LEVEL;
+
+            // Same derivation as app/activities/[slug]/page.tsx's displayLevel, so the card and
+            // the page it links to can't disagree: the running session's own level, else the
+            // level the student's next click would actually produce (their next unpassed level,
+            // capped at MAX_DIFFICULTY_LEVEL — see POST /api/sessions).
+            const level = (card.running?.difficulty_level ?? nextDifficultyLevel(highestPassedLevel)) as Difficulty;
+
+            return (
+              <ActivityCard
+                key={card.activity.slug}
+                activity={card.activity}
+                level={level}
+                title={earnedTitle(titleEntry)}
+                status={deriveActivityCardStatus(card.running, card.best, isMastered)}
+              />
+            );
+          })}
         </div>
       )}
     </AppShell>

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -4,12 +4,12 @@ import {
   DEFAULT_QUESTION_MAX_SCORE,
   QUESTIONS_PER_SESSION,
   SESSION_COLUMNS,
-  START_DIFFICULTY_LEVEL,
   isSessionStatus,
 } from '../../../lib/sessionRules';
 import {
   type SupabaseClient,
   findInProgressSession,
+  findStartDifficultyLevel,
   loadProgressForSessions,
   loadSessionQuestions,
 } from '../../../lib/sessionQueries';
@@ -146,14 +146,19 @@ export async function POST(request: Request) {
   if (existing.error) return Response.json({ error: existing.error.message }, { status: 500 });
   if (existing.session) return respondWithSession(supabase, existing.session, { created: false });
 
-  // AC 1: draw QUESTIONS_PER_SESSION questions matching activity type and difficulty level 1.
+  // The student's next unpassed level for this activity: one past the highest difficulty_level
+  // they've passed, capped at MAX_DIFFICULTY_LEVEL. No prior passed session -> level 1.
+  const { startLevel, error: levelError } = await findStartDifficultyLevel(supabase, user.id, activityType);
+  if (levelError) return Response.json({ error: levelError.message }, { status: 500 });
+
+  // AC 1: draw QUESTIONS_PER_SESSION questions matching activity type and the computed level.
   // GitHub #124: filtered through an inner join against the activity_type table (#122/#123)
   // instead of a plain equality check on the free-text column.
   const { data: pool, error: poolError } = await supabase
     .from('question')
     .select('question_id, max_score, activity:activity_type!inner ( activity_type )')
     .eq('activity.activity_type', activityType)
-    .eq('difficulty_level', START_DIFFICULTY_LEVEL);
+    .eq('difficulty_level', startLevel);
 
   if (poolError) return Response.json({ error: poolError.message }, { status: 500 });
 
@@ -181,7 +186,7 @@ export async function POST(request: Request) {
       session_id: sessionId,
       user_id: user.id,
       activity_type: activityType,
-      difficulty_level: START_DIFFICULTY_LEVEL,
+      difficulty_level: startLevel,
       status: 'in-progress',
       cumulative_score: 0,
       max_score: maxScore,

--- a/lib/activityCardStatus.ts
+++ b/lib/activityCardStatus.ts
@@ -17,6 +17,7 @@ import { QUESTIONS_PER_SESSION } from './sessionRules';
 
 export type ActivityCardStatus =
   | { kind: 'in-progress'; answered: number; total: number }
+  | { kind: 'mastered' }
   | { kind: 'best-score'; score: number; maxScore: number }
   | { kind: 'not-attempted' };
 
@@ -25,6 +26,8 @@ export function activityCardStatusLabel(status: ActivityCardStatus): string {
   switch (status.kind) {
     case 'in-progress':
       return `In progress · ${status.answered} of ${status.total}`;
+    case 'mastered':
+      return 'All levels completed!';
     case 'best-score':
       return `Best score: ${status.score} / ${status.maxScore}`;
     case 'not-attempted':
@@ -35,12 +38,13 @@ export function activityCardStatusLabel(status: ActivityCardStatus): string {
 }
 
 /**
- * Which of the three states a card is in.
+ * Which of the four states a card is in.
  *
- * A running session outranks a best score: the student's next click resumes it, so that is the
- * more useful thing to show even when they have finished this activity before. A best score
- * outranks the empty state for the same reason the empty state exists at all — it is only
- * honest when there is genuinely nothing behind it.
+ * A running session outranks everything else: the student's next click resumes it, so that is
+ * the more useful thing to show even when they have finished this activity before, or mastered
+ * it. Mastered (every level passed) outranks a plain best score — it is strictly more complete
+ * information about the same history. A best score outranks the empty state for the same reason
+ * the empty state exists at all — it is only honest when there is genuinely nothing behind it.
  *
  * questionCount falls back to QUESTIONS_PER_SESSION rather than rendering "of 0": a session with
  * no linked questions shouldn't be able to exist, and if one does, the constant is closer to the
@@ -49,6 +53,7 @@ export function activityCardStatusLabel(status: ActivityCardStatus): string {
 export function deriveActivityCardStatus(
   inProgress: { answeredCount: number; questionCount: number } | null,
   bestScore: { score: number; maxScore: number } | null,
+  isMastered: boolean,
 ): ActivityCardStatus {
   if (inProgress) {
     return {
@@ -56,6 +61,10 @@ export function deriveActivityCardStatus(
       answered: inProgress.answeredCount,
       total: inProgress.questionCount || QUESTIONS_PER_SESSION,
     };
+  }
+
+  if (isMastered) {
+    return { kind: 'mastered' };
   }
 
   if (bestScore) {

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -2,7 +2,14 @@
 // client see" are answered in exactly one place.
 
 import { getSupabaseClient } from './supabase';
-import { DEFAULT_QUESTION_MAX_SCORE, SESSION_COLUMNS } from './sessionRules';
+import {
+  DEFAULT_QUESTION_MAX_SCORE,
+  MAX_DIFFICULTY_LEVEL,
+  SESSION_COLUMNS,
+  START_DIFFICULTY_LEVEL,
+  highestPassedLevelByType,
+  type PassedSessionRow,
+} from './sessionRules';
 import type { InstructorActivityEntry, InstructorSessionEntry, SessionListEntry, SessionRecord } from './sessionTypes';
 import { shuffleArray } from './shuffleArray';
 
@@ -77,6 +84,32 @@ export async function findInProgressSession(
     .maybeSingle();
 
   return { session: error ? null : data, error };
+}
+
+/**
+ * Where a new session for activityType should start: one level past the highest difficulty_level
+ * this student has passed for that activity type, capped at MAX_DIFFICULTY_LEVEL. No prior passed
+ * session -> START_DIFFICULTY_LEVEL, unchanged.
+ */
+export async function findStartDifficultyLevel(
+  supabase: SupabaseClient,
+  userId: string,
+  activityType: string,
+) {
+  const { data, error } = await supabase
+    .from('session_log')
+    .select('activity_type, difficulty_level, passed')
+    .eq('user_id', userId)
+    .eq('activity_type', activityType);
+
+  if (error) return { startLevel: null, error };
+
+  const highestPassed = highestPassedLevelByType((data ?? []) as PassedSessionRow[]);
+  const highestPassedLevel = highestPassed.get(activityType) ?? null;
+  const startLevel =
+    highestPassedLevel === null ? START_DIFFICULTY_LEVEL : Math.min(highestPassedLevel + 1, MAX_DIFFICULTY_LEVEL);
+
+  return { startLevel, error: null };
 }
 
 /**

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -4,10 +4,9 @@
 import { getSupabaseClient } from './supabase';
 import {
   DEFAULT_QUESTION_MAX_SCORE,
-  MAX_DIFFICULTY_LEVEL,
   SESSION_COLUMNS,
-  START_DIFFICULTY_LEVEL,
   highestPassedLevelByType,
+  nextDifficultyLevel,
   type PassedSessionRow,
 } from './sessionRules';
 import type { InstructorActivityEntry, InstructorSessionEntry, SessionListEntry, SessionRecord } from './sessionTypes';
@@ -106,8 +105,7 @@ export async function findStartDifficultyLevel(
 
   const highestPassed = highestPassedLevelByType((data ?? []) as PassedSessionRow[]);
   const highestPassedLevel = highestPassed.get(activityType) ?? null;
-  const startLevel =
-    highestPassedLevel === null ? START_DIFFICULTY_LEVEL : Math.min(highestPassedLevel + 1, MAX_DIFFICULTY_LEVEL);
+  const startLevel = nextDifficultyLevel(highestPassedLevel);
 
   return { startLevel, error: null };
 }

--- a/lib/sessionRules.ts
+++ b/lib/sessionRules.ts
@@ -60,3 +60,16 @@ export function highestPassedLevelByType(sessions: readonly PassedSessionRow[]):
   }
   return highestPassed;
 }
+
+/**
+ * The difficulty level a new session for one activity should start at, given the highest level
+ * already passed (null if none has been). One level past that, capped at MAX_DIFFICULTY_LEVEL.
+ * Shared by the session-start route (lib/sessionQueries.ts's findStartDifficultyLevel) and the
+ * activity list's level display (app/activities/page.tsx), so the two can't disagree about what
+ * "next level" means.
+ */
+export function nextDifficultyLevel(highestPassedLevel: number | null): number {
+  return highestPassedLevel === null
+    ? START_DIFFICULTY_LEVEL
+    : Math.min(highestPassedLevel + 1, MAX_DIFFICULTY_LEVEL);
+}

--- a/lib/sessionRules.ts
+++ b/lib/sessionRules.ts
@@ -5,6 +5,10 @@ export const START_DIFFICULTY_LEVEL = 1;
 export const QUESTIONS_PER_SESSION = 4;
 export const DEFAULT_QUESTION_MAX_SCORE = 25;
 
+// Mirrors ck_question_difficulty_level / ck_user_story_difficulty_level (supabase/schema.sql):
+// levels run 1-3 across the whole schema.
+export const MAX_DIFFICULTY_LEVEL = 3;
+
 // "If the student has a cumulative score of 75% on the questions, then the student can
 // advance to the next level of difficulty." (docs/requirements/requirements.md)
 export const PASS_RATIO = 0.75;
@@ -36,4 +40,23 @@ export function isPassing(cumulativeScore: number, maxScore: number): boolean {
  */
 export function scoreForAnswer(isCorrect: boolean, questionMaxScore: number | null): number {
   return isCorrect ? questionMaxScore ?? DEFAULT_QUESTION_MAX_SCORE : 0;
+}
+
+export type PassedSessionRow = { activity_type: string; difficulty_level: number; passed: boolean };
+
+/**
+ * Reduces session_log rows to the highest difficulty_level passed, per activity_type. Pure so it
+ * can be shared between computeStudentTitles (lib/titleQueries.ts, unscoped — every activity type
+ * a student has touched) and the session-start route's per-activity-type lookup
+ * (lib/sessionQueries.ts's findStartDifficultyLevel), instead of two copies of the same reduction
+ * drifting apart.
+ */
+export function highestPassedLevelByType(sessions: readonly PassedSessionRow[]): Map<string, number> {
+  const highestPassed = new Map<string, number>();
+  for (const row of sessions) {
+    if (!row.passed) continue;
+    const current = highestPassed.get(row.activity_type) ?? 0;
+    if (row.difficulty_level > current) highestPassed.set(row.activity_type, row.difficulty_level);
+  }
+  return highestPassed;
 }

--- a/lib/titleQueries.ts
+++ b/lib/titleQueries.ts
@@ -3,6 +3,7 @@
 // notification from REQ-GAM-PL-2.4) cannot drift apart.
 
 import { ACTIVITY_TYPES } from './activityTypes';
+import { highestPassedLevelByType, type PassedSessionRow } from './sessionRules';
 import type { SupabaseClient } from './sessionQueries';
 
 export type StudentTitle = {
@@ -11,7 +12,7 @@ export type StudentTitle = {
   title: string | null;
 };
 
-type SessionRow = { activity_type: string; difficulty_level: number; passed: boolean };
+type SessionRow = PassedSessionRow;
 type TitleDefinitionRow = { activity_type: string; difficulty_level: number; title_name: string };
 
 const NOT_STARTED = 'Not yet started';
@@ -41,12 +42,7 @@ export async function computeStudentTitles(supabase: SupabaseClient, userId: str
 
   const attempted = new Set(sessions.map((row) => row.activity_type));
 
-  const highestPassed = new Map<string, number>();
-  for (const row of sessions) {
-    if (!row.passed) continue;
-    const current = highestPassed.get(row.activity_type) ?? 0;
-    if (row.difficulty_level > current) highestPassed.set(row.activity_type, row.difficulty_level);
-  }
+  const highestPassed = highestPassedLevelByType(sessions);
 
   // ACTIVITY_TYPES order keeps the response deterministic regardless of session_log row order.
   const titles: StudentTitle[] = ACTIVITY_TYPES.filter((type) => attempted.has(type)).map((activityType) => {

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -372,6 +372,7 @@ ALTER TABLE title_definition ADD CONSTRAINT ck_title_definition_difficulty_level
 ALTER TABLE title_definition ADD CONSTRAINT uq_title_definition_activity_level UNIQUE (activity_type, difficulty_level);
 
 ALTER TABLE session_log ADD CONSTRAINT ck_session_log_status CHECK (status IN ('in-progress', 'completed', 'abandoned'));
+ALTER TABLE session_log ADD CONSTRAINT ck_session_log_difficulty_level CHECK (difficulty_level BETWEEN 1 AND 3);
 
 -- GitHub #82: the only two roles the app understands. Set at profile-creation time from
 -- auth.users.raw_user_meta_data.role (see app/api/profile/route.ts) — INSTRUCTOR_SIGNUP_CODE
@@ -602,6 +603,12 @@ CREATE POLICY own_submissions_insert ON submission
 --
 --   ALTER TABLE "user" ADD COLUMN IF NOT EXISTS role text NOT NULL DEFAULT 'student';
 --   ALTER TABLE "user" ADD CONSTRAINT ck_user_role CHECK (role IN ('student', 'instructor'));
+
+-- Fix (session difficulty level bug): session_log.difficulty_level has always existed (DEFAULT 1),
+-- so no column change is needed here -- only the missing CHECK constraint. Safe to add against
+-- existing rows: every session was previously inserted at level 1 regardless of activity type.
+--
+--   ALTER TABLE session_log ADD CONSTRAINT ck_session_log_difficulty_level CHECK (difficulty_level BETWEEN 1 AND 3);
 
 -- GitHub #96 (answered_question_log.answer_id renamed to submitted_option, so the column name
 -- says what it holds — the option the student picked, not a row in the answer table). RENAME


### PR DESCRIPTION
# Level Progression for Activities

Previously, every time a student started a new attempt at an activity, it always began at the
easiest level — even if they had already mastered harder levels before. This meant students could
get stuck repeating "Easy" questions over and over instead of moving forward.

## What changed

- Starting a new activity now automatically picks up at the **next difficulty level** the student
  hasn't passed yet, instead of always resetting to the easiest level.
- Once a student has completed all available difficulty levels for an activity, the "Choose an
  activity" page now shows **"All levels completed!"** instead of a level number, so they can see
  at a glance that they've mastered it.
- The activity cards on that page also now always show the correct, up-to-date level a student is
  on, based on their actual progress.

## Why it matters

Students no longer have to manually track which level they're on or feel like their progress isn't
being recognized. The app now reflects their real skill level and clearly celebrates when they've
completed everything an activity has to offer.

resolve #340