### PR TITLE
UI: Added loading animation for activities

### DIFF
--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -289,6 +289,7 @@ describe('POST /api/sessions', () => {
   // level. The ceiling for the override is the auto-advance level itself (findStartDifficultyLevel),
   // not just already-passed levels, so a level shown as "next" in the picker is a legal request too.
   it('accepts a requested difficultyLevel at or below the highest passed level', async () => {
+    queueValidActivityType();
     queue('session_log', { data: null, error: null }); // no session in progress
     queue('session_log', {
       data: [
@@ -318,6 +319,7 @@ describe('POST /api/sessions', () => {
   });
 
   it('accepts a requested difficultyLevel equal to the auto-advance level, even though it was never passed', async () => {
+    queueValidActivityType();
     queue('session_log', { data: null, error: null }); // no session in progress
     queue('session_log', {
       data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, passed: true }],
@@ -337,6 +339,7 @@ describe('POST /api/sessions', () => {
   });
 
   it('accepts a requested difficultyLevel of 1 when nothing has been passed yet', async () => {
+    queueValidActivityType();
     queue('session_log', { data: null, error: null }); // no session in progress
     queue('session_log', { data: [], error: null }); // nothing passed -> auto-advance ceiling is 1
     queue('question', { data: pool, error: null });
@@ -353,6 +356,7 @@ describe('POST /api/sessions', () => {
   });
 
   it('rejects a requested difficultyLevel above the auto-advance ceiling', async () => {
+    queueValidActivityType();
     queue('session_log', { data: null, error: null }); // no session in progress
     queue('session_log', {
       data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, passed: true }],
@@ -366,6 +370,7 @@ describe('POST /api/sessions', () => {
   });
 
   it('rejects a requested difficultyLevel above the ceiling when nothing has been passed yet', async () => {
+    queueValidActivityType();
     queue('session_log', { data: null, error: null }); // no session in progress
     queue('session_log', { data: [], error: null }); // nothing passed -> auto-advance ceiling is 1
 

--- a/app/activities/[slug]/page.tsx
+++ b/app/activities/[slug]/page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef, useState } from "react";
+import { ActivityDetailSkeleton } from "../../../components/ActivityDetailSkeleton";
 import { AppShell } from "../../../components/AppShell";
 import { CompletedAttemptsTable } from "../../../components/CompletedAttemptsTable";
 import { LevelReplaySelector } from "../../../components/LevelReplaySelector";
@@ -71,6 +72,10 @@ function ActivityDetailContent({
   // running", which the render below treats the same as "not started".
   const [current, setCurrent] = useState<CurrentSessionResult | null>(null);
   const [attempts, setAttempts] = useState<CompletedAttempt[] | null>(null);
+  // True until the current-session and completed-attempts fetches below have both resolved —
+  // the hero card and level picker render nothing real before then, only ActivityDetailSkeleton,
+  // so a level/status guess is never shown and then corrected once real data lands.
+  const [isLoading, setIsLoading] = useState(true);
   const [starting, setStarting] = useState(false);
   // The level picked in LevelReplaySelector — chosen ahead of time, not acted on until Start is
   // clicked. Seeded from initialLevel (the list page's own value) rather than null, so the badge
@@ -116,7 +121,13 @@ function ActivityDetailContent({
   // Both reads in one pass, because the page re-runs this on every return from /play: the
   // running session decides Start vs. Resume/Abandon, the finished ones fill the history below.
   useEffect(() => {
-    if (!token || !activity || !profile?.user_id) return;
+    if (!token || !activity || !profile?.user_id) {
+      // Nothing to fetch yet (still resolving auth, or no profile row — see handleStart's 409
+      // handling) — there is no load in flight to wait on, so don't leave the skeleton spinning
+      // forever; the page renders its normal empty/default state instead.
+      setIsLoading(false);
+      return;
+    }
     let cancelled = false;
 
     Promise.all([
@@ -128,6 +139,7 @@ function ActivityDetailContent({
       // An empty list and a failed read are different things, so the history only
       // renders once it is actually known — null keeps it out of the way until then.
       if (completed.ok) setAttempts(completed.data.attempts);
+      setIsLoading(false);
     });
 
     return () => {
@@ -242,72 +254,78 @@ function ActivityDetailContent({
           ← Back to Activities
         </Link>
 
-        <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-8 text-[#F3F1FF]">
-          <div className="mb-4 flex flex-wrap gap-2">
-            <span className={`rounded-full px-2.5 py-1 text-xs font-extrabold ${DIFFICULTY_COLOR[displayLevel] ?? "bg-white/10 text-brand-teal"}`}>
-              {DIFFICULTY_LABEL[displayLevel] ?? "Level"} · Level {displayLevel}
-            </span>
-            <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs font-bold text-[#A79FC9]">
-              {activity.category}
-            </span>
-          </div>
-          <h2 className="mb-2 text-2xl font-extrabold text-white">
-            {activity.name}
-          </h2>
-          <p className="mb-6 text-sm font-semibold text-[#A79FC9]">
-            {activity.instructions}
-          </p>
+        {isLoading ? (
+          <ActivityDetailSkeleton />
+        ) : (
+          <>
+            <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-8 text-[#F3F1FF]">
+              <div className="mb-4 flex flex-wrap gap-2">
+                <span className={`rounded-full px-2.5 py-1 text-xs font-extrabold ${DIFFICULTY_COLOR[displayLevel] ?? "bg-white/10 text-brand-teal"}`}>
+                  {DIFFICULTY_LABEL[displayLevel] ?? "Level"} · Level {displayLevel}
+                </span>
+                <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs font-bold text-[#A79FC9]">
+                  {activity.category}
+                </span>
+              </div>
+              <h2 className="mb-2 text-2xl font-extrabold text-white">
+                {activity.name}
+              </h2>
+              <p className="mb-6 text-sm font-semibold text-[#A79FC9]">
+                {activity.instructions}
+              </p>
 
-          {session ? (
-            <ResumeOrAbandonPrompt
-              message="You have a previous attempt in progress."
-              progressLabel={`${answeredCount} / ${totalQuestions} answered`}
-              progressFraction={totalQuestions > 0 ? answeredCount / totalQuestions : 0}
-              onResume={handleResume}
-              onAbandon={handleAbandon}
-              abandoning={abandoning}
-              confirmMessage="Abandon this in-progress attempt? Your answers so far will be discarded."
-            />
-          ) : (
-            <button
-              onClick={handleStart}
-              disabled={starting}
-              className="rounded-full bg-[#7C4DFF] px-6 py-3 text-sm font-extrabold text-white hover:bg-[#6234d1] disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {starting ? "Starting…" : "Start"}
-            </button>
-          )}
-
-          {error ? (
-            <div className="mt-4 rounded-brand-md border border-brand-danger/40 bg-brand-danger/10 p-4 text-sm font-semibold text-brand-danger-light">
-              {error.message}
-              {error.needsProfile ? (
-                <Link
-                  href="/profile"
-                  className="ml-1 underline hover:text-white"
+              {session ? (
+                <ResumeOrAbandonPrompt
+                  message="You have a previous attempt in progress."
+                  progressLabel={`${answeredCount} / ${totalQuestions} answered`}
+                  progressFraction={totalQuestions > 0 ? answeredCount / totalQuestions : 0}
+                  onResume={handleResume}
+                  onAbandon={handleAbandon}
+                  abandoning={abandoning}
+                  confirmMessage="Abandon this in-progress attempt? Your answers so far will be discarded."
+                />
+              ) : (
+                <button
+                  onClick={handleStart}
+                  disabled={starting}
+                  className="rounded-full bg-[#7C4DFF] px-6 py-3 text-sm font-extrabold text-white hover:bg-[#6234d1] disabled:cursor-not-allowed disabled:opacity-40"
                 >
-                  Go to your profile
-                </Link>
+                  {starting ? "Starting…" : "Start"}
+                </button>
+              )}
+
+              {error ? (
+                <div className="mt-4 rounded-brand-md border border-brand-danger/40 bg-brand-danger/10 p-4 text-sm font-semibold text-brand-danger-light">
+                  {error.message}
+                  {error.needsProfile ? (
+                    <Link
+                      href="/profile"
+                      className="ml-1 underline hover:text-white"
+                    >
+                      Go to your profile
+                    </Link>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {!session ? (
+                <LevelReplaySelector
+                  highestSelectableLevel={highestSelectableLevel}
+                  selectedLevel={selectedLevel}
+                  // A level, once replayable, is always selected — clicking a button switches the
+                  // selection, it never clears it back to auto-advance.
+                  onSelect={(level) => {
+                    userPickedLevelRef.current = true;
+                    setSelectedLevel(level);
+                  }}
+                  disabled={starting}
+                />
               ) : null}
             </div>
-          ) : null}
 
-          {!session ? (
-            <LevelReplaySelector
-              highestSelectableLevel={highestSelectableLevel}
-              selectedLevel={selectedLevel}
-              // A level, once replayable, is always selected — clicking a button switches the
-              // selection, it never clears it back to auto-advance.
-              onSelect={(level) => {
-                userPickedLevelRef.current = true;
-                setSelectedLevel(level);
-              }}
-              disabled={starting}
-            />
-          ) : null}
-        </div>
-
-        <CompletedAttemptsTable attempts={attempts} />
+            <CompletedAttemptsTable attempts={attempts} />
+          </>
+        )}
       </div>
     </AppShell>
   );

--- a/app/activities/[slug]/page.tsx
+++ b/app/activities/[slug]/page.tsx
@@ -28,14 +28,12 @@ const DIFFICULTY_LABEL: Record<number, string> = {
 
 // Easy-to-hard reads green-to-orange, using the existing brand palette (CLAUDE.md's Styling
 // Guidelines) rather than new hex values: brand-green for passing/easy, brand-danger — the
-// closest existing token to orange — for the hardest level, brand-gold bridging the two.
-// Level 2 (Medium) reuses components/ActivityCard.tsx's exact medium classes — a tinted pill
-// with brand-gold (the brighter of the two yellows) as the text, not just gold text on the
-// neutral bg-white/10 the other two levels keep, since plain gold text read too low-contrast
-// against this card's dark background on its own.
+// closest existing token to orange — for the hardest level, brand-gold bridging the two. All
+// three levels share the same neutral bg-white/10 pill and differ only by text color, matching
+// how the category badge right next to this one is styled.
 const DIFFICULTY_COLOR: Record<number, string> = {
   1: "bg-white/10 text-brand-green",
-  2: "bg-[#8A6100]/25 text-brand-gold",
+  2: "bg-white/10 text-brand-gold",
   3: "bg-white/10 text-brand-danger",
 };
 

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -50,6 +50,12 @@ export default function ActivitiesPage() {
   // GitHub #108: explicit loading state rather than inferring it from cards === null — the
   // retry button needs to distinguish "haven't loaded yet" from "loaded, then failed".
   const [isLoading, setIsLoading] = useState(true);
+  // Titles load in their own effect below (a failing titles call must not cost the whole list),
+  // but a card rendered before titles arrives would briefly show no title and the wrong level
+  // (nextDifficultyLevel(null) — "Easy" — even for a student who's already passed levels), then
+  // jump once titles lands. Tracked separately from isLoading so cards/titles can fail or arrive
+  // independently while the page still waits for both before showing anything real.
+  const [titlesLoading, setTitlesLoading] = useState(true);
   const [loadFailed, setLoadFailed] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
 
@@ -117,12 +123,19 @@ export default function ActivitiesPage() {
   // sessions. Not cached (see loadStudentTitles) — a title the student just earned must show up.
   // A failed call leaves titles null, which simply renders no title, same as not having one.
   useEffect(() => {
-    if (!token || !profile?.user_id) return;
+    if (!token || !profile?.user_id) {
+      // Nothing to fetch yet — don't leave the page waiting forever on a load that never started
+      // (see app/activities/[slug]/page.tsx's identical guard on its own loading state).
+      setTitlesLoading(false);
+      return;
+    }
     let cancelled = false;
+    setTitlesLoading(true);
 
     loadStudentTitles(token, profile.user_id).then((result) => {
       if (cancelled) return;
       if (result.ok) setTitles(result.data.titles);
+      setTitlesLoading(false);
     });
 
     return () => {
@@ -136,7 +149,7 @@ export default function ActivitiesPage() {
     <AppShell active="activities">
       <h3 className="mb-5 text-lg font-extrabold">Choose an activity</h3>
 
-      {isLoading ? (
+      {isLoading || titlesLoading ? (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2" role="status" aria-label="Loading activities">
           {ACTIVITIES.map((activity) => (
             <ActivityCardSkeleton key={activity.slug} />

--- a/app/activities/write-acceptance-criteria/page.tsx
+++ b/app/activities/write-acceptance-criteria/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import { ActivityDetailSkeleton } from '../../../components/ActivityDetailSkeleton';
 import { AppShell } from '../../../components/AppShell';
 import { CompletedAttemptsTable } from '../../../components/CompletedAttemptsTable';
 import { LevelReplaySelector } from '../../../components/LevelReplaySelector';
@@ -35,6 +36,10 @@ export default function WriteAcceptanceCriteriaLandingPage() {
   // local/mock notion of progress any more. null means "not checked yet or nothing running".
   const [current, setCurrent] = useState<CurrentAcSessionResult | null>(null);
   const [attempts, setAttempts] = useState<CompletedAttempt[] | null>(null);
+  // True until the current-session and completed-attempts fetches below have both resolved —
+  // the hero card renders nothing real before then, only ActivityDetailSkeleton (same as
+  // app/activities/[slug]/page.tsx).
+  const [isLoading, setIsLoading] = useState(true);
   const [starting, setStarting] = useState(false);
   const [abandoning, setAbandoning] = useState(false);
   const [error, setError] = useState<{ message: string; needsProfile: boolean } | null>(null);
@@ -42,7 +47,12 @@ export default function WriteAcceptanceCriteriaLandingPage() {
   // Both reads in one pass, because this page re-runs them on every return from /play: the
   // running session decides Start vs. Resume/Abandon, the finished ones fill the history below.
   useEffect(() => {
-    if (!token || !profile?.user_id) return;
+    if (!token || !profile?.user_id) {
+      // Nothing to fetch yet — don't leave the skeleton spinning forever waiting on a load that
+      // was never started (see app/activities/[slug]/page.tsx's identical guard).
+      setIsLoading(false);
+      return;
+    }
     let cancelled = false;
 
     Promise.all([
@@ -52,6 +62,7 @@ export default function WriteAcceptanceCriteriaLandingPage() {
       if (cancelled) return;
       if (currentResult.ok) setCurrent(currentResult.data);
       if (completed.ok) setAttempts(completed.data.attempts);
+      setIsLoading(false);
     });
 
     return () => {
@@ -146,63 +157,70 @@ export default function WriteAcceptanceCriteriaLandingPage() {
           ← Back to Activities
         </Link>
 
-        <div className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-8 text-brand-ink">
-          <div className="mb-4 flex flex-wrap gap-2">
-            {/* This activity has no difficulty progression (CLAUDE.md's "half-connected worlds"
-                note on write-acceptance-criteria) — every session is level 1, so this badge is
-                the same fixed "Easy · Level 1" app/activities/[slug]/page.tsx shows a level-1
-                student, just without a live displayLevel to read from. */}
-            <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs font-extrabold text-brand-green">
-              Easy · Level 1
-            </span>
-            <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs font-bold text-brand-ink-muted">
-              {ACTIVITY.category}
-            </span>
-          </div>
-          <h2 className="mb-2 text-2xl font-extrabold text-white">{ACTIVITY.name}</h2>
-          <p className="mb-6 text-sm font-semibold text-brand-ink-muted">{ACTIVITY.instructions}</p>
+        {isLoading ? (
+          <ActivityDetailSkeleton />
+        ) : (
+          <>
+            <div className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-8 text-brand-ink">
+              <div className="mb-4 flex flex-wrap gap-2">
+                {/* This activity has no difficulty progression (CLAUDE.md's "half-connected
+                    worlds" note on write-acceptance-criteria) — every session is level 1, so this
+                    badge is the same fixed "Easy · Level 1" app/activities/[slug]/page.tsx shows
+                    a level-1 student, just without a live displayLevel to read from. */}
+                <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs font-extrabold text-brand-green">
+                  Easy · Level 1
+                </span>
+                <span className="rounded-full bg-white/10 px-2.5 py-1 text-xs font-bold text-brand-ink-muted">
+                  {ACTIVITY.category}
+                </span>
+              </div>
+              <h2 className="mb-2 text-2xl font-extrabold text-white">{ACTIVITY.name}</h2>
+              <p className="mb-6 text-sm font-semibold text-brand-ink-muted">{ACTIVITY.instructions}</p>
 
-          {session ? (
-            <ResumeOrAbandonPrompt
-              message="You have a session in progress."
-              progressLabel={`${answeredCount} / ${totalStories} answered`}
-              progressFraction={totalStories > 0 ? answeredCount / totalStories : 0}
-              resumeLabel="Continue"
-              onResume={handleResume}
-              onAbandon={handleAbandon}
-              abandoning={abandoning}
-              confirmMessage="Abandon this in-progress attempt? Your answers so far will be discarded."
-            />
-          ) : (
-            <button
-              onClick={handleStart}
-              disabled={starting}
-              className="rounded-full bg-brand-purple px-6 py-3 text-sm font-extrabold text-white hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
-            >
-              {starting ? 'Starting…' : 'Start'}
-            </button>
-          )}
+              {session ? (
+                <ResumeOrAbandonPrompt
+                  message="You have a session in progress."
+                  progressLabel={`${answeredCount} / ${totalStories} answered`}
+                  progressFraction={totalStories > 0 ? answeredCount / totalStories : 0}
+                  resumeLabel="Continue"
+                  onResume={handleResume}
+                  onAbandon={handleAbandon}
+                  abandoning={abandoning}
+                  confirmMessage="Abandon this in-progress attempt? Your answers so far will be discarded."
+                />
+              ) : (
+                <button
+                  onClick={handleStart}
+                  disabled={starting}
+                  className="rounded-full bg-brand-purple px-6 py-3 text-sm font-extrabold text-white hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {starting ? 'Starting…' : 'Start'}
+                </button>
+              )}
 
-          {error ? (
-            <div className="mt-4 rounded-brand-md border border-brand-danger/40 bg-brand-danger/10 p-4 text-sm font-semibold text-brand-danger-light">
-              {error.message}
-              {error.needsProfile ? (
-                <Link href="/profile" className="ml-1 underline hover:text-white">
-                  Go to your profile
-                </Link>
+              {error ? (
+                <div className="mt-4 rounded-brand-md border border-brand-danger/40 bg-brand-danger/10 p-4 text-sm font-semibold text-brand-danger-light">
+                  {error.message}
+                  {error.needsProfile ? (
+                    <Link href="/profile" className="ml-1 underline hover:text-white">
+                      Go to your profile
+                    </Link>
+                  ) : null}
+                </div>
+              ) : null}
+
+              {/* Level 1 is the only level this activity ever has, so unlike
+                  app/activities/[slug]/page.tsx there's nothing to pick between — shown purely
+                  for visual consistency with the other activity detail pages (see the badge
+                  above). */}
+              {!session ? (
+                <LevelReplaySelector highestSelectableLevel={1} selectedLevel={1} onSelect={() => {}} disabled={starting} />
               ) : null}
             </div>
-          ) : null}
 
-          {/* Level 1 is the only level this activity ever has, so unlike
-              app/activities/[slug]/page.tsx there's nothing to pick between — shown purely for
-              visual consistency with the other activity detail pages (see the badge above). */}
-          {!session ? (
-            <LevelReplaySelector highestSelectableLevel={1} selectedLevel={1} onSelect={() => {}} disabled={starting} />
-          ) : null}
-        </div>
-
-        <CompletedAttemptsTable attempts={attempts} showLevel={false} />
+            <CompletedAttemptsTable attempts={attempts} showLevel={false} />
+          </>
+        )}
       </div>
     </AppShell>
   );

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -7,9 +7,9 @@ import type { ActivitySlug, Difficulty } from '../lib/activityContent';
 const DIFFICULTY_LABEL: Record<Difficulty, string> = { 1: 'Easy', 2: 'Medium', 3: 'Hard' };
 // Same green-to-orange difficulty color schema as the activity detail page
 // (app/activities/[slug]/page.tsx's DIFFICULTY_COLOR) — kept in sync there rather than shared.
-// Levels 1 and 3 there stay solid text on a neutral bg-white/10 pill; level 2 (Medium) there
-// copies this card's exact tinted-pill classes verbatim, since plain gold text alone read too
-// low-contrast on that page's dark card.
+// That page's badge uses solid text on a neutral bg-white/10 pill for all three levels; this
+// card's chips are tinted-background pills instead (its own established style, predating the
+// color schema unification), so the two intentionally differ in treatment while sharing hue.
 //
 // The tinted pill background stays a literal hex value (not the bg-brand-* token) deliberately:
 // brand-* colors are `var(--rc-*)` references (tailwind.config.js), and Tailwind can only apply

--- a/components/ActivityDetailSkeleton.tsx
+++ b/components/ActivityDetailSkeleton.tsx
@@ -1,0 +1,49 @@
+/**
+ * Shown on app/activities/[slug]/page.tsx while its current-session and completed-attempts
+ * fetches are both still in flight — shaped like the real hero card (badges, title,
+ * instructions, Start/Resume button, level picker) in the same shimmer-block style as
+ * components/AcceptanceCriteriaWritingScreenSkeleton.tsx, so nothing about "the activity" is
+ * shown until there's real data to show; CompletedAttemptsTable's own attempts === null skeleton
+ * covers the history table underneath once this skeleton gives way to the real card.
+ */
+export function ActivityDetailSkeleton() {
+  return (
+    <div role="status" aria-label="Loading activity">
+      <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-8">
+        <div className="mb-4 flex flex-wrap gap-2">
+          <span className="skeleton-block block h-6 w-24 rounded-full" />
+          <span className="skeleton-block block h-6 w-20 rounded-full" />
+        </div>
+        <span className="skeleton-block mb-3 block h-6 w-2/3 rounded-full" />
+        <span className="skeleton-block mb-1.5 block h-4 w-full rounded-full" />
+        <span className="skeleton-block mb-6 block h-4 w-4/5 rounded-full" />
+        <span className="skeleton-block block h-11 w-32 rounded-full" />
+        <div className="mt-6 flex flex-wrap gap-2">
+          <span className="skeleton-block block h-7 w-20 rounded-full" />
+          <span className="skeleton-block block h-7 w-20 rounded-full" />
+        </div>
+      </div>
+      <style jsx>{`
+        .skeleton-block {
+          background: linear-gradient(90deg, rgba(255, 255, 255, 0.06) 25%, rgba(255, 255, 255, 0.16) 37%, rgba(255, 255, 255, 0.06) 63%);
+          background-size: 400% 100%;
+          animation: skeleton-shimmer 1.6s ease-in-out infinite;
+        }
+        @keyframes skeleton-shimmer {
+          0% {
+            background-position: 100% 50%;
+          }
+          100% {
+            background-position: 0% 50%;
+          }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .skeleton-block {
+            animation: none;
+            background: rgba(255, 255, 255, 0.08);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}


### PR DESCRIPTION
## Show a loading animation instead of partial/incorrect data

Both activity detail pages (the MCQ flow and Write Acceptance Criteria) and the "Choose an activity" list page could briefly render before all their data had actually loaded — showing a default level, an empty title, or a guessed status that then jumped to the correct value a moment later once the real fetch resolved.

- Added `ActivityDetailSkeleton`, a shimmer-block loading state matching the existing skeleton style in this codebase, shown on both activity detail pages until their current-session and completed-attempts fetches have both resolved.
- The "Choose an activity" list page had a skeleton for its cards already, but the mastery-titles fetch ran in a separate, ungated effect — so cards could render with no title and the wrong level before titles arrived. Added a second loading flag so the list now waits for both fetches before showing any card.

No behavior change for a fully-loaded page — this only affects the moment between navigating in and the data actually being ready.

resolve #355 