### PR TITLE
Daily Challenge endpoint

### DIFF
--- a/__tests__/api/daily-challenge-answers.test.ts
+++ b/__tests__/api/daily-challenge-answers.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Same harness shape as __tests__/api/daily-challenge.test.ts, extended with update()/is() —
+// this route is the only one of the two that writes via UPDATE instead of INSERT.
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    updates: [] as { table: string; payload: unknown }[],
+    tables: [] as string[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      is: () => builder,
+      update: (payload: unknown) => {
+        state.updates.push({ table, payload });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'user-123' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { POST } from '../../app/api/daily-challenge/[attemptId]/answers/route';
+
+const future = new Date(Date.now() + 60_000).toISOString();
+const past = new Date(Date.now() - 60_000).toISOString();
+
+const baseAttempt = {
+  daily_challenge_attempt_id: 'attempt-1',
+  user_id: 'user-123',
+  question_id: 'q-1',
+  challenge_date: '2026-08-14',
+  started_at: '2026-08-14T10:00:00.000Z',
+  deadline_at: future,
+  submitted_option: null,
+  is_correct: null,
+  score: null,
+  submitted_at: null,
+};
+
+const questionPlain = {
+  question_id: 'q-1',
+  question_prompt: 'What is a good acceptance criterion?',
+  difficulty_level: 1,
+  activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+  max_score: 25,
+};
+
+const questionToAnswerWithSolution = [
+  { answer: { answer_id: 'a-1', option_text: 'Option 1', explanation: 'Because of X.', is_correct: true } },
+  { answer: { answer_id: 'a-2', option_text: 'Option 2', explanation: 'Because of Y.', is_correct: false } },
+];
+
+function req(body: object | null, token: string | null = 'valid-token') {
+  return new Request('http://localhost/api/daily-challenge/attempt-1/answers', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+function call(body: object | null, token: string | null = 'valid-token') {
+  return POST(req(body, token), { params: { attemptId: 'attempt-1' } });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.updates = [];
+  h.state.tables = [];
+});
+
+describe('POST /api/daily-challenge/{attemptId}/answers', () => {
+  it('returns 401 without a token', async () => {
+    expect((await call(null, null)).status).toBe(401);
+  });
+
+  it('returns 400 for a malformed JSON body', async () => {
+    const response = await POST(
+      new Request('http://localhost/api/daily-challenge/attempt-1/answers', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json', authorization: 'Bearer valid-token' },
+        body: '{ not json',
+      }),
+      { params: { attemptId: 'attempt-1' } },
+    );
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 for an unknown or not-owned attempt', async () => {
+    queue('daily_challenge_attempt', { data: null, error: null });
+
+    const response = await call({ selectedOptionId: 'a-1' });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 409 with the recorded result when already submitted', async () => {
+    const submitted = {
+      ...baseAttempt,
+      submitted_option: 'a-1',
+      is_correct: true,
+      score: 50,
+      submitted_at: '2026-08-14T10:00:30.000Z',
+    };
+    queue('daily_challenge_attempt', { data: submitted, error: null });
+    queue('question', { data: questionPlain, error: null });
+    queue('question_to_answer', { data: questionToAnswerWithSolution, error: null });
+
+    const response = await call({ selectedOptionId: 'a-2' }); // resubmitting with a different option changes nothing
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.correct).toBe(true);
+    expect(body.score).toBe(50);
+    expect(body.explanation).toBe('Because of X.');
+  });
+
+  it('returns 409 without writing anything once the deadline has passed', async () => {
+    queue('daily_challenge_attempt', { data: { ...baseAttempt, deadline_at: past }, error: null });
+
+    const response = await call({ selectedOptionId: 'a-1' });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.expired).toBe(true);
+    expect(h.state.updates).toHaveLength(0);
+    expect(h.state.tables).toEqual(['daily_challenge_attempt']);
+  });
+
+  it('returns 400 when the option does not belong to the question', async () => {
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null });
+    queue('question_to_answer', { data: null, error: null });
+
+    const response = await call({ selectedOptionId: 'a-from-another-question' });
+
+    expect(response.status).toBe(400);
+    expect(h.state.updates).toHaveLength(0);
+  });
+
+  it('awards double the question max_score for a correct answer', async () => {
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null });
+    queue('question_to_answer', { data: { answer: { answer_id: 'a-1', is_correct: true, explanation: 'Because of X.' } }, error: null });
+    queue('question', { data: { max_score: 25 }, error: null });
+    queue('daily_challenge_attempt', {
+      data: { ...baseAttempt, submitted_option: 'a-1', is_correct: true, score: 50, submitted_at: '2026-08-14T10:00:30.000Z' },
+      error: null,
+    });
+
+    const response = await call({ selectedOptionId: 'a-1' });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.correct).toBe(true);
+    expect(body.score).toBe(50);
+    expect(body.explanation).toBe('Because of X.');
+  });
+
+  it('awards zero points for an incorrect answer', async () => {
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null });
+    queue('question_to_answer', { data: { answer: { answer_id: 'a-2', is_correct: false, explanation: 'Because of Y.' } }, error: null });
+    queue('question', { data: { max_score: 25 }, error: null });
+    queue('daily_challenge_attempt', {
+      data: { ...baseAttempt, submitted_option: 'a-2', is_correct: false, score: 0, submitted_at: '2026-08-14T10:00:30.000Z' },
+      error: null,
+    });
+
+    const response = await call({ selectedOptionId: 'a-2' });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.correct).toBe(false);
+    expect(body.score).toBe(0);
+  });
+
+  it('returns 409 when a concurrent submit already won the race', async () => {
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null }); // initial select
+    queue('question_to_answer', { data: { answer: { answer_id: 'a-1', is_correct: true, explanation: 'Because of X.' } }, error: null });
+    queue('question', { data: { max_score: 25 }, error: null });
+    queue('daily_challenge_attempt', { data: null, error: null }); // update finds no row (lost race)
+    const won = { ...baseAttempt, submitted_option: 'a-2', is_correct: false, score: 0, submitted_at: '2026-08-14T10:00:30.000Z' };
+    queue('daily_challenge_attempt', { data: won, error: null }); // refetch
+    queue('question', { data: questionPlain, error: null });
+    queue('question_to_answer', { data: questionToAnswerWithSolution, error: null });
+
+    const response = await call({ selectedOptionId: 'a-1' });
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.correct).toBe(false);
+    expect(body.explanation).toBe('Because of Y.');
+  });
+});

--- a/__tests__/api/daily-challenge.test.ts
+++ b/__tests__/api/daily-challenge.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Hoisted so the vi.mock factory below can close over it safely — same harness shape as
+// __tests__/api/sessions.test.ts.
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    inserts: [] as { table: string; payload: unknown }[],
+    tables: [] as string[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      eq: () => builder,
+      in: () => builder,
+      order: () => builder,
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      single: async () => result,
+      // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly.
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+/** Queues the result the next `from(table)` chain resolves to. */
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'user-123' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { GET, POST } from '../../app/api/daily-challenge/route';
+
+const future = new Date(Date.now() + 60_000).toISOString();
+const past = new Date(Date.now() - 60_000).toISOString();
+
+const baseAttempt = {
+  daily_challenge_attempt_id: 'attempt-1',
+  user_id: 'user-123',
+  question_id: 'q-1',
+  challenge_date: '2026-08-14',
+  started_at: '2026-08-14T10:00:00.000Z',
+  deadline_at: future,
+  submitted_option: null,
+  is_correct: null,
+  score: null,
+  submitted_at: null,
+};
+
+const questionWithOptions = {
+  question_id: 'q-1',
+  question_prompt: 'What is a good acceptance criterion?',
+  difficulty_level: 1,
+  activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+  max_score: 25,
+  question_to_answer: [
+    { answer: { answer_id: 'a-1', option_text: 'Option 1' } },
+    { answer: { answer_id: 'a-2', option_text: 'Option 2' } },
+  ],
+};
+
+const questionPlain = {
+  question_id: 'q-1',
+  question_prompt: 'What is a good acceptance criterion?',
+  difficulty_level: 1,
+  activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+  max_score: 25,
+};
+
+const questionToAnswerWithSolution = [
+  { answer: { answer_id: 'a-1', option_text: 'Option 1', explanation: 'Because of X.', is_correct: true } },
+  { answer: { answer_id: 'a-2', option_text: 'Option 2', explanation: 'Because of Y.', is_correct: false } },
+];
+
+function req(method: 'GET' | 'POST', token: string | null = 'valid-token') {
+  return new Request('http://localhost/api/daily-challenge', {
+    method,
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
+}
+
+function queueNoCourses() {
+  queue('daily_challenge_attempt', { data: null, error: null }); // findTodayAttempt: none yet
+  queue('student_course', { data: [], error: null }); // getEnrolledCourseIds: not enrolled anywhere
+}
+
+function queueEligiblePool() {
+  queue('student_course', { data: [{ course_id: 'c-1' }], error: null });
+  queue('course', { data: [{ creator_id: 'instr-1' }], error: null });
+  queue('question', { data: [{ question_id: 'q-1', max_score: 25 }], error: null });
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.inserts = [];
+  h.state.tables = [];
+});
+
+describe('GET /api/daily-challenge', () => {
+  it('returns 401 without a token', async () => {
+    expect((await GET(req('GET', null))).status).toBe(401);
+  });
+
+  it('returns 401 for an invalid token', async () => {
+    expect((await GET(req('GET', 'bad-token'))).status).toBe(401);
+  });
+
+  it('reports unavailable when the student is enrolled in no courses', async () => {
+    queueNoCourses();
+
+    const body = await (await GET(req('GET'))).json();
+
+    expect(body).toEqual({ attempt: null, available: false, question: null });
+    expect(h.state.tables).toEqual(['daily_challenge_attempt', 'student_course']);
+  });
+
+  it('reports available when the enrolled courses have questions', async () => {
+    queue('daily_challenge_attempt', { data: null, error: null });
+    queueEligiblePool();
+
+    const body = await (await GET(req('GET'))).json();
+
+    expect(body).toEqual({ attempt: null, available: true, question: null });
+  });
+
+  it('returns the drawn question, undisclosed, for an in-progress attempt', async () => {
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null });
+    queue('question', { data: questionWithOptions, error: null });
+
+    const response = await GET(req('GET'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.expired).toBe(false);
+    expect(body.attempt).toEqual(baseAttempt);
+    expect(body.question.options).toHaveLength(2);
+    // The attempt row itself legitimately carries a null is_correct column pre-submission — only
+    // the options must withhold the solution.
+    body.question.options.forEach((option: Record<string, unknown>) => {
+      expect(option).not.toHaveProperty('is_correct');
+      expect(option).not.toHaveProperty('explanation');
+    });
+  });
+
+  it('reports expired without disclosing the question once the deadline has passed', async () => {
+    queue('daily_challenge_attempt', { data: { ...baseAttempt, deadline_at: past }, error: null });
+
+    const response = await GET(req('GET'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.expired).toBe(true);
+    expect(body.question).toBeNull();
+    // No question lookup for an already-expired, unsubmitted attempt.
+    expect(h.state.tables).toEqual(['daily_challenge_attempt']);
+  });
+
+  it('discloses correctness and score for a submitted attempt', async () => {
+    const submitted = {
+      ...baseAttempt,
+      submitted_option: 'a-1',
+      is_correct: true,
+      score: 50,
+      submitted_at: '2026-08-14T10:00:30.000Z',
+    };
+    queue('daily_challenge_attempt', { data: submitted, error: null });
+    queue('question', { data: questionPlain, error: null });
+    queue('question_to_answer', { data: questionToAnswerWithSolution, error: null });
+
+    const body = await (await GET(req('GET'))).json();
+
+    expect(body.correct).toBe(true);
+    expect(body.score).toBe(50);
+    expect(body.explanation).toBe('Because of X.');
+    expect(body.question.options[0]).toHaveProperty('is_correct');
+  });
+});
+
+describe('POST /api/daily-challenge', () => {
+  it('returns 401 without a token', async () => {
+    expect((await POST(req('POST', null))).status).toBe(401);
+  });
+
+  it('returns 400 when the student has no eligible questions', async () => {
+    queueNoCourses();
+
+    const response = await POST(req('POST'));
+
+    expect(response.status).toBe(400);
+    expect(h.state.inserts).toHaveLength(0);
+  });
+
+  it('draws and inserts a new attempt', async () => {
+    queue('daily_challenge_attempt', { data: null, error: null }); // findTodayAttempt: none
+    queueEligiblePool();
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null }); // insert echo
+    queue('question', { data: questionWithOptions, error: null }); // buildAttemptResponse's draw
+
+    const response = await POST(req('POST'));
+    const body = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(body.resumed).toBe(false);
+    expect(body.attempt).toEqual(baseAttempt);
+    expect(body.question.options).toHaveLength(2);
+
+    const insertPayload = h.state.inserts.find((i) => i.table === 'daily_challenge_attempt')!
+      .payload as Record<string, unknown>;
+    expect(insertPayload).toMatchObject({ user_id: 'user-123', question_id: 'q-1', challenge_date: expect.any(String) });
+  });
+
+  it('returns the existing attempt instead of drawing a second one', async () => {
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null });
+    queue('question', { data: questionWithOptions, error: null });
+
+    const response = await POST(req('POST'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.resumed).toBe(true);
+    expect(h.state.inserts).toHaveLength(0);
+  });
+
+  it('returns the winning attempt when a parallel request hit the unique index', async () => {
+    queue('daily_challenge_attempt', { data: null, error: null }); // findTodayAttempt: none
+    queueEligiblePool();
+    queue('daily_challenge_attempt', { data: null, error: { code: '23505', message: 'duplicate key' } }); // insert loses the race
+    queue('daily_challenge_attempt', { data: baseAttempt, error: null }); // refetch
+    queue('question', { data: questionWithOptions, error: null });
+
+    const response = await POST(req('POST'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.resumed).toBe(true);
+    expect(body.attempt).toEqual(baseAttempt);
+  });
+});

--- a/app/api/daily-challenge/[attemptId]/answers/route.ts
+++ b/app/api/daily-challenge/[attemptId]/answers/route.ts
@@ -1,0 +1,146 @@
+import { getSupabaseClient } from '../../../../../lib/supabase';
+import { DAILY_CHALLENGE_COLUMNS, isExpired, scoreForDailyChallenge } from '../../../../../lib/dailyChallengeRules';
+import {
+  type DailyChallengeAttempt,
+  loadDailyChallengeQuestionWithSolution,
+} from '../../../../../lib/dailyChallengeQueries';
+import type { SupabaseClient } from '../../../../../lib/sessionQueries';
+
+type SubmittedOption = { answer_id: string; is_correct: boolean; explanation: string | null };
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * POST /api/daily-challenge/{attemptId}/answers — records the caller's answer and reveals the
+ * result (GitHub #337).
+ *
+ * Write-through, same as POST /api/sessions/{sessionId}/answers: the answer is committed first,
+ * the outcome disclosed second. The time limit is enforced here, not just client-side — a
+ * request past deadline_at is rejected outright and nothing is written, since the row is
+ * deliberately left unfinalized on a miss (see supabase/schema.sql's header comment on the
+ * table).
+ */
+export async function POST(request: Request, { params }: { params: { attemptId: string } }) {
+  const token = getToken(request);
+  if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { selectedOptionId } = (body ?? {}) as { selectedOptionId?: unknown };
+
+  if (typeof selectedOptionId !== 'string') {
+    return Response.json({ error: 'selectedOptionId is required.' }, { status: 400 });
+  }
+
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
+
+  const { attemptId } = params;
+
+  // Scoped by user_id: a foreign attempt id is indistinguishable from a non-existent one, same
+  // convention POST /api/sessions/{sessionId}/answers uses for session_log.
+  const { data: attemptRow, error: attemptError } = await supabase
+    .from('daily_challenge_attempt')
+    .select(DAILY_CHALLENGE_COLUMNS)
+    .eq('daily_challenge_attempt_id', attemptId)
+    .eq('user_id', user.id)
+    .maybeSingle();
+
+  if (attemptError) return Response.json({ error: attemptError.message }, { status: 500 });
+  if (!attemptRow) return Response.json({ error: 'Attempt not found.' }, { status: 404 });
+
+  const attempt = attemptRow as DailyChallengeAttempt;
+
+  if (attempt.submitted_at) {
+    return Response.json(await alreadySubmittedBody(supabase, attempt), { status: 409 });
+  }
+
+  if (isExpired(attempt.deadline_at)) {
+    return Response.json({ error: 'Time limit exceeded.', expired: true }, { status: 409 });
+  }
+
+  // Reject options belonging to a different question, same check the session answers route runs.
+  const { data: optionRow, error: optionError } = await supabase
+    .from('question_to_answer')
+    .select('answer:answer_id ( answer_id, is_correct, explanation )')
+    .eq('question_id', attempt.question_id)
+    .eq('answer_id', selectedOptionId)
+    .maybeSingle();
+
+  if (optionError) return Response.json({ error: optionError.message }, { status: 500 });
+
+  const option = (optionRow as { answer: SubmittedOption | null } | null)?.answer;
+  if (!option) {
+    return Response.json({ error: 'Selected option does not belong to this question.' }, { status: 400 });
+  }
+
+  const { data: questionRow, error: maxScoreError } = await supabase
+    .from('question')
+    .select('max_score')
+    .eq('question_id', attempt.question_id)
+    .maybeSingle();
+
+  if (maxScoreError) return Response.json({ error: maxScoreError.message }, { status: 500 });
+
+  const score = scoreForDailyChallenge(option.is_correct, (questionRow as { max_score: number | null } | null)?.max_score ?? null);
+
+  // submitted_at IS NULL guards the same race a 23505 catch would on an insert — here it's an
+  // UPDATE, so a lost race shows up as "no row returned" instead of a unique-violation error.
+  const { data: updated, error: updateError } = await supabase
+    .from('daily_challenge_attempt')
+    .update({
+      submitted_option: option.answer_id,
+      is_correct: option.is_correct,
+      score,
+      submitted_at: new Date().toISOString(),
+    })
+    .eq('daily_challenge_attempt_id', attemptId)
+    .is('submitted_at', null)
+    .select(DAILY_CHALLENGE_COLUMNS)
+    .maybeSingle();
+
+  if (updateError) return Response.json({ error: updateError.message }, { status: 500 });
+
+  if (!updated) {
+    // Someone else's concurrent submit won the race — report the state it left behind.
+    const { data: current, error: currentError } = await supabase
+      .from('daily_challenge_attempt')
+      .select(DAILY_CHALLENGE_COLUMNS)
+      .eq('daily_challenge_attempt_id', attemptId)
+      .maybeSingle();
+
+    if (currentError) return Response.json({ error: currentError.message }, { status: 500 });
+    if (current) return Response.json(await alreadySubmittedBody(supabase, current as DailyChallengeAttempt), { status: 409 });
+    return Response.json({ error: 'This attempt has already been submitted.' }, { status: 409 });
+  }
+
+  return Response.json(
+    { attempt: updated, correct: option.is_correct, explanation: option.explanation, score },
+    { status: 200 },
+  );
+}
+
+/** The 409 body for an attempt that already has a recorded answer — discloses what was recorded. */
+async function alreadySubmittedBody(supabase: SupabaseClient, attempt: DailyChallengeAttempt) {
+  const { question } = await loadDailyChallengeQuestionWithSolution(supabase, attempt.question_id);
+  const submittedOption = question?.options.find((option) => option.answer_id === attempt.submitted_option) ?? null;
+
+  return {
+    error: 'This attempt has already been submitted.',
+    attempt,
+    correct: attempt.is_correct,
+    score: attempt.score,
+    explanation: submittedOption?.explanation ?? null,
+  };
+}

--- a/app/api/daily-challenge/route.ts
+++ b/app/api/daily-challenge/route.ts
@@ -1,0 +1,149 @@
+import { getSupabaseClient } from '../../../lib/supabase';
+import { DAILY_CHALLENGE_COLUMNS, TIME_LIMIT_SECONDS, isExpired } from '../../../lib/dailyChallengeRules';
+import {
+  type DailyChallengeAttempt,
+  findTodayAttempt,
+  loadDailyChallengeQuestion,
+  loadDailyChallengeQuestionWithSolution,
+  loadEligibleQuestionIds,
+  todayUtc,
+} from '../../../lib/dailyChallengeQueries';
+import type { SupabaseClient } from '../../../lib/sessionQueries';
+
+const UNIQUE_VIOLATION = '23505';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/daily-challenge — today's Daily Challenge state for the caller (GitHub #337).
+ *
+ * A pure read, same principle as GET /api/sessions/current: it never draws a question or starts
+ * an attempt — that is POST's job. See buildAttemptResponse below for the "what may the client
+ * see" branching this shares with POST's "existing attempt" case.
+ */
+export async function GET(request: Request) {
+  const token = getToken(request);
+  if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
+
+  const { attempt, error } = await findTodayAttempt(supabase, user.id, todayUtc());
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  if (!attempt) {
+    const { questions, error: poolError } = await loadEligibleQuestionIds(supabase, user.id);
+    if (poolError) return Response.json({ error: poolError.message }, { status: 500 });
+
+    return Response.json({ attempt: null, available: (questions ?? []).length > 0, question: null }, { status: 200 });
+  }
+
+  return buildAttemptResponse(supabase, attempt);
+}
+
+/**
+ * POST /api/daily-challenge — starts today's Daily Challenge, or returns the one already drawn.
+ *
+ * Idempotent by design, same shape as POST /api/sessions: uq_daily_challenge_attempt_user_date
+ * caps the caller at one attempt per UTC day, and "start" and "resume" are the same call.
+ */
+export async function POST(request: Request) {
+  const token = getToken(request);
+  if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
+
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
+
+  const challengeDate = todayUtc();
+
+  const existing = await findTodayAttempt(supabase, user.id, challengeDate);
+  if (existing.error) return Response.json({ error: existing.error.message }, { status: 500 });
+  if (existing.attempt) return buildAttemptResponse(supabase, existing.attempt, { resumed: true, status: 200 });
+
+  const { questions: pool, error: poolError } = await loadEligibleQuestionIds(supabase, user.id);
+  if (poolError) return Response.json({ error: poolError.message }, { status: 500 });
+
+  if (!pool || pool.length === 0) {
+    return Response.json(
+      { error: 'Enroll in a course with available questions to unlock the Daily Challenge.' },
+      { status: 400 },
+    );
+  }
+
+  const picked = pool[Math.floor(Math.random() * pool.length)];
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('daily_challenge_attempt')
+    .insert({
+      daily_challenge_attempt_id: crypto.randomUUID(),
+      user_id: user.id,
+      question_id: picked.question_id,
+      challenge_date: challengeDate,
+      deadline_at: new Date(Date.now() + TIME_LIMIT_SECONDS * 1000).toISOString(),
+    })
+    .select(DAILY_CHALLENGE_COLUMNS)
+    .single();
+
+  if (insertError || !inserted) {
+    // A parallel request already claimed today's attempt — return that one instead of failing.
+    if (insertError?.code === UNIQUE_VIOLATION) {
+      const raced = await findTodayAttempt(supabase, user.id, challengeDate);
+      if (raced.attempt) return buildAttemptResponse(supabase, raced.attempt, { resumed: true, status: 200 });
+    }
+    return Response.json({ error: insertError?.message ?? 'Could not start the Daily Challenge.' }, { status: 500 });
+  }
+
+  return buildAttemptResponse(supabase, inserted as DailyChallengeAttempt, { resumed: false, status: 201 });
+}
+
+/**
+ * The response shape shared by GET and POST once an attempt row exists — branches on whether it
+ * was submitted, and whether the deadline has passed. `extra` is only ever passed by POST
+ * (resumed flag + the status code for that branch); GET's plain read defaults to 200.
+ */
+async function buildAttemptResponse(
+  supabase: SupabaseClient,
+  attempt: DailyChallengeAttempt,
+  extra?: { resumed: boolean; status: number },
+) {
+  const status = extra?.status ?? 200;
+  const resumedField = extra ? { resumed: extra.resumed } : {};
+
+  if (attempt.submitted_at) {
+    const { question, error } = await loadDailyChallengeQuestionWithSolution(supabase, attempt.question_id);
+    if (error) return Response.json({ error: error.message }, { status: 500 });
+
+    const submittedOption = question?.options.find((option) => option.answer_id === attempt.submitted_option) ?? null;
+
+    return Response.json(
+      {
+        attempt,
+        question,
+        correct: attempt.is_correct,
+        score: attempt.score,
+        explanation: submittedOption?.explanation ?? null,
+        expired: false,
+        ...resumedField,
+      },
+      { status },
+    );
+  }
+
+  if (isExpired(attempt.deadline_at)) {
+    return Response.json({ attempt, question: null, expired: true, ...resumedField }, { status });
+  }
+
+  const { question, error } = await loadDailyChallengeQuestion(supabase, attempt.question_id);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ attempt, question, expired: false, ...resumedField }, { status });
+}

--- a/lib/dailyChallengeQueries.ts
+++ b/lib/dailyChallengeQueries.ts
@@ -1,0 +1,175 @@
+// Queries for the Daily Challenge routes (GitHub #337), so "which question comes today" and
+// "what may the client see before submitting" are answered in exactly one place — mirrors the
+// role lib/sessionQueries.ts plays for Type A sessions.
+
+import { DAILY_CHALLENGE_COLUMNS } from './dailyChallengeRules';
+import { getEnrolledCourseIds } from './courseQueries';
+import { loadQuestionOptions, type SupabaseClient } from './sessionQueries';
+import { DEFAULT_QUESTION_MAX_SCORE } from './sessionRules';
+import { shuffleArray } from './shuffleArray';
+
+// Options are never sent with is_correct/explanation before a submission exists — same
+// non-disclosure boundary as SESSION_QUESTION_COLUMNS in lib/sessionQueries.ts.
+const DAILY_CHALLENGE_QUESTION_COLUMNS = `
+  question_id,
+  question_prompt,
+  difficulty_level,
+  activity_type,
+  max_score,
+  question_to_answer (
+    answer:answer_id ( answer_id, option_text )
+  )
+`;
+
+type QuestionRow = {
+  question_id: string;
+  question_prompt: string;
+  difficulty_level: number;
+  activity_type: string;
+  max_score: number | null;
+  question_to_answer: { answer: { answer_id: string; option_text: string } | null }[] | null;
+};
+
+export type DailyChallengeAttempt = {
+  daily_challenge_attempt_id: string;
+  user_id: string;
+  question_id: string;
+  challenge_date: string;
+  started_at: string;
+  deadline_at: string;
+  submitted_option: string | null;
+  is_correct: boolean | null;
+  score: number | null;
+  submitted_at: string | null;
+};
+
+/** Today's UTC calendar day, e.g. "2026-08-14" — toISOString() is always UTC. */
+export function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** The caller's attempt for one UTC day, or null — at most one exists (uq_daily_challenge_attempt_user_date). */
+export async function findTodayAttempt(supabase: SupabaseClient, userId: string, challengeDate: string) {
+  const { data, error } = await supabase
+    .from('daily_challenge_attempt')
+    .select(DAILY_CHALLENGE_COLUMNS)
+    .eq('user_id', userId)
+    .eq('challenge_date', challengeDate)
+    .maybeSingle();
+
+  return { attempt: error ? null : (data as DailyChallengeAttempt | null), error };
+}
+
+/**
+ * The question ids the Daily Challenge may draw from for one student: every question authored
+ * by an instructor whose course the student is enrolled in (course.creator_id -> question.user_id),
+ * per the team's scoping decision — not the whole cross-instructor bank. No activity_type or
+ * difficulty_level filter: the issue asks for "one random question," not a leveled draw.
+ *
+ * A student enrolled in no courses short-circuits to an empty pool without querying course/question.
+ */
+export async function loadEligibleQuestionIds(supabase: SupabaseClient, userId: string) {
+  const enrolled = await getEnrolledCourseIds(supabase, userId);
+  if (enrolled.error) return { questions: null, error: enrolled.error };
+  if (enrolled.courseIds.length === 0) {
+    return { questions: [] as { question_id: string; max_score: number | null }[], error: null };
+  }
+
+  const { data: courses, error: coursesError } = await supabase
+    .from('course')
+    .select('creator_id')
+    .in('course_id', enrolled.courseIds);
+
+  if (coursesError) return { questions: null, error: coursesError };
+
+  const instructorIds = [...new Set(((courses ?? []) as { creator_id: string }[]).map((row) => row.creator_id))];
+  if (instructorIds.length === 0) return { questions: [], error: null };
+
+  const { data: questions, error: questionsError } = await supabase
+    .from('question')
+    .select('question_id, max_score')
+    .in('user_id', instructorIds);
+
+  if (questionsError) return { questions: null, error: questionsError };
+
+  return { questions: (questions ?? []) as { question_id: string; max_score: number | null }[], error: null };
+}
+
+/**
+ * One question with its shuffled options, no solution — the same shape loadSessionQuestions
+ * (lib/sessionQueries.ts) builds per drawn question, just fetched directly by question_id
+ * instead of via session_to_question, since a Daily Challenge attempt draws exactly one.
+ */
+export async function loadDailyChallengeQuestion(supabase: SupabaseClient, questionId: string) {
+  const { data, error } = await supabase
+    .from('question')
+    .select(DAILY_CHALLENGE_QUESTION_COLUMNS)
+    .eq('question_id', questionId)
+    .maybeSingle();
+
+  if (error) return { question: null, error };
+  if (!data) return { question: null, error: null };
+
+  const row = data as unknown as QuestionRow;
+
+  return {
+    question: {
+      question_id: row.question_id,
+      question_prompt: row.question_prompt,
+      difficulty_level: row.difficulty_level,
+      activity_type: row.activity_type,
+      max_score: row.max_score ?? DEFAULT_QUESTION_MAX_SCORE,
+      options: shuffleArray(
+        (row.question_to_answer ?? [])
+          .map((link) => link.answer)
+          .filter((answer): answer is { answer_id: string; option_text: string } => answer !== null),
+      ),
+    },
+    error: null,
+  };
+}
+
+/**
+ * The same question, but with every option's is_correct/explanation disclosed — for an attempt
+ * that has already been submitted. Reuses loadQuestionOptions (lib/sessionQueries.ts), the same
+ * "reveal after commit" helper the session feedback route reads from, rather than a second copy
+ * of that join.
+ *
+ * Only ever called after daily_challenge_attempt.submitted_at is set — revealing this before
+ * that would turn the endpoint into an oracle for trying options until one is right, the same
+ * risk loadSessionQuestions/loadQuestionOptions's split guards against.
+ */
+export async function loadDailyChallengeQuestionWithSolution(supabase: SupabaseClient, questionId: string) {
+  const [{ data: questionRow, error: questionError }, { options, error: optionsError }] = await Promise.all([
+    supabase
+      .from('question')
+      .select('question_id, question_prompt, difficulty_level, activity_type, max_score')
+      .eq('question_id', questionId)
+      .maybeSingle(),
+    loadQuestionOptions(supabase, questionId),
+  ]);
+
+  const error = questionError ?? optionsError;
+  if (error) return { question: null, error };
+  if (!questionRow) return { question: null, error: null };
+
+  const row = questionRow as {
+    question_id: string;
+    question_prompt: string;
+    difficulty_level: number;
+    activity_type: string;
+    max_score: number | null;
+  };
+
+  return {
+    question: {
+      question_id: row.question_id,
+      question_prompt: row.question_prompt,
+      difficulty_level: row.difficulty_level,
+      activity_type: row.activity_type,
+      max_score: row.max_score ?? DEFAULT_QUESTION_MAX_SCORE,
+      options: options ?? [],
+    },
+    error: null,
+  };
+}

--- a/lib/dailyChallengeRules.ts
+++ b/lib/dailyChallengeRules.ts
@@ -1,0 +1,28 @@
+// Shared rules for the Daily Challenge (GitHub #337), so the daily-challenge and its answers
+// route cannot drift apart — mirrors the role lib/sessionRules.ts plays for Type A sessions.
+
+import { toInstant } from './dateTime';
+import { scoreForAnswer } from './sessionRules';
+
+// Placeholder — neither the issue nor docs/requirements/requirements.md's "Daily Challenges"
+// entry names a specific duration. Easy to tune; nothing else depends on this exact number.
+export const TIME_LIMIT_SECONDS = 60;
+
+// "award double points" (GitHub #337).
+export const SCORE_MULTIPLIER = 2;
+
+export const DAILY_CHALLENGE_COLUMNS =
+  'daily_challenge_attempt_id, user_id, question_id, challenge_date, started_at, deadline_at, submitted_option, is_correct, score, submitted_at';
+
+/** All-or-nothing like scoreForAnswer, just doubled — "award double points" (GitHub #337). */
+export function scoreForDailyChallenge(isCorrect: boolean, questionMaxScore: number | null): number {
+  return scoreForAnswer(isCorrect, questionMaxScore) * SCORE_MULTIPLIER;
+}
+
+/**
+ * Whether the time limit has passed. deadline_at comes back from PostgREST zone-less (see
+ * lib/dateTime.ts), so it is routed through toInstant before comparing against `now`.
+ */
+export function isExpired(deadlineAt: string, now: Date = new Date()): boolean {
+  return now.getTime() > new Date(toInstant(deadlineAt)).getTime();
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -290,6 +290,32 @@ CREATE TABLE answered_question_log (
     PRIMARY KEY (log_id));
 
 
+-- ---------------------------------------------------------------------
+-- GitHub #337: Daily Challenge
+--
+-- One random cross-course question a day, drawn from the courses the student is enrolled in
+-- (course.creator_id -> question.user_id), with a server-enforced time limit and double points.
+-- submitted_option/is_correct/score/submitted_at are nullable for the same write-before-disclose
+-- reason as answered_question_log/submission: the row is inserted at draw time (locking in the
+-- question and today's deadline), then filled in only if the student submits before deadline_at.
+-- A missed deadline is left unfinalized on purpose — nothing outside this table reads it for
+-- scoring, so an unfinalized row's only job is to keep uq_daily_challenge_attempt_user_date
+-- blocking a second attempt that day, finished or not.
+-- ---------------------------------------------------------------------
+CREATE TABLE daily_challenge_attempt (
+    daily_challenge_attempt_id uuid      NOT NULL,
+    user_id                    uuid      NOT NULL,
+    question_id                uuid      NOT NULL,
+    challenge_date              date      NOT NULL,
+    started_at                  timestamp NOT NULL DEFAULT now(),
+    deadline_at                  timestamp NOT NULL,
+    submitted_option             uuid,
+    is_correct                   bool,
+    score                        int4,
+    submitted_at                 timestamp,
+    PRIMARY KEY (daily_challenge_attempt_id));
+
+
 -- =====================================================================
 -- Foreign Keys
 -- Naming pattern: fk_<table_with_the_fk>_<referenced_table>
@@ -349,6 +375,14 @@ ALTER TABLE session_to_question ADD CONSTRAINT fk_session_to_question_question F
 
 ALTER TABLE session_to_user_story ADD CONSTRAINT fk_session_to_user_story_session FOREIGN KEY (session_id) REFERENCES session_log (session_id) ON DELETE CASCADE;
 ALTER TABLE session_to_user_story ADD CONSTRAINT fk_session_to_user_story_user_story FOREIGN KEY (user_story_id) REFERENCES user_story (user_story_id);
+
+-- GitHub #337: no ON DELETE clause on the user/question FKs, matching fk_session_log_user and
+-- fk_session_to_question_question — a deleted account or question should not silently cascade
+-- away attempt history, and there is no parent session row to cascade from the way submission
+-- cascades from session_log.
+ALTER TABLE daily_challenge_attempt ADD CONSTRAINT fk_daily_challenge_attempt_user FOREIGN KEY (user_id) REFERENCES "user" (user_id);
+ALTER TABLE daily_challenge_attempt ADD CONSTRAINT fk_daily_challenge_attempt_question FOREIGN KEY (question_id) REFERENCES question (question_id);
+ALTER TABLE daily_challenge_attempt ADD CONSTRAINT fk_daily_challenge_attempt_answer FOREIGN KEY (submitted_option) REFERENCES answer (answer_id);
 
 
 -- =====================================================================
@@ -443,6 +477,15 @@ ALTER TABLE answered_question_log ADD CONSTRAINT uq_answered_question_log_sessio
 -- wiring existed.
 ALTER TABLE submission ADD CONSTRAINT uq_submission_session_user_story UNIQUE (session_id, user_story_id);
 
+-- GitHub #337: the server-side "one attempt per day" rule. A second POST for the same UTC day
+-- cannot insert a second row, race or not — the same mechanism as uq_session_log_one_active,
+-- just a plain unique index rather than a partial one since every row here counts, not only
+-- in-progress ones.
+ALTER TABLE daily_challenge_attempt ADD CONSTRAINT uq_daily_challenge_attempt_user_date UNIQUE (user_id, challenge_date);
+
+-- The daily draw's course-scoped pool query and the per-student attempt lookup both filter here.
+CREATE INDEX ix_daily_challenge_attempt_user_id ON daily_challenge_attempt (user_id);
+
 
 -- =====================================================================
 -- Score roll-up
@@ -514,6 +557,7 @@ ALTER TABLE student_course ENABLE ROW LEVEL SECURITY;
 ALTER TABLE session_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE answered_question_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE submission ENABLE ROW LEVEL SECURITY;
+ALTER TABLE daily_challenge_attempt ENABLE ROW LEVEL SECURITY;
 
 -- Without this, "user" is readable through PostgREST with the anon key —
 -- the real names of every student in the class, next to the performance
@@ -551,6 +595,13 @@ CREATE POLICY own_answers_insert ON answered_question_log
 CREATE POLICY own_submissions_select ON submission
   FOR SELECT USING (auth.uid() = user_id);
 CREATE POLICY own_submissions_insert ON submission
+  FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- GitHub #337: same own-row shape as session_log above. No UPDATE policy — recording the
+-- submitted answer is service-role only, same as submission's grading columns.
+CREATE POLICY own_daily_challenge_attempt_select ON daily_challenge_attempt
+  FOR SELECT USING (auth.uid() = user_id);
+CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
   FOR INSERT WITH CHECK (auth.uid() = user_id);
 
 
@@ -702,6 +753,13 @@ CREATE POLICY own_submissions_insert ON submission
 -- and user_story to already exist. If your database has everything above and you only need this
 -- table, run just its CREATE TABLE, both FKs, uq_session_to_user_story_position,
 -- uq_session_to_user_story_story, and RLS statements from this script.
+
+-- Daily Challenge (GitHub #337): also a new table, no rename path. Its three FKs
+-- (fk_daily_challenge_attempt_user, fk_daily_challenge_attempt_question,
+-- fk_daily_challenge_attempt_answer) require "user", question and answer to already exist. If
+-- your database has everything above and you only need this table, run just its CREATE TABLE,
+-- all three FKs, uq_daily_challenge_attempt_user_date, ix_daily_challenge_attempt_user_id, and
+-- RLS statements from this script.
 
 -- Write Acceptance Criteria sessions: if your database already has session_to_user_story and
 -- submission.session_id from an earlier run of this script but predates their being wired up to


### PR DESCRIPTION
-Resolve #337 
As the system, I want to serve one random cross-instructor question per day, enforce the time limit and one-attempt-per-day rule server-side, and award double points, so the challenge can't be gamed by a slow network or repeated retries.

New table/route — nothing exists today for this feature.
Question is drawn at random from the full question bank across all instructors — clarify with the team whether it should instead be scoped to the instructors of the student's enrolled courses.
Time limit enforced server-side (reject a submission past the deadline), not just a client-side countdown.
Awarded score is double the normal quiz value for that question.
One attempt per calendar day, enforced server-side — decide UTC vs. student-local day, keeping in mind the codebase's zone-less-timestamp gotcha (lib/dateTime.ts's toInstant()).
Do not confuse with the existing, unrelated daily-streak feature (lib/streakQueries.ts, GitHub https://github.com/brockenbrough/requirements-coach/issues/307) — that counts consecutive days of passed activities; this is a single bonus question per day.