### PR TITLE
Make the activities cache refresh in the backgound and first show the cached results

### DIFF
--- a/__tests__/lib/acSessionCache.test.ts
+++ b/__tests__/lib/acSessionCache.test.ts
@@ -86,6 +86,42 @@ describe('loadCompletedAttempts — WRITE_ACCEPTANCE_CRITERIA cache (GitHub #258
     expect(cached).toEqual({ ok: true, data: { attempts: [ATTEMPT, newAttempt] } });
   });
 
+  it('AC4: with onRevalidate, a cache hit still fetches in the background and reports a changed result', async () => {
+    // Warm the cache with the old list (device A).
+    stubFetch(() => jsonResponse({ attempts: [ATTEMPT] }));
+    await loadCompletedAttempts(TOKEN, STUDENT_ID, 'WRITE_ACCEPTANCE_CRITERIA');
+
+    // Device B finished a session in the meantime — the server now has one more attempt.
+    const newAttempt: CompletedAttempt = { ...ATTEMPT, sessionId: 'session-xyz', score: 35, passed: true };
+    const fetchSpy = stubFetch(() => jsonResponse({ attempts: [newAttempt, ATTEMPT] }));
+
+    const onRevalidate = vi.fn();
+    const result = await loadCompletedAttempts(TOKEN, STUDENT_ID, 'WRITE_ACCEPTANCE_CRITERIA', { onRevalidate });
+
+    // The cached list is what the caller gets back immediately...
+    expect(result).toEqual({ ok: true, data: { attempts: [ATTEMPT] } });
+
+    // ...but the background fetch still went out, and once it lands with a different result,
+    // onRevalidate reports it.
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(onRevalidate).toHaveBeenCalledWith([newAttempt, ATTEMPT]));
+  });
+
+  it("AC5: with onRevalidate, a cache hit whose background fetch matches doesn't report a change", async () => {
+    stubFetch(() => jsonResponse({ attempts: [ATTEMPT] }));
+    await loadCompletedAttempts(TOKEN, STUDENT_ID, 'WRITE_ACCEPTANCE_CRITERIA');
+
+    const fetchSpy = stubFetch(() => jsonResponse({ attempts: [ATTEMPT] }));
+    const onRevalidate = vi.fn();
+    await loadCompletedAttempts(TOKEN, STUDENT_ID, 'WRITE_ACCEPTANCE_CRITERIA', { onRevalidate });
+
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    // Give the background .then() a chance to run — since it never fires, there's nothing to
+    // wait for directly, so flush a tick and assert it stayed quiet.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(onRevalidate).not.toHaveBeenCalled();
+  });
+
   it('AC3: signing out clears the cache so the next student sees no previous history', async () => {
     // Student A warms the cache.
     stubFetch(() => jsonResponse({ attempts: [ATTEMPT] }));

--- a/app/activities/[slug]/page.tsx
+++ b/app/activities/[slug]/page.tsx
@@ -132,7 +132,13 @@ function ActivityDetailContent({
 
     Promise.all([
       loadCurrentSession(token, activity.activityType),
-      loadCompletedAttempts(token, profile.user_id, activity.activityType),
+      loadCompletedAttempts(token, profile.user_id, activity.activityType, {
+        // A quiz finished on another device wouldn't otherwise show up here until something on
+        // this device invalidated the cache — see loadCompletedAttempts's own comment.
+        onRevalidate: (attempts) => {
+          if (!cancelled) setAttempts(attempts);
+        },
+      }),
     ]).then(([currentResult, completed]) => {
       if (cancelled) return;
       if (currentResult.ok) setCurrent(currentResult.data);

--- a/app/activities/write-acceptance-criteria/page.tsx
+++ b/app/activities/write-acceptance-criteria/page.tsx
@@ -57,7 +57,13 @@ export default function WriteAcceptanceCriteriaLandingPage() {
 
     Promise.all([
       loadCurrentAcceptanceCriteriaSession(token),
-      loadCompletedAttempts(token, profile.user_id, 'WRITE_ACCEPTANCE_CRITERIA'),
+      loadCompletedAttempts(token, profile.user_id, 'WRITE_ACCEPTANCE_CRITERIA', {
+        // A quiz finished on another device wouldn't otherwise show up here until something on
+        // this device invalidated the cache — see loadCompletedAttempts's own comment.
+        onRevalidate: (attempts) => {
+          if (!cancelled) setAttempts(attempts);
+        },
+      }),
     ]).then(([currentResult, completed]) => {
       if (cancelled) return;
       if (currentResult.ok) setCurrent(currentResult.data);

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -248,29 +248,7 @@ export function loadSessions(
   });
 }
 
-/**
- * The student's finished attempts at one activity, newest first. An empty list is a normal
- * 200 — a student who has not completed anything yet simply has no history.
- *
- * Cached in localStorage (lib/completedAttemptsStore.ts) keyed by studentId *and* activityType,
- * the same pattern as loadStudentScore/loadSessions('completed', ...), since the activity detail
- * page otherwise refetches this on every mount. A plain call is served from the cache when
- * present; pass forceRefresh to bypass it and re-cache the server's answer — the play flow does
- * this once a session for that activity completes, since that's the only thing that changes it.
- */
-export function loadCompletedAttempts(
-  token: string,
-  studentId: string,
-  activityType: ActivityType,
-  options: { forceRefresh?: boolean } = {},
-) {
-  if (!options.forceRefresh) {
-    const cached = getCachedCompletedAttempts(studentId, activityType);
-    if (cached !== null) {
-      return Promise.resolve<ApiResult<{ attempts: CompletedAttempt[] }>>({ ok: true, data: { attempts: cached } });
-    }
-  }
-
+function fetchCompletedAttempts(token: string, studentId: string, activityType: ActivityType) {
   return request<{ attempts: CompletedAttempt[] }>(
     `/api/sessions/completed?activityType=${encodeURIComponent(activityType)}`,
     { method: 'GET' },
@@ -288,6 +266,45 @@ export function loadCompletedAttempts(
     setCachedCompletedAttempts(studentId, activityType, attempts);
     return { ok: true as const, data: { attempts } };
   });
+}
+
+/**
+ * The student's finished attempts at one activity, newest first. An empty list is a normal
+ * 200 — a student who has not completed anything yet simply has no history.
+ *
+ * Cached in localStorage (lib/completedAttemptsStore.ts) keyed by studentId *and* activityType,
+ * the same pattern as loadStudentScore/loadSessions('completed', ...), since the activity detail
+ * page otherwise refetches this on every mount. A plain call resolves from the cache immediately
+ * when present, but — unlike the other cache-first loaders — still fires the network request in
+ * parallel underneath: a session finished on another device is otherwise invisible here forever,
+ * since nothing on *this* device would ever have a reason to invalidate the cache (GitHub #333).
+ * That background result only reaches the caller via onRevalidate, and only when it actually
+ * differs from what was just returned — a same-device reload re-fetching identical rows should
+ * not cause the table to re-render. Pass forceRefresh to skip the cache and await the network
+ * result directly instead — the play flow does this once a session for that activity completes.
+ */
+export function loadCompletedAttempts(
+  token: string,
+  studentId: string,
+  activityType: ActivityType,
+  options: { forceRefresh?: boolean; onRevalidate?: (attempts: CompletedAttempt[]) => void } = {},
+) {
+  if (!options.forceRefresh) {
+    const cached = getCachedCompletedAttempts(studentId, activityType);
+    if (cached !== null) {
+      if (options.onRevalidate) {
+        const onRevalidate = options.onRevalidate;
+        fetchCompletedAttempts(token, studentId, activityType).then((result) => {
+          if (result.ok && JSON.stringify(result.data.attempts) !== JSON.stringify(cached)) {
+            onRevalidate(result.data.attempts);
+          }
+        });
+      }
+      return Promise.resolve<ApiResult<{ attempts: CompletedAttempt[] }>>({ ok: true, data: { attempts: cached } });
+    }
+  }
+
+  return fetchCompletedAttempts(token, studentId, activityType);
 }
 
 /**


### PR DESCRIPTION
The bug: loadCompletedAttempts (lib/sessionClient.ts) was cache-first in a way that fully short-circuited the network call — once localStorage had any entry for (studentId, activityType), it was served forever with no way to notice a session finished on another device.

Fix, in the shape the story asked for (show cache immediately, revalidate in parallel, only touch the table if the fetched data differs):

- lib/sessionClient.ts: extracted the fetch+cache logic into fetchCompletedAttempts, and loadCompletedAttempts now accepts an optional onRevalidate callback. On a cache hit it still resolves instantly with the cached list, but also fires the network request in the background; if the fresh result differs from what was cached (compared via JSON.stringify), onRevalidate is called with the new list. No callback → old behavior (no network on cache hit), so other callers (e.g. the activities list's best-score fetch) are unaffected.
- app/activities/[slug]/page.tsx and app/activities/write-acceptance-criteria/page.tsx (the two pages rendering CompletedAttemptsTable): pass onRevalidate: (attempts) => setAttempts(attempts), guarded by the existing cancelled flag.

resolve #358 