### PR TITLE
UI for Daily Challenge

### DIFF
--- a/__tests__/lib/dailyChallengeStatus.test.ts
+++ b/__tests__/lib/dailyChallengeStatus.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { dailyChallengeCardStatusLabel, deriveDailyChallengeCardStatus } from '../../lib/dailyChallengeStatus';
+
+describe('deriveDailyChallengeCardStatus', () => {
+  it('reports loading before the first fetch resolves', () => {
+    expect(deriveDailyChallengeCardStatus(null)).toEqual({ kind: 'loading' });
+  });
+
+  it('reports unavailable when nothing has been drawn and no questions are eligible', () => {
+    expect(deriveDailyChallengeCardStatus({ attempt: null, available: false, question: null })).toEqual({
+      kind: 'unavailable',
+    });
+  });
+
+  it('reports available when nothing has been drawn and questions are eligible', () => {
+    expect(deriveDailyChallengeCardStatus({ attempt: null, available: true, question: null })).toEqual({
+      kind: 'available',
+    });
+  });
+
+  const attempt = {
+    daily_challenge_attempt_id: 'a-1',
+    user_id: 'u-1',
+    question_id: 'q-1',
+    challenge_date: '2026-08-14',
+    started_at: '2026-08-14T10:00:00.000Z',
+    deadline_at: '2026-08-14T10:01:00.000Z',
+    submitted_option: null,
+    is_correct: null,
+    score: null,
+    submitted_at: null,
+  };
+
+  it('reports in-progress for an unsubmitted, unexpired attempt', () => {
+    expect(
+      deriveDailyChallengeCardStatus({ attempt, question: { question_id: 'q-1', question_prompt: '', difficulty_level: 1, activity_type: 'x', max_score: 25, options: [] }, expired: false }),
+    ).toEqual({ kind: 'in-progress' });
+  });
+
+  it('reports done with no result for an expired, unsubmitted attempt', () => {
+    expect(deriveDailyChallengeCardStatus({ attempt, question: null, expired: true })).toEqual({
+      kind: 'done',
+      result: null,
+    });
+  });
+
+  it('reports done with the score for a submitted attempt', () => {
+    const submitted = { ...attempt, submitted_option: 'a-1', is_correct: true, submitted_at: '2026-08-14T10:00:30.000Z' };
+    expect(
+      deriveDailyChallengeCardStatus({
+        attempt: submitted,
+        question: { question_id: 'q-1', question_prompt: '', difficulty_level: 1, activity_type: 'x', max_score: 25, options: [] },
+        correct: true,
+        score: 50,
+        expired: false,
+      }),
+    ).toEqual({ kind: 'done', result: { correct: true, score: 50 } });
+  });
+});
+
+describe('dailyChallengeCardStatusLabel', () => {
+  it('names the action for the available state', () => {
+    expect(dailyChallengeCardStatusLabel({ kind: 'available' })).toMatch(/double points/i);
+  });
+
+  it('shows the score for a completed attempt', () => {
+    expect(dailyChallengeCardStatusLabel({ kind: 'done', result: { correct: true, score: 50 } })).toBe(
+      'You scored 50 pts today — come back tomorrow.',
+    );
+  });
+
+  it('shows a distinct message for an expired, unfinished attempt', () => {
+    expect(dailyChallengeCardStatusLabel({ kind: 'done', result: null })).toBe('Time ran out today — come back tomorrow.');
+  });
+
+  it('invites joining a course when unavailable', () => {
+    expect(dailyChallengeCardStatusLabel({ kind: 'unavailable' })).toMatch(/join a course/i);
+  });
+});

--- a/app/daily-challenge/page.tsx
+++ b/app/daily-challenge/page.tsx
@@ -1,0 +1,241 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { AppShell } from '../../components/AppShell';
+import { FeedbackCard } from '../../components/FeedbackCard';
+import { QuestionCard } from '../../components/QuestionCard';
+import { loadDailyChallenge, startDailyChallenge, submitDailyChallengeAnswer } from '../../lib/dailyChallengeClient';
+import type { DailyChallengeState } from '../../lib/dailyChallengeTypes';
+import { toInstant } from '../../lib/dateTime';
+import { useRequireRole } from '../../lib/useRequireRole';
+
+function formatRemaining(ms: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`;
+}
+
+/**
+ * The Daily Challenge attempt screen (GitHub #336) — landing/in-progress/expired/completed all
+ * live on this one route, unlike the Type A activities/play split, since there is no
+ * difficulty-level choice or multi-question setup to show first: a single question either is or
+ * isn't running.
+ */
+export default function DailyChallengePage() {
+  const router = useRouter();
+  const { token, loading, authorized } = useRequireRole('student');
+
+  const [state, setState] = useState<DailyChallengeState | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!token) return;
+    const result = await loadDailyChallenge(token);
+    if (!result.ok) {
+      if (result.status === 401) {
+        router.replace('/login');
+        return;
+      }
+      setError(result.error);
+      return;
+    }
+    setState(result.data);
+  }, [token, router]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  // Ticks every second while an attempt is running and unsubmitted, computed from deadline_at via
+  // toInstant — the same UTC-pinning lib/dailyChallengeRules.ts's server-side isExpired uses, so
+  // the display and the enforcement can't disagree about what the timestamp means. Re-fetches from
+  // the server on hitting zero rather than flipping a local "expired" flag: the server is the only
+  // side that actually knows whether the deadline has passed.
+  useEffect(() => {
+    if (!state?.attempt || state.attempt.submitted_at || state.expired) {
+      setRemainingMs(null);
+      return;
+    }
+
+    const deadline = new Date(toInstant(state.attempt.deadline_at)).getTime();
+    let cancelled = false;
+
+    function tick() {
+      const remaining = deadline - Date.now();
+      if (cancelled) return;
+      setRemainingMs(Math.max(0, remaining));
+      if (remaining <= 0) {
+        clearInterval(interval);
+        void refresh();
+      }
+    }
+
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [state?.attempt, state?.expired, refresh]);
+
+  if (loading || !authorized) return null;
+
+  async function handleStart() {
+    if (!token || starting) return;
+    setStarting(true);
+    const result = await startDailyChallenge(token);
+    setStarting(false);
+
+    if (!result.ok) {
+      if (result.status === 401) {
+        router.replace('/login');
+        return;
+      }
+      setError(result.error);
+      return;
+    }
+    setState(result.data);
+  }
+
+  async function handleSubmit(selectedOptionId: string) {
+    if (!token || submitting || !state?.attempt) return;
+    setSubmitting(true);
+    const result = await submitDailyChallengeAnswer(token, state.attempt.daily_challenge_attempt_id, selectedOptionId);
+    setSubmitting(false);
+
+    if (!result.ok) {
+      if (result.status === 401) {
+        router.replace('/login');
+        return;
+      }
+      // 409: already submitted (another tab/device), or the deadline passed between the last
+      // tick and this click — the server's version wins either way, so re-read instead of
+      // reporting a conflict the student cannot act on.
+      if (result.status === 409) {
+        await refresh();
+        return;
+      }
+      setError(result.error);
+      return;
+    }
+
+    // The response already carries everything the completed view needs — no second round trip.
+    setState((current) =>
+      current
+        ? {
+            ...current,
+            attempt: result.data.attempt,
+            correct: result.data.correct,
+            score: result.data.score,
+            explanation: result.data.explanation,
+          }
+        : current,
+    );
+  }
+
+  if (error) {
+    return (
+      <AppShell active="dashboard">
+        <div className="mx-auto max-w-xl rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-6 text-sm font-semibold text-brand-danger-light">
+          {error}
+          <Link href="/dashboard" className="ml-1 underline hover:text-white">
+            Back to the dashboard
+          </Link>
+        </div>
+      </AppShell>
+    );
+  }
+
+  return (
+    <AppShell active="dashboard">
+      <div className="mx-auto max-w-xl">
+        {state === null ? (
+          <p className="text-sm font-semibold text-gray-500">Loading today’s challenge…</p>
+        ) : !state.attempt ? (
+          !state.available ? (
+            <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-6 text-[#F3F1FF]">
+              <h2 className="mb-2 text-xl font-extrabold text-white">No Daily Challenge yet</h2>
+              <p className="mb-4 text-sm font-semibold text-[#A79FC9]">
+                Join a course to unlock a daily bonus question drawn from its question bank.
+              </p>
+              <Link
+                href="/courses"
+                className="inline-block rounded-[10px] bg-[#7C4DFF] px-5 py-2.5 text-sm font-extrabold text-white hover:bg-[#6234d1]"
+              >
+                Browse courses
+              </Link>
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-6 text-[#F3F1FF]">
+              <h2 className="mb-2 text-xl font-extrabold text-white">Today’s Daily Challenge</h2>
+              <p className="mb-4 text-sm font-semibold text-[#A79FC9]">
+                One question, double points, under a time limit. The clock starts the moment you begin.
+              </p>
+              <button
+                type="button"
+                onClick={handleStart}
+                disabled={starting}
+                className="rounded-[10px] bg-[#7C4DFF] px-5 py-2.5 text-sm font-extrabold text-white transition hover:bg-[#6234d1] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {starting ? 'Starting…' : 'Start Daily Challenge'}
+              </button>
+            </div>
+          )
+        ) : state.attempt.submitted_at ? (
+          <>
+            {state.question ? (
+              <FeedbackCard
+                prompt={state.question.question_prompt}
+                options={state.question.options}
+                selectedAnswerId={state.attempt.submitted_option ?? ''}
+                correctAnswerId={
+                  state.question.options.find((option) => option.is_correct)?.answer_id ??
+                  state.attempt.submitted_option ??
+                  ''
+                }
+                selectedExplanation={state.explanation ?? null}
+                correctExplanation={
+                  state.correct ? null : state.question.options.find((option) => option.is_correct)?.explanation ?? null
+                }
+                awardedScore={state.score ?? 0}
+                isCorrect={!!state.correct}
+              />
+            ) : null}
+            <p className="mt-5 text-center text-sm font-semibold text-gray-500">
+              That’s today’s Daily Challenge — come back tomorrow for another one.
+            </p>
+          </>
+        ) : state.expired ? (
+          <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-6 text-[#F3F1FF]">
+            <h2 className="mb-2 text-xl font-extrabold text-white">Time’s up</h2>
+            <p className="mb-4 text-sm font-semibold text-[#A79FC9]">
+              Today’s attempt has closed. Come back tomorrow for a new question.
+            </p>
+            <Link
+              href="/dashboard"
+              className="inline-block rounded-[10px] bg-[#7C4DFF] px-5 py-2.5 text-sm font-extrabold text-white hover:bg-[#6234d1]"
+            >
+              Back to dashboard
+            </Link>
+          </div>
+        ) : (
+          <>
+            <div className="mb-5 flex items-center justify-between">
+              <span className="text-xs font-extrabold uppercase tracking-wide text-[#FFD666]">Daily Challenge · 2x points</span>
+              <span className="rounded-full bg-[#241f52] px-3 py-1 text-sm font-extrabold text-white">
+                {remainingMs === null ? '…' : formatRemaining(remainingMs)}
+              </span>
+            </div>
+            {state.question ? <QuestionCard question={state.question} disabled={submitting} onSubmit={handleSubmit} /> : null}
+          </>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,10 +4,13 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import { AppShell } from "../../components/AppShell";
 import { ActivityLogRow } from "../../components/ActivityLogRow";
+import { DailyChallengeCard } from "../../components/DailyChallengeCard";
 import { LeaderboardPreview } from "../../components/LeaderboardPreview";
 import { ACTIVITIES, Difficulty } from "../../lib/activityContent";
 import { toActivityLogEntry } from "../../lib/activityLogTypes";
 import { ActivityState, getActivityState } from "../../lib/activityStore";
+import { loadDailyChallenge } from "../../lib/dailyChallengeClient";
+import type { DailyChallengeState } from "../../lib/dailyChallengeTypes";
 import { type SessionListEntry, type StudentTitle, loadSessions, loadStudentTitles } from "../../lib/sessionClient";
 import { useRequireRole } from "../../lib/useRequireRole";
 
@@ -31,6 +34,7 @@ export default function DashboardPage() {
   > | null>(null);
   const [recent, setRecent] = useState<SessionListEntry[] | null>(null);
   const [titles, setTitles] = useState<StudentTitle[] | null>(null);
+  const [dailyChallenge, setDailyChallenge] = useState<DailyChallengeState | null>(null);
 
   useEffect(() => {
     if (!token) return;
@@ -66,6 +70,16 @@ export default function DashboardPage() {
     });
     return () => { cancelled = true; };
   }, [token, profile?.user_id]);
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    loadDailyChallenge(token).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setDailyChallenge(result.data);
+    });
+    return () => { cancelled = true; };
+  }, [token]);
 
   // Blank rather than a "logged out" message while useRequireRole's effect redirects — for
   // a wrong role that message would be actively misleading (an instructor isn't logged out).
@@ -249,6 +263,8 @@ export default function DashboardPage() {
           </Link>
         </div>
       )}
+
+      <DailyChallengeCard state={dailyChallenge} />
 
       {token ? <LeaderboardPreview token={token} studentId={profile?.user_id} /> : null}
 

--- a/components/DailyChallengeCard.tsx
+++ b/components/DailyChallengeCard.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Link from 'next/link';
+import { dailyChallengeCardStatusLabel, deriveDailyChallengeCardStatus } from '../lib/dailyChallengeStatus';
+import type { DailyChallengeState } from '../lib/dailyChallengeTypes';
+
+/**
+ * The dashboard's Daily Challenge entry point (GitHub #336) — same dark-card visual language as
+ * the dashboard's "continue where you left off" card (app/dashboard/page.tsx), showing whether
+ * today's attempt is still available, running, or already used.
+ */
+export function DailyChallengeCard({ state }: { state: DailyChallengeState | null }) {
+  const status = deriveDailyChallengeCardStatus(state);
+  const label = dailyChallengeCardStatusLabel(status);
+  const canPlay = status.kind === 'available' || status.kind === 'in-progress';
+
+  return (
+    <div className="mb-7 flex flex-col gap-5 rounded-2xl bg-[#1b1642] p-6 text-[#F3F1FF] sm:flex-row sm:items-center">
+      <div className="flex-1">
+        <div className="mb-2 text-xs font-extrabold uppercase tracking-wide text-[#FFD666]">Daily Challenge</div>
+        <h3 className="mb-2 text-xl font-extrabold text-white">
+          {status.kind === 'in-progress' ? 'Today’s question is waiting' : 'Today’s Daily Challenge'}
+        </h3>
+        {/* No placeholder button while loading — the same wrong-content flash the mastery title
+            slot guards against (see lib/activityCardStatus.ts's header), just for a CTA instead
+            of a title. */}
+        <p className={`mb-4 text-sm font-semibold text-[#A79FC9] ${status.kind === 'loading' ? 'opacity-60' : ''}`}>
+          {label}
+        </p>
+        {canPlay ? (
+          <Link
+            href="/daily-challenge"
+            className="inline-block rounded-[10px] bg-[#7C4DFF] px-5 py-2.5 text-sm font-extrabold text-white hover:bg-[#6234d1]"
+          >
+            {status.kind === 'in-progress' ? 'Resume' : 'Play now'}
+          </Link>
+        ) : status.kind === 'unavailable' ? (
+          <Link
+            href="/courses"
+            className="inline-block rounded-[10px] border border-[#332b6b] px-5 py-2.5 text-sm font-extrabold text-[#A79FC9] hover:border-[#8b5cf6] hover:text-white"
+          >
+            Browse courses
+          </Link>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/QuestionCard.tsx
+++ b/components/QuestionCard.tsx
@@ -1,14 +1,24 @@
 'use client';
 
 import { useState } from 'react';
-import type { SessionQuestion } from '../lib/sessionClient';
+import type { SessionQuestionOption } from '../lib/sessionClient';
+
+// Narrower than SessionQuestion on purpose: this component never reads position/difficulty_level/
+// activity_type/max_score, so any question-shaped object with a prompt, id and options — a
+// SessionQuestion (app/activities/.../play/page.tsx) or a DailyChallengeQuestion
+// (app/daily-challenge/page.tsx) — satisfies it without either caller reshaping its data.
+type QuestionCardQuestion = {
+  question_id: string;
+  question_prompt: string;
+  options: SessionQuestionOption[];
+};
 
 export function QuestionCard({
   question,
   disabled = false,
   onSubmit,
 }: {
-  question: SessionQuestion;
+  question: QuestionCardQuestion;
   disabled?: boolean;
   onSubmit: (answerId: string) => void;
 }) {

--- a/lib/dailyChallengeClient.ts
+++ b/lib/dailyChallengeClient.ts
@@ -1,0 +1,62 @@
+'use client';
+
+// The UI's one gateway to the Daily Challenge routes (GitHub #337) — same role
+// lib/sessionClient.ts plays for the MCQ session routes. request()/postJson() are copied rather
+// than imported from sessionClient.ts (both are private to that file) — the same
+// per-file-duplication precedent already accepted for getToken across the API routes.
+
+import type { ApiResult } from './sessionClient';
+import type { DailyChallengeAnswerResult, DailyChallengeState } from './dailyChallengeTypes';
+
+const NETWORK_ERROR = 'Could not reach the server. Please try again.';
+
+async function request<T>(url: string, init: RequestInit, token: string): Promise<ApiResult<T>> {
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      ...init,
+      headers: { ...init.headers, Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    return { ok: false, status: 0, error: NETWORK_ERROR };
+  }
+
+  const body = await response.json().catch(() => null);
+
+  if (!response.ok) {
+    return { ok: false, status: response.status, error: body?.error || 'Something went wrong.' };
+  }
+
+  return { ok: true, data: body as T };
+}
+
+function postJson(payload: unknown): RequestInit {
+  return {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  };
+}
+
+/** Today's state — a pure read, never draws or starts anything (GET /api/daily-challenge). */
+export function loadDailyChallenge(token: string) {
+  return request<DailyChallengeState>('/api/daily-challenge', { method: 'GET' }, token);
+}
+
+/**
+ * Starts today's Daily Challenge, or returns the one already drawn — idempotent, same as
+ * startSession (lib/sessionClient.ts). No body: the route derives everything from the token.
+ */
+export function startDailyChallenge(token: string) {
+  return request<DailyChallengeState>('/api/daily-challenge', { method: 'POST' }, token);
+}
+
+/** Submits an answer for one attempt and reveals the result in the same round trip. */
+export function submitDailyChallengeAnswer(token: string, attemptId: string, selectedOptionId: string) {
+  return request<DailyChallengeAnswerResult>(
+    `/api/daily-challenge/${attemptId}/answers`,
+    postJson({ selectedOptionId }),
+    token,
+  );
+}

--- a/lib/dailyChallengeStatus.ts
+++ b/lib/dailyChallengeStatus.ts
@@ -1,0 +1,54 @@
+// What the Daily Challenge dashboard card says (GitHub #336), split out from
+// components/DailyChallengeCard.tsx so it can be tested as a pure helper — same reason
+// lib/activityCardStatus.ts exists, since the components themselves stay untested by design.
+//
+// 'done' folds two different server states — a submitted attempt and an expired-but-never-
+// submitted one — into one card message, because both mean the same thing to the student today:
+// "come back tomorrow." The finer distinction (was there a score to show) only matters on the
+// attempt page itself, where the two need visibly different screens.
+
+import type { DailyChallengeState } from './dailyChallengeTypes';
+
+export type DailyChallengeCardStatus =
+  | { kind: 'loading' }
+  | { kind: 'unavailable' }
+  | { kind: 'available' }
+  | { kind: 'in-progress' }
+  | { kind: 'done'; result: { correct: boolean; score: number } | null };
+
+/** Which of the five states the card is in, from the raw GET /api/daily-challenge response. */
+export function deriveDailyChallengeCardStatus(state: DailyChallengeState | null): DailyChallengeCardStatus {
+  if (state === null) return { kind: 'loading' };
+
+  if (!state.attempt) {
+    return state.available ? { kind: 'available' } : { kind: 'unavailable' };
+  }
+
+  if (state.attempt.submitted_at) {
+    return { kind: 'done', result: { correct: state.correct ?? false, score: state.score ?? 0 } };
+  }
+
+  if (state.expired) {
+    return { kind: 'done', result: null };
+  }
+
+  return { kind: 'in-progress' };
+}
+
+/** The card's status line. One place, so the wording can't drift between the five states. */
+export function dailyChallengeCardStatusLabel(status: DailyChallengeCardStatus): string {
+  switch (status.kind) {
+    case 'loading':
+      return 'Checking today’s challenge…';
+    case 'unavailable':
+      return 'Join a course to unlock the Daily Challenge.';
+    case 'available':
+      return 'Double points, one question, today only.';
+    case 'in-progress':
+      return 'Challenge in progress — keep going!';
+    case 'done':
+      return status.result
+        ? `You scored ${status.result.score} pts today — come back tomorrow.`
+        : 'Time ran out today — come back tomorrow.';
+  }
+}

--- a/lib/dailyChallengeTypes.ts
+++ b/lib/dailyChallengeTypes.ts
@@ -1,0 +1,62 @@
+// The shapes the Daily Challenge routes (GitHub #337) travel over the wire — mirrors
+// lib/sessionTypes.ts's role. Deliberately imports nothing, same reasoning: it stays readable by
+// both lib/dailyChallengeClient.ts ('use client') and, if a server module ever needs the same
+// shape, without dragging a client-only module (or the service-role key) across that boundary.
+
+export type DailyChallengeOption = {
+  answer_id: string;
+  option_text: string;
+  // Only present once the attempt is submitted (loadDailyChallengeQuestionWithSolution in
+  // lib/dailyChallengeQueries.ts) — absent before that, the same non-disclosure boundary the API
+  // itself enforces (see loadDailyChallengeQuestion vs. …WithSolution).
+  explanation?: string | null;
+  is_correct?: boolean | null;
+};
+
+export type DailyChallengeQuestion = {
+  question_id: string;
+  question_prompt: string;
+  difficulty_level: number;
+  activity_type: string;
+  max_score: number;
+  options: DailyChallengeOption[];
+};
+
+/** One row of daily_challenge_attempt, exactly as the routes disclose it. */
+export type DailyChallengeAttempt = {
+  daily_challenge_attempt_id: string;
+  user_id: string;
+  question_id: string;
+  challenge_date: string;
+  started_at: string;
+  deadline_at: string;
+  submitted_option: string | null;
+  is_correct: boolean | null;
+  score: number | null;
+  submitted_at: string | null;
+};
+
+/**
+ * The shape GET/POST /api/daily-challenge both return — see app/api/daily-challenge/route.ts's
+ * buildAttemptResponse for the exact branching. `available` only appears when `attempt` is null
+ * (nothing drawn yet today); `expired`/`correct`/`score`/`explanation` only appear once an
+ * attempt exists; `resumed` only appears on the POST response.
+ */
+export type DailyChallengeState = {
+  attempt: DailyChallengeAttempt | null;
+  available?: boolean;
+  question: DailyChallengeQuestion | null;
+  expired?: boolean;
+  correct?: boolean | null;
+  score?: number | null;
+  explanation?: string | null;
+  resumed?: boolean;
+};
+
+/** POST /api/daily-challenge/{attemptId}/answers's success response. */
+export type DailyChallengeAnswerResult = {
+  attempt: DailyChallengeAttempt;
+  correct: boolean;
+  explanation: string | null;
+  score: number;
+};


### PR DESCRIPTION
As a student, I want to see and attempt today's Daily Challenge question — worth double points, under a time limit, once per day — so that I have a reason to come back and practice every day.

New "Daily Challenge" entry point (dashboard card or nav item) showing whether today's attempt is still available or already used.
Visible countdown while attempting (display only — the real limit is enforced server-side, see API story).
Once attempted, the entry point shows "come back tomorrow" until the next calendar day.
-Resolve #336 