### PR TITLE
Only show activity filters for activities a user already attempted

### DIFF
--- a/__tests__/lib/activityLogTypes.test.ts
+++ b/__tests__/lib/activityLogTypes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { summarizeStudents, type StudentActivitySummary } from '../../lib/activityLogTypes';
+import { deriveActivityFilterOptions, summarizeStudents, type ActivityLogEntry, type StudentActivitySummary } from '../../lib/activityLogTypes';
 
 /**
  * summarizeStudents is a pure helper, so this test builds its input directly instead of mocking
@@ -91,5 +91,77 @@ describe('summarizeStudents', () => {
     const rows = summarizeStudents([attempt()], [{ studentId: 'student-z', studentName: 'Zoe Newcomer' }]);
 
     expect(rows.map((row) => row.studentId).sort()).toEqual(['student-a', 'student-z']);
+  });
+});
+
+/**
+ * deriveActivityFilterOptions is a pure helper too — same "build the input directly" shape as
+ * summarizeStudents above.
+ */
+function logEntry(overrides: Partial<ActivityLogEntry> = {}): ActivityLogEntry {
+  return {
+    id: 'session-1',
+    activityType: 'identify-weak-user-stories',
+    activityName: 'Identify Weak User Stories',
+    level: 1,
+    dateTime: '2026-08-01T10:00:00.000Z',
+    status: 'completed',
+    passed: true,
+    score: 4,
+    maxScore: 4,
+    totalQuestions: 4,
+    answeredQuestions: 4,
+    ...overrides,
+  };
+}
+
+describe('deriveActivityFilterOptions', () => {
+  it('only offers activity types the student actually has entries for', () => {
+    const options = deriveActivityFilterOptions([logEntry()]);
+
+    expect(options).toEqual([{ value: 'identify-weak-user-stories', label: 'Identify Weak User Stories' }]);
+  });
+
+  it('never offers a built-in type with zero attempts', () => {
+    const options = deriveActivityFilterOptions([logEntry()]);
+
+    expect(options.some((option) => option.value === 'write-acceptance-criteria')).toBe(false);
+  });
+
+  it('returns no options for an empty log, so the filter shows only "All"', () => {
+    expect(deriveActivityFilterOptions([])).toEqual([]);
+  });
+
+  it('collapses duplicate entries of the same type into one option', () => {
+    const options = deriveActivityFilterOptions([logEntry(), logEntry({ id: 'session-2' })]);
+
+    expect(options).toHaveLength(1);
+  });
+
+  it('prefers a real quiz_name over the raw activity_type key for a custom quiz', () => {
+    const options = deriveActivityFilterOptions(
+      [logEntry({ activityType: 'custom-jane-quiz-abc123', activityName: 'custom-jane-quiz-abc123' })],
+      new Map([['custom-jane-quiz-abc123', "Jane's Custom Quiz"]]),
+    );
+
+    expect(options).toEqual([{ value: 'custom-jane-quiz-abc123', label: "Jane's Custom Quiz" }]);
+  });
+
+  it('falls back to the entry\'s own activityName when nameByType has no match', () => {
+    const options = deriveActivityFilterOptions(
+      [logEntry({ activityType: 'custom-jane-quiz-abc123', activityName: 'custom-jane-quiz-abc123' })],
+      new Map([['some-other-type', 'Some Other Quiz']]),
+    );
+
+    expect(options).toEqual([{ value: 'custom-jane-quiz-abc123', label: 'custom-jane-quiz-abc123' }]);
+  });
+
+  it('sorts options alphabetically by label', () => {
+    const options = deriveActivityFilterOptions([
+      logEntry({ activityType: 'write-acceptance-criteria', activityName: 'Write Acceptance Criteria' }),
+      logEntry({ activityType: 'identify-weak-user-stories', activityName: 'Identify Weak User Stories' }),
+    ]);
+
+    expect(options.map((option) => option.value)).toEqual(['identify-weak-user-stories', 'write-acceptance-criteria']);
   });
 });

--- a/app/dashboard/log/page.tsx
+++ b/app/dashboard/log/page.tsx
@@ -11,8 +11,9 @@ import {
 } from '../../../components/ActivityFilters';
 import { ActivityLogTable } from '../../../components/ActivityLogTable';
 import { ActivityStatsCards } from '../../../components/ActivityStatsCards';
-import { resultStateOf, toActivityLogEntry, type ActivityLogEntry } from '../../../lib/activityLogTypes';
-import { loadActivityLog } from '../../../lib/sessionClient';
+import { deriveActivityFilterOptions, resultStateOf, toActivityLogEntry, type ActivityLogEntry } from '../../../lib/activityLogTypes';
+import type { AvailableActivityTitles } from '../../../lib/leaderboardTypes';
+import { loadActivityLog, loadAvailableTitles } from '../../../lib/sessionClient';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
 const PAGE_SIZE = 8;
@@ -24,6 +25,7 @@ export default function ActivityLogPage() {
 
   const [entries, setEntries] = useState<ActivityLogEntry[] | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [availableTitles, setAvailableTitles] = useState<AvailableActivityTitles[]>([]);
 
   const [activity, setActivity] = useState<ActivityFilterValue>('all');
   const [status, setStatus] = useState<StatusFilterValue>('all');
@@ -42,10 +44,29 @@ export default function ActivityLogPage() {
       else setError(result.error);
     });
 
+    // Not blocking, and no dedicated error state: this only ever upgrades a custom quiz's filter
+    // label from its raw activity_type key to the real activity_type.quiz_name (see
+    // deriveActivityFilterOptions below) — a failure just leaves labels at their entries-only
+    // fallback rather than breaking the filter.
+    loadAvailableTitles(token, profile.user_id).then((result) => {
+      if (cancelled) return;
+      if (result.ok) setAvailableTitles(result.data.activities);
+    });
+
     return () => {
       cancelled = true;
     };
   }, [token, profile?.user_id]);
+
+  const nameByType = useMemo(
+    () => new Map(availableTitles.map((entry) => [entry.activityType, entry.activityName])),
+    [availableTitles],
+  );
+
+  const activityOptions = useMemo(
+    () => deriveActivityFilterOptions(entries ?? [], nameByType),
+    [entries, nameByType],
+  );
 
   // Filtering/sorting stays client-side over the full fetched list — the same shape GitHub #48
   // was originally built against, just sourced from the API now.
@@ -102,6 +123,7 @@ export default function ActivityLogPage() {
 
             <ActivityFilters
               activity={activity}
+              activityOptions={activityOptions}
               status={status}
               sort={sort}
               onActivityChange={handleActivityChange}

--- a/components/ActivityFilters.tsx
+++ b/components/ActivityFilters.tsx
@@ -5,13 +5,6 @@ export type ActivityFilterValue = 'all' | ActivityType;
 export type StatusFilterValue = 'all' | ActivityResultState;
 export type SortOrder = 'newest' | 'oldest' | 'highest' | 'lowest';
 
-const ACTIVITY_OPTIONS: { value: ActivityFilterValue; label: string }[] = [
-  { value: 'all', label: 'All' },
-  { value: 'IDENTIFY_WEAK_USER_STORIES', label: 'Weak User Stories' },
-  { value: 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA', label: 'Weak Acceptance Criteria' },
-  { value: 'WRITE_ACCEPTANCE_CRITERIA', label: 'Write Acceptance Criteria' },
-];
-
 const STATUS_OPTIONS: { value: StatusFilterValue; label: string }[] = [
   { value: 'all', label: 'All' },
   { value: 'passed', label: 'Passed' },
@@ -43,9 +36,17 @@ function PillButton({ active, onClick, children }: { active: boolean; onClick: (
   );
 }
 
-/** Activity + status filters (pills, so the current selection reads at a glance) plus a sort order — all controlled from the Activity Log page so filtering/sorting stays a single, testable state object. */
+/**
+ * Activity + status filters (pills, so the current selection reads at a glance) plus a sort order
+ * — all controlled from the Activity Log page so filtering/sorting stays a single, testable state
+ * object. `activityOptions` is the caller's derived "what has this student actually attempted"
+ * list (lib/activityLogTypes.ts's deriveActivityFilterOptions) — "All" is injected here rather
+ * than required from the caller, so it can never be dropped and an empty `activityOptions` still
+ * renders a usable (if single-pill) filter.
+ */
 export function ActivityFilters({
   activity,
+  activityOptions,
   status,
   sort,
   onActivityChange,
@@ -53,18 +54,24 @@ export function ActivityFilters({
   onSortChange,
 }: {
   activity: ActivityFilterValue;
+  activityOptions: { value: ActivityFilterValue; label: string }[];
   status: StatusFilterValue;
   sort: SortOrder;
   onActivityChange: (value: ActivityFilterValue) => void;
   onStatusChange: (value: StatusFilterValue) => void;
   onSortChange: (value: SortOrder) => void;
 }) {
+  const allActivityOptions: { value: ActivityFilterValue; label: string }[] = [
+    { value: 'all', label: 'All' },
+    ...activityOptions,
+  ];
+
   return (
     <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
       <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
         <div className="flex flex-wrap items-center gap-1.5">
           <span className="mr-0.5 text-[11px] font-extrabold uppercase tracking-wide text-gray-400">Activity</span>
-          {ACTIVITY_OPTIONS.map((option) => (
+          {allActivityOptions.map((option) => (
             <PillButton key={option.value} active={activity === option.value} onClick={() => onActivityChange(option.value)}>
               {option.label}
             </PillButton>

--- a/lib/activityLogTypes.ts
+++ b/lib/activityLogTypes.ts
@@ -42,6 +42,36 @@ export function resultStateOf(entry: Pick<ActivityLogEntry, 'status' | 'passed'>
   return entry.passed ? 'passed' : 'not-passed';
 }
 
+export type ActivityFilterOption = { value: ActivityType; label: string };
+
+/**
+ * The Activity Log filter's options (GitHub #380-ish "filter by what I've actually attempted") —
+ * distinct activityTypes present in `entries`, each with a human-readable label. Replaces a
+ * hardcoded 3-item list that could never surface a custom quiz and never shrank when a built-in
+ * type had zero attempts: since the options come only from `entries`, an unattempted type can
+ * never appear and an empty log yields an empty list (the filter then shows only "All").
+ *
+ * `nameByType` (activityType -> activityName, e.g. from GET /api/students/{id}/available-titles,
+ * which resolves the real activity_type.quiz_name) is optional context for a better label than an
+ * entry's own denormalized activityName can offer — toActivityLogEntry falls back to the raw
+ * activity_type key for a custom quiz, since getActivityByType only knows the three built-ins.
+ * Purely a label upgrade: it never changes which types show up as options.
+ */
+export function deriveActivityFilterOptions(
+  entries: ActivityLogEntry[],
+  nameByType: Map<string, string> = new Map(),
+): ActivityFilterOption[] {
+  const labelByType = new Map<string, string>();
+  for (const entry of entries) {
+    if (labelByType.has(entry.activityType)) continue;
+    labelByType.set(entry.activityType, nameByType.get(entry.activityType) ?? entry.activityName);
+  }
+
+  return [...labelByType.entries()]
+    .map(([value, label]) => ({ value: value as ActivityType, label }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
 /**
  * One student's attempt, as the Instructor Dashboard (GitHub #82) needs it — every field of
  * ActivityLogEntry plus who it belongs to. Deliberately an extension rather than a parallel


### PR DESCRIPTION
The Activity Log's Activity filter (components/ActivityFilters.tsx) was a hardcoded, module-level list of the three built-in activity types. It was a hand-duplicated copy of lib/activityContent.ts's built-ins, not derived from the student's real session history — so an instructor-created custom quiz the student had actually attempted had no filter pill at all, while a built-in type the student had never touched still showed a pill that filtered to nothing.

The filter's options are now derived from the activity types actually present in the student's loaded log, each with a real human-readable name — reusing data the page already fetches instead of hand-duplicating another static list.

Changes
- lib/activityLogTypes.ts — added deriveActivityFilterOptions(entries, nameByType?), a pure helper that returns the distinct activity types present in a set of log entries, sorted alphabetically by label. An optional nameByType map upgrades a custom quiz's label to its real activity_type.quiz_name (from GET /api/students/{id}/available-titles) instead of the raw DB key toActivityLogEntry falls back to today.
- components/ActivityFilters.tsx — removed the hardcoded ACTIVITY_OPTIONS constant; the component now takes an activityOptions prop and injects "All" itself, so it can never be dropped by a caller and an empty options list still renders a usable single-pill filter.
- app/dashboard/log/page.tsx — fetches loadAvailableTitles alongside the existing loadActivityLog call (non-blocking, no dedicated error state — a failure just leaves labels at their existing fallback), derives activityOptions via useMemo, and passes it to ActivityFilters.
- __tests__/lib/activityLogTypes.test.ts — added tests for deriveActivityFilterOptions: only attempted types appear, unattempted built-ins never appear, an empty log yields no options, duplicate entries collapse, custom quiz names resolve via nameByType with a fallback when absent, and alphabetical ordering.

Behavior
- A custom quiz a student has attempted now shows up as a selectable, human-readable filter pill.
- A built-in type the student has never attempted no longer shows an empty pill.
Selecting a pill and "All" behave exactly as before.
- A student with zero sessions sees only the "All" pill.

resolve #388 