### PR TITLE
Add per-course engagement endpoint

### DIFF
--- a/app/api/instructor/courses/[id]/engagement/route.ts
+++ b/app/api/instructor/courses/[id]/engagement/route.ts
@@ -1,0 +1,57 @@
+import { getSupabaseClient } from '../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../lib/instructorAuth';
+import { findOwnedCourse, getCourseEngagement } from '../../../../../../lib/courseQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * GET /api/instructor/courses/{id}/engagement — enrolled count, active students, average score,
+ * and pass rate for a course the calling instructor owns (GitHub #335).
+ *
+ * - 401 missing/invalid bearer token
+ * - 403 caller isn't an instructor (no body)
+ * - 404 course not found
+ * - 403 course exists but caller doesn't own it (no body)
+ * - 200 { courseId, courseName, enrolledCount, activeStudentCount, averageScore, passRate }
+ * - 500 Supabase not configured or any query failure
+ *
+ * averageScore and passRate are null when no enrolled student has a completed session yet.
+ * averageScore is a fraction 0–1 (e.g. 0.72 = 72%), not a raw point total.
+ */
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const found = await findOwnedCourse(supabase, params.id, guard.user_id);
+  if (found.status === 'error') return Response.json({ error: found.error.message }, { status: 500 });
+  if (found.status === 'not_found') return Response.json({ error: 'Course not found.' }, { status: 404 });
+  if (found.status === 'forbidden') return new Response(null, { status: 403 });
+
+  const { engagement, error } = await getCourseEngagement(supabase, params.id);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json(
+    {
+      courseId: found.course.course_id,
+      courseName: found.course.course_name,
+      enrolledCount: engagement!.enrolledCount,
+      activeStudentCount: engagement!.activeStudentCount,
+      averageScore: engagement!.averageScore,
+      passRate: engagement!.passRate,
+    },
+    { status: 200 },
+  );
+}

--- a/lib/courseQueries.ts
+++ b/lib/courseQueries.ts
@@ -220,6 +220,69 @@ export async function loadEnrolledStudents(supabase: SupabaseClient, courseId: s
   return { students, error: null };
 }
 
+export type CourseEngagement = {
+  enrolledCount: number;
+  activeStudentCount: number;
+  averageScore: number | null;
+  passRate: number | null;
+};
+
+/**
+ * Per-course engagement stats for the instructor dashboard (GitHub #335).
+ * Three numbers come from two queries merged in JS:
+ *   1. student_course → list of enrolled user_ids (→ enrolledCount)
+ *   2. session_log for those users, status=completed → activeStudentCount, averageScore, passRate
+ * "Active" means at least one completed session ever, not necessarily in a date window.
+ * averageScore/passRate are null when no enrolled student has a completed session yet.
+ */
+export async function getCourseEngagement(
+  supabase: SupabaseClient,
+  courseId: string,
+): Promise<{ engagement: CourseEngagement | null; error: { message: string } | null }> {
+  const { data: enrolled, error: enrolledError } = await supabase
+    .from('student_course')
+    .select('user_id')
+    .eq('course_id', courseId);
+
+  if (enrolledError) return { engagement: null, error: enrolledError };
+
+  const enrolledIds = ((enrolled ?? []) as { user_id: string }[]).map((r) => r.user_id);
+
+  if (enrolledIds.length === 0) {
+    return {
+      engagement: { enrolledCount: 0, activeStudentCount: 0, averageScore: null, passRate: null },
+      error: null,
+    };
+  }
+
+  const { data: sessions, error: sessionsError } = await supabase
+    .from('session_log')
+    .select('user_id, cumulative_score, max_score, passed')
+    .in('user_id', enrolledIds)
+    .eq('status', 'completed');
+
+  if (sessionsError) return { engagement: null, error: sessionsError };
+
+  type SessionRow = { user_id: string; cumulative_score: number; max_score: number; passed: boolean | null };
+  const rows = (sessions ?? []) as SessionRow[];
+
+  const activeStudentCount = new Set(rows.map((r) => r.user_id)).size;
+
+  const scorable = rows.filter((r) => r.max_score > 0);
+  const averageScore =
+    scorable.length > 0
+      ? scorable.reduce((sum, r) => sum + r.cumulative_score / r.max_score, 0) / scorable.length
+      : null;
+
+  const passRate =
+    rows.length > 0 ? rows.filter((r) => r.passed === true).length / rows.length : null;
+
+  return {
+    engagement: { enrolledCount: enrolledIds.length, activeStudentCount, averageScore, passRate },
+    error: null,
+  };
+}
+
 /**
  * Unenrolls a student. Idempotent by design: deleting a link that doesn't exist is still a
  * success (error stays null either way) — the end state ("not enrolled") is identical, and the


### PR DESCRIPTION
New endpoint `GET /api/instructor/courses/{id}/engagement` returns enrolled student count, active student count, average score, and pass rate for a course the instructor owns.

- Call endpoint with valid instructor token → 200 with enrolledCount, activeStudentCount, averageScore, passRate
- Call with another instructor's course id → 403
- Call with unknown course id → 404

Resolves #335
