### PR TITLE
Show assembled quiz names in per-course stats on instructor dashboard

### DIFF
--- a/app/api/instructor/statistics/route.ts
+++ b/app/api/instructor/statistics/route.ts
@@ -1,6 +1,8 @@
 import { getSupabaseClient } from '../../../../lib/supabase';
 import { requireInstructor } from '../../../../lib/instructorAuth';
 import { computeQuizStatistics } from '../../../../lib/quizStatisticsQueries';
+import { findOwnedCourse } from '../../../../lib/courseQueries';
+import { computeCourseQuizStats } from '../../../../lib/assembledQuizQueries';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -32,11 +34,23 @@ export async function GET(request: Request) {
         );
   }
 
+  const { searchParams } = new URL(request.url);
+  const courseId = searchParams.get('courseId');
+
+  if (courseId) {
+    const found = await findOwnedCourse(supabase, courseId, guard.user_id);
+    if (found.status === 'error') return Response.json({ error: found.error.message }, { status: 500 });
+    if (found.status === 'not_found') return Response.json({ error: 'Course not found.' }, { status: 404 });
+    if (found.status === 'forbidden') return new Response(null, { status: 403 });
+
+    const { stats, error } = await computeCourseQuizStats(supabase, courseId);
+    if (error) return Response.json({ error: error.message }, { status: 500 });
+    return Response.json({ statistics: stats ?? [] }, { status: 200 });
+  }
+
   const { statistics, error } = await computeQuizStatistics(supabase);
   if (error) return Response.json({ error: error.message }, { status: 500 });
 
-  // AC: 404 when there are no quizzes at all — not to be confused with a quiz that simply has
-  // no completed attempts yet, which still gets an entry (at 0%/0%).
   if (!statistics || statistics.length === 0) {
     return Response.json({ error: 'No quizzes found for this professor.' }, { status: 404 });
   }

--- a/components/InstructorActivityStats.tsx
+++ b/components/InstructorActivityStats.tsx
@@ -1,5 +1,6 @@
 import type { OwnedActivityTypeSummary } from '../lib/activityTypeQueries';
 import type { StudentActivitySummary } from '../lib/activityLogTypes';
+import type { CourseActivityStats } from '../lib/courseClient';
 
 /**
  * Class-wide average score and pass rate per activity type — the baseline an instructor reads
@@ -24,11 +25,56 @@ export function InstructorActivityStats({
   entries,
   ownedActivityTypes,
   acParticipation,
+  courseStats,
 }: {
   entries: StudentActivitySummary[];
   ownedActivityTypes: OwnedActivityTypeSummary[];
   acParticipation: { attempted: number; total: number } | null;
+  courseStats?: CourseActivityStats[] | null;
 }) {
+  // Course-scoped mode: only show catalogs assigned to this course (via assembled_quiz)
+  if (courseStats !== undefined && courseStats !== null) {
+    if (courseStats.length === 0) {
+      return (
+        <div className="mb-6 rounded-brand-lg border border-gray-100 bg-gray-50 p-5 text-sm font-semibold text-gray-400">
+          No quizzes assigned to this course yet.
+        </div>
+      );
+    }
+    return (
+      <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+        {courseStats.map((stat) => {
+          return (
+            <div key={stat.quizId} className="rounded-brand-lg border border-gray-100 bg-gray-50 p-5">
+              <p className="text-sm font-extrabold text-brand-navy">{stat.quizName}</p>
+              <div className="mt-3 flex gap-8">
+                <div>
+                  <div className="text-xl font-extrabold tabular-nums text-brand-navy">
+                    {stat.classAverage > 0 ? `${stat.classAverage}%` : '—'}
+                  </div>
+                  <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">Class average</div>
+                </div>
+                <div>
+                  <div className="text-xl font-extrabold tabular-nums text-brand-teal-dark">
+                    {stat.passRate > 0 ? `${stat.passRate}%` : '—'}
+                  </div>
+                  <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">Pass rate</div>
+                </div>
+                <div>
+                  <div className="text-xl font-extrabold tabular-nums text-brand-navy">
+                    {stat.completionCount} / {stat.enrolledCount}
+                  </div>
+                  <div className="mt-0.5 text-xs font-bold uppercase tracking-wide text-gray-400">Attempted</div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Class-wide mode: show instructor's own catalogs
   return (
     <div className="mb-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
       {ownedActivityTypes.map((activity) => {

--- a/lib/assembledQuizQueries.ts
+++ b/lib/assembledQuizQueries.ts
@@ -194,6 +194,88 @@ export async function deleteAssembledQuiz(supabase: SupabaseClient, quizId: stri
 }
 
 /** Every activity_type this quiz currently draws from, for validation and composition queries. */
+export type CourseQuizStat = {
+  quizId: string;
+  quizName: string;
+  classAverage: number;
+  passRate: number;
+  completionCount: number;
+  enrolledCount: number;
+};
+
+/**
+ * Per-assembled-quiz stats for a course: class average, pass rate, and how many enrolled
+ * students completed at least one session for any catalog in that quiz.
+ */
+export async function computeCourseQuizStats(
+  supabase: SupabaseClient,
+  courseId: string,
+): Promise<{ stats: CourseQuizStat[] | null; error: { message: string } | null }> {
+  type QuizRow = {
+    assembled_quiz_id: string;
+    quiz_name: string;
+    assembled_quiz_catalog: { activity_type: string }[] | null;
+  };
+  type SessionRow = { activity_type: string; cumulative_score: number; max_score: number; passed: boolean; user_id: string };
+
+  const [quizzesResult, enrolledResult] = await Promise.all([
+    supabase
+      .from('assembled_quiz')
+      .select('assembled_quiz_id, quiz_name, assembled_quiz_catalog(activity_type)')
+      .eq('course_id', courseId),
+    supabase.from('student_course').select('user_id').eq('course_id', courseId),
+  ]);
+
+  if (quizzesResult.error) return { stats: null, error: quizzesResult.error };
+  if (enrolledResult.error) return { stats: null, error: enrolledResult.error };
+
+  const quizzes = (quizzesResult.data ?? []) as unknown as QuizRow[];
+  const studentIds = ((enrolledResult.data ?? []) as { user_id: string }[]).map((r) => r.user_id);
+  const enrolledCount = studentIds.length;
+
+  if (quizzes.length === 0) return { stats: [], error: null };
+
+  const allActivityTypes = [...new Set(quizzes.flatMap((q) => (q.assembled_quiz_catalog ?? []).map((c) => c.activity_type)))];
+
+  let sessionQuery = supabase
+    .from('session_log')
+    .select('activity_type, cumulative_score, max_score, passed, user_id')
+    .eq('status', 'completed')
+    .in('activity_type', allActivityTypes);
+
+  if (studentIds.length > 0) sessionQuery = sessionQuery.in('user_id', studentIds);
+
+  const { data: sessionRows, error: sessionError } = await sessionQuery;
+  if (sessionError) return { stats: null, error: sessionError };
+
+  const sessions = (sessionRows ?? []) as SessionRow[];
+
+  const stats: CourseQuizStat[] = quizzes.map((quiz) => {
+    const quizActivityTypes = new Set((quiz.assembled_quiz_catalog ?? []).map((c) => c.activity_type));
+    const quizSessions = sessions.filter((s) => quizActivityTypes.has(s.activity_type));
+
+    const completionCount = new Set(quizSessions.map((s) => s.user_id)).size;
+
+    if (quizSessions.length === 0) {
+      return { quizId: quiz.assembled_quiz_id, quizName: quiz.quiz_name, classAverage: 0, passRate: 0, completionCount, enrolledCount };
+    }
+
+    const totalPercent = quizSessions.reduce((sum, s) => sum + (s.max_score > 0 ? (s.cumulative_score / s.max_score) * 100 : 0), 0);
+    const passCount = quizSessions.filter((s) => s.passed).length;
+
+    return {
+      quizId: quiz.assembled_quiz_id,
+      quizName: quiz.quiz_name,
+      classAverage: Math.round(totalPercent / quizSessions.length),
+      passRate: Math.round((passCount / quizSessions.length) * 100),
+      completionCount,
+      enrolledCount,
+    };
+  });
+
+  return { stats, error: null };
+}
+
 export async function listQuizCatalogActivityTypes(supabase: SupabaseClient, quizId: string) {
   const { data, error } = await supabase.from('assembled_quiz_catalog').select('activity_type').eq('assembled_quiz_id', quizId);
   if (error) return { activityTypes: null, error };

--- a/lib/courseClient.ts
+++ b/lib/courseClient.ts
@@ -156,6 +156,24 @@ export function loadCourseQuizzes(token: string, courseId: string): Promise<ApiR
   );
 }
 
+export type CourseActivityStats = {
+  quizId: string;
+  quizName: string;
+  classAverage: number;
+  passRate: number;
+  completionCount: number;
+  enrolledCount: number;
+};
+
+/** Per-quiz completion stats scoped to a course (GET /api/instructor/statistics?courseId=). */
+export function loadCourseStats(token: string, courseId: string): Promise<ApiResult<{ statistics: CourseActivityStats[] }>> {
+  return request<{ statistics: CourseActivityStats[] }>(
+    `/api/instructor/statistics?courseId=${encodeURIComponent(courseId)}`,
+    { method: 'GET' },
+    token,
+  );
+}
+
 /** Enrolls a student in a course (POST /api/instructor/courses/{id}/students). */
 export function addStudentToCourse(token: string, courseId: string, studentId: string): Promise<ApiResult<{ student: CourseStudent }>> {
   return request<{ student: CourseStudent }>(


### PR DESCRIPTION
- Instructor dashboard shows per-course quiz completion stats grouped by assembled quiz
- Clicking a course card displays one stat card per quiz assigned to that course, with the quiz name (e.g. "Karwans Quiz"), class average, pass rate, and X/Y attempted
- Stats are scoped to enrolled students of the selected course

- `lib/assembledQuizQueries.ts`: new `computeCourseQuizStats()` — fetches all assembled quizzes for a course, aggregates session_log stats across each quiz's catalogs, scoped to enrolled students
- `app/api/instructor/statistics/route.ts`: course-scoped branch now calls `computeCourseQuizStats` instead of the old catalog filter
- `lib/courseClient.ts`: `CourseActivityStats` type updated to `{ quizId, quizName, classAverage, passRate, completionCount, enrolledCount }`
- `components/InstructorActivityStats.tsx`: course-mode cards now display the quiz name directly

Resolves #394
