### PR TITLE
Guide instructor to Question Catalogs before Quizzes on course

### DIFF
--- a/app/instructor/assembled-quizzes/page.tsx
+++ b/app/instructor/assembled-quizzes/page.tsx
@@ -62,10 +62,7 @@ export default function InstructorAssembledQuizzesPage() {
   if (loading || !authorized) return null;
   if (!token) return null;
 
-  function handleCreated(quiz: { id: string; name: string; description: string | null; courseId: string; catalogNames: string[] }) {
-    // Optimistic insert: the response only echoes ids, but the course name needed to render the
-    // new row is already in this page's own state (courses, loaded for the modal's own dropdown)
-    // — catalogNames comes from the modal itself, which has the same mapping available.
+  function handleCreated(quiz: { id: string; name: string; description: string | null; courseId: string; catalogs: { activityType: string; name: string }[]; catalogNames: string[] }) {
     const course = (courses ?? []).find((c) => c.id === quiz.courseId);
 
     setQuizzes((current) => [
@@ -75,6 +72,7 @@ export default function InstructorAssembledQuizzesPage() {
         description: quiz.description,
         courseId: quiz.courseId,
         courseName: course?.name ?? 'Unknown course',
+        catalogs: quiz.catalogs,
         catalogNames: quiz.catalogNames,
         createdAt: new Date().toISOString(),
       },

--- a/app/instructor/courses/[id]/page.tsx
+++ b/app/instructor/courses/[id]/page.tsx
@@ -251,9 +251,6 @@ export default function CourseDetailPage({ params }: { params: { id: string } })
 
             {error ? <p className="mb-4 text-sm font-semibold text-brand-danger">{error}</p> : null}
 
-            <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">
-              Quizzes {quizzes ? `(${quizzes.length})` : ''}
-            </p>
             {quizzesLoadFailed ? (
               <div className="rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-4 text-center">
                 <p className="mb-3 text-sm font-semibold text-brand-danger">Failed to load this course&apos;s quizzes.</p>
@@ -268,7 +265,7 @@ export default function CourseDetailPage({ params }: { params: { id: string } })
             ) : quizzes === null ? (
               <p className="text-sm font-semibold text-gray-500">Loading…</p>
             ) : (
-              <CourseQuizzesList quizzes={quizzes} />
+              <CourseQuizzesList quizzes={quizzes} courseId={params.id} />
             )}
           </>
         )}

--- a/app/instructor/quizzes/page.tsx
+++ b/app/instructor/quizzes/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
 import { AppShell } from '../../../components/AppShell';
 import { CreateCatalogModal } from '../../../components/CreateCatalogModal';
 import { loadQuizzes, type CreatedQuiz, type QuizSummary } from '../../../lib/quizClient';
@@ -29,7 +30,17 @@ const TOAST_MS = 3200;
  * (GitHub #359) that replaces the retired flat Question Bank page.
  */
 export default function InstructorQuizzesPage() {
+  return (
+    <Suspense fallback={null}>
+      <InstructorQuizzesContent />
+    </Suspense>
+  );
+}
+
+function InstructorQuizzesContent() {
   const { token, profile, loading, authorized } = useRequireRole('instructor');
+  const searchParams = useSearchParams();
+  const fromCourseId = searchParams.get('courseId');
 
   const [quizzes, setQuizzes] = useState<QuizSummary[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -105,6 +116,16 @@ export default function InstructorQuizzesPage() {
             Create catalog
           </button>
         </div>
+
+        {fromCourseId ? (
+          <div className="mb-5 mt-3 flex items-center gap-2.5 rounded-brand-md border border-brand-purple/30 bg-brand-purple/5 px-4 py-3 text-sm font-semibold text-brand-navy">
+            Create a catalog, then&nbsp;
+            <Link href={`/instructor/courses/${encodeURIComponent(fromCourseId)}`} className="font-extrabold text-brand-purple hover:underline">
+              return to your course
+            </Link>
+            &nbsp;to assemble a quiz from it.
+          </div>
+        ) : null}
 
         {toastMessage ? (
           <div

--- a/components/CourseQuizzesList.tsx
+++ b/components/CourseQuizzesList.tsx
@@ -1,45 +1,85 @@
 import Link from 'next/link';
 import type { AssembledQuizSummary } from '../lib/assembledQuizClient';
 
-/**
- * A course's assigned quizzes (GitHub #360, course detail page section added in a #362
- * follow-up) — same card/list look as CourseStudentList.tsx so the page's two sections
- * (participants, content) read as one design system rather than two. Each row links straight to
- * the quiz's own existing detail page (app/instructor/assembled-quizzes/[quizId]/page.tsx,
- * GitHub #360/#361) rather than duplicating any composition UI here — this is a read-only summary,
- * the same relationship CourseCard has to the course detail page it links into.
- */
-export function CourseQuizzesList({ quizzes }: { quizzes: AssembledQuizSummary[] }) {
-  if (quizzes.length === 0) {
-    return (
-      <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center">
-        <p className="mb-4 text-sm font-semibold text-gray-500">No quizzes assigned to this course yet.</p>
-        <Link
-          href="/instructor/assembled-quizzes"
-          className="inline-flex items-center rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
-        >
-          Go to Quizzes
-        </Link>
-      </div>
-    );
-  }
+export function CourseQuizzesList({ quizzes, courseId }: { quizzes: AssembledQuizSummary[]; courseId: string }) {
+  const uniqueCatalogs = [
+    ...new Map(
+      quizzes.flatMap((q) => q.catalogs).map((c) => [c.activityType, c]),
+    ).values(),
+  ];
+
+  const hasCatalogs = uniqueCatalogs.length > 0;
 
   return (
-    <div className="flex flex-col gap-2.5">
-      {quizzes.map((quiz) => (
-        <Link
-          key={quiz.id}
-          href={`/instructor/assembled-quizzes/${encodeURIComponent(quiz.id)}`}
-          className="block rounded-brand-lg border border-gray-100 bg-gray-50 p-4 transition hover:border-brand-purple/40"
-        >
-          <span className="font-extrabold text-brand-navy">{quiz.name}</span>
-          {quiz.description ? <p className="mt-1 text-xs font-semibold text-gray-500">{quiz.description}</p> : null}
-          <p className="mt-1.5 text-xs font-semibold text-gray-500">
-            {quiz.catalogNames.length} catalog{quiz.catalogNames.length === 1 ? '' : 's'}
-            {quiz.catalogNames.length > 0 ? ` — ${quiz.catalogNames.join(', ')}` : ''}
+    <>
+      {hasCatalogs ? (
+        <div className="mb-8">
+          <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">
+            Question Catalogs ({uniqueCatalogs.length})
           </p>
-        </Link>
-      ))}
-    </div>
+          <div className="flex flex-col gap-2.5">
+            {uniqueCatalogs.map((catalog) => (
+              <Link
+                key={catalog.activityType}
+                href={`/instructor/quizzes/${encodeURIComponent(catalog.activityType)}`}
+                className="block rounded-brand-lg border border-gray-100 bg-gray-50 p-4 transition hover:border-brand-purple/40"
+              >
+                <span className="font-extrabold text-brand-navy">{catalog.name}</span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">
+        Quizzes {quizzes.length > 0 ? `(${quizzes.length})` : ''}
+      </p>
+
+      {quizzes.length === 0 ? (
+        <div className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center">
+          {hasCatalogs ? (
+            <>
+              <p className="mb-4 text-sm font-semibold text-gray-500">No quizzes assigned to this course yet.</p>
+              <Link
+                href="/instructor/assembled-quizzes"
+                className="inline-flex items-center rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+              >
+                Go to Quizzes
+              </Link>
+            </>
+          ) : (
+            <>
+              <p className="mb-1 text-sm font-extrabold text-brand-navy">Start with a question catalog</p>
+              <p className="mb-4 text-sm font-semibold text-gray-500">
+                Link a question catalog to this course before assembling a quiz.
+              </p>
+              <Link
+                href={`/instructor/quizzes?courseId=${encodeURIComponent(courseId)}`}
+                className="inline-flex items-center rounded-full bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+              >
+                Choose question catalogs
+              </Link>
+            </>
+          )}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {quizzes.map((quiz) => (
+            <Link
+              key={quiz.id}
+              href={`/instructor/assembled-quizzes/${encodeURIComponent(quiz.id)}`}
+              className="block rounded-brand-lg border border-gray-100 bg-gray-50 p-4 transition hover:border-brand-purple/40"
+            >
+              <span className="font-extrabold text-brand-navy">{quiz.name}</span>
+              {quiz.description ? <p className="mt-1 text-xs font-semibold text-gray-500">{quiz.description}</p> : null}
+              <p className="mt-1.5 text-xs font-semibold text-gray-500">
+                {quiz.catalogNames.length} catalog{quiz.catalogNames.length === 1 ? '' : 's'}
+                {quiz.catalogNames.length > 0 ? ` — ${quiz.catalogNames.join(', ')}` : ''}
+              </p>
+            </Link>
+          ))}
+        </div>
+      )}
+    </>
   );
 }

--- a/components/CreateQuizModal.tsx
+++ b/components/CreateQuizModal.tsx
@@ -32,7 +32,7 @@ export function CreateQuizModal({
    * only echoes ids, not display names — the modal already has the mapping (via its own `catalogs`
    * prop) that the page's optimistic-insert row needs to render immediately.
    */
-  onCreated: (quiz: { id: string; name: string; description: string | null; courseId: string; catalogNames: string[] }) => void;
+  onCreated: (quiz: { id: string; name: string; description: string | null; courseId: string; catalogs: { activityType: string; name: string }[]; catalogNames: string[] }) => void;
 }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -78,11 +78,14 @@ export function CreateQuizModal({
       return;
     }
 
-    const catalogNames = selectedCatalogs
-      .map((activityType) => catalogs.find((c) => c.activityType === activityType)?.name)
-      .filter((catalogName): catalogName is string => Boolean(catalogName));
+    const resolvedCatalogs = selectedCatalogs
+      .map((activityType) => {
+        const found = catalogs.find((c) => c.activityType === activityType);
+        return found ? { activityType, name: found.name } : null;
+      })
+      .filter((c): c is { activityType: string; name: string } => c !== null);
 
-    onCreated({ ...result.data.quiz, catalogNames });
+    onCreated({ ...result.data.quiz, catalogs: resolvedCatalogs, catalogNames: resolvedCatalogs.map((c) => c.name) });
     requestClose();
   }
 

--- a/lib/assembledQuizClient.ts
+++ b/lib/assembledQuizClient.ts
@@ -16,6 +16,7 @@ export type AssembledQuizSummary = {
   description: string | null;
   courseId: string;
   courseName: string;
+  catalogs: { activityType: string; name: string }[];
   catalogNames: string[];
   createdAt: string;
 };

--- a/lib/assembledQuizQueries.ts
+++ b/lib/assembledQuizQueries.ts
@@ -26,6 +26,7 @@ export type AssembledQuizSummary = {
   description: string | null;
   courseId: string;
   courseName: string;
+  catalogs: { activityType: string; name: string }[];
   catalogNames: string[];
   createdAt: string;
 };
@@ -37,20 +38,25 @@ type AssembledQuizRow = {
   course_id: string;
   created_at: string;
   course: { course_name: string } | null;
-  assembled_quiz_catalog: { catalog: { quiz_name: string } | null }[] | null;
+  assembled_quiz_catalog: { activity_type: string; catalog: { quiz_name: string } | null }[] | null;
 };
 
 const ASSEMBLED_QUIZ_SUMMARY_SELECT =
-  'assembled_quiz_id, quiz_name, description, course_id, created_at, course:course_id(course_name), assembled_quiz_catalog(catalog:activity_type(quiz_name))';
+  'assembled_quiz_id, quiz_name, description, course_id, created_at, course:course_id(course_name), assembled_quiz_catalog(activity_type, catalog:activity_type(quiz_name))';
 
 function mapAssembledQuizRow(row: AssembledQuizRow): AssembledQuizSummary {
+  const catalogs = (row.assembled_quiz_catalog ?? []).map((link) => ({
+    activityType: link.activity_type,
+    name: link.catalog?.quiz_name ?? 'Unknown catalog',
+  }));
   return {
     id: row.assembled_quiz_id,
     name: row.quiz_name,
     description: row.description,
     courseId: row.course_id,
     courseName: row.course?.course_name ?? 'Unknown course',
-    catalogNames: (row.assembled_quiz_catalog ?? []).map((link) => link.catalog?.quiz_name ?? 'Unknown catalog'),
+    catalogs,
+    catalogNames: catalogs.map((c) => c.name),
     createdAt: row.created_at,
   };
 }


### PR DESCRIPTION
- Course detail page now shows a "Question Catalogs (n)" section above Quizzes, listing every catalog used in the course's assembled quizzes, each linking to its detail page
- When a course has no quizzes yet, the primary CTA reads "Choose question catalogs" and links to /instructor/quizzes?courseId=… instead of going straight to Quizzes
- The Quizzes section explains "Link a question catalog to this course before assembling a quiz" when no quizzes exist
- Question Catalogs page shows a context banner with a link back to the course when opened via ?courseId=

- `lib/assembledQuizQueries.ts` / `lib/assembledQuizClient.ts`: added `catalogs: { activityType, name }[]` to `AssembledQuizSummary`
- `components/CourseQuizzesList.tsx`: new conditional sections based on quiz/catalog state
- `components/CreateQuizModal.tsx`: `onCreated` now includes `catalogs` alongside `catalogNames`
- `app/instructor/assembled-quizzes/page.tsx`: `handleCreated` passes `catalogs`
- `app/instructor/courses/[id]/page.tsx`: passes `courseId` to `CourseQuizzesList`
- `app/instructor/quizzes/page.tsx`: handles `?courseId=` param — shows context banner

Resolves #399
