### PR TITLE
resolve issue #417

### DIFF
--- a/app/instructor/quizzes/[activityType]/page.tsx
+++ b/app/instructor/quizzes/[activityType]/page.tsx
@@ -162,7 +162,10 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
         : [savedQuestion, ...(current ?? [])],
     );
 
-    setLevel('all');
+    // The filter now seeds the modal's level (GitHub #417), so what was just saved is usually
+    // already inside the filtered level and visible. Only a level the instructor changed inside
+    // the modal needs the filter opened up, so the row can't vanish the moment it is written.
+    if (level !== 'all' && savedQuestion.level !== level) setLevel('all');
     setHighlight({ id: savedQuestion.id, label: isEdit ? '✓ Updated' : '✓ Just added' });
     setToastMessage(isEdit ? 'Changes saved.' : 'Question added to this catalog.');
 
@@ -201,7 +204,8 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
         : [saved, ...(current ?? [])],
     );
 
-    setLevel('all');
+    // Same rule as handleSaveQuestion above (GitHub #417).
+    if (level !== 'all' && saved.level !== level) setLevel('all');
     setHighlight({ id: saved.id, label: isEdit ? '✓ Updated' : '✓ Just added' });
     setToastMessage(isEdit ? 'Changes saved.' : 'Prompt added to this catalog.');
 
@@ -452,6 +456,7 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
           mode={modalState.mode}
           initialData={modalState.mode === 'edit' ? modalState.question : undefined}
           defaultQuizType={params.activityType}
+          defaultLevel={level === 'all' ? undefined : level}
           quizOptions={quizOptions}
           onClose={() => setModalState(null)}
           onSave={handleSaveQuestion}
@@ -472,6 +477,7 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
           mode={promptModalState.mode}
           initialData={promptModalState.mode === 'edit' ? promptModalState.prompt : undefined}
           defaultActivityType={params.activityType}
+          defaultLevel={level === 'all' ? undefined : level}
           catalogOptions={quizOptions}
           onClose={() => setPromptModalState(null)}
           onSave={handleSavePrompt}

--- a/components/PromptFormModal.tsx
+++ b/components/PromptFormModal.tsx
@@ -34,6 +34,7 @@ export function PromptFormModal({
   mode,
   initialData,
   defaultActivityType,
+  defaultLevel,
   catalogOptions,
   onClose,
   onSave,
@@ -41,12 +42,14 @@ export function PromptFormModal({
   mode: 'add' | 'edit';
   initialData?: CatalogUserStory;
   defaultActivityType: ActivityType;
+  /** Mirrors QuestionFormModal's prop of the same name (GitHub #417): the page's active level filter. */
+  defaultLevel?: 1 | 2 | 3;
   catalogOptions: { value: ActivityType; label: string }[];
   onClose: () => void;
   onSave: (prompt: UserStoryDraft) => Promise<{ ok: true } | { ok: false; error: string }>;
 }) {
   const [activityType, setActivityType] = useState<ActivityType>(initialData?.activityType ?? defaultActivityType);
-  const [level, setLevel] = useState<1 | 2 | 3>(initialData?.level ?? 1);
+  const [level, setLevel] = useState<1 | 2 | 3>(initialData?.level ?? defaultLevel ?? 1);
   const [storyText, setStoryText] = useState(initialData?.storyText ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');

--- a/components/QuestionFormModal.tsx
+++ b/components/QuestionFormModal.tsx
@@ -37,6 +37,7 @@ export function QuestionFormModal({
   mode,
   initialData,
   defaultQuizType,
+  defaultLevel,
   quizOptions,
   onClose,
   onSave,
@@ -46,6 +47,12 @@ export function QuestionFormModal({
   initialData?: QuizQuestion;
   /** Which quiz's tab/filter the page currently has active — the starting value in 'add' mode. */
   defaultQuizType: ActivityType;
+  /**
+   * Which difficulty the page's level filter currently has active — the starting value in 'add'
+   * mode (GitHub #417). A caller with no level filter, or one sitting on "All levels", omits it
+   * and gets the old Level 1 default. Ignored in 'edit' mode, where the question's own level wins.
+   */
+  defaultLevel?: 1 | 2 | 3;
   /**
    * The choices the "Quiz" dropdown offers (GitHub #359). A catalog's detail page passes its own
    * single catalog here, effectively locking the field to "this catalog" without special-casing
@@ -58,7 +65,7 @@ export function QuestionFormModal({
   onSave: (question: QuizQuestion) => Promise<{ ok: true } | { ok: false; error: string }>;
 }) {
   const [quizType, setQuizType] = useState<ActivityType>(initialData?.quizType ?? defaultQuizType);
-  const [level, setLevel] = useState<1 | 2 | 3>(initialData?.level ?? 1);
+  const [level, setLevel] = useState<1 | 2 | 3>(initialData?.level ?? defaultLevel ?? 1);
   const [questionText, setQuestionText] = useState(initialData?.questionText ?? '');
   const [optionTexts, setOptionTexts] = useState<string[]>(
     initialData ? initialData.answerOptions.map((option) => option.text) : EMPTY_OPTIONS,


### PR DESCRIPTION
resolve #417: pre-select the filtered difficulty level in the authoring modals

The catalog detail page's level filter had no effect on the "New Question"
modal, which always opened on Easy · Level 1 — so an instructor working
through one level had to re-pick it every time, and could easily create a
question at the wrong level without noticing.

Both QuestionFormModal and PromptFormModal now take an optional
`defaultLevel` prop, following the existing `defaultQuizType` pattern, and
seed their level state with `initialData?.level ?? defaultLevel ?? 1`.
initialData wins first so edit mode still shows the question's own level
rather than the filter's; omitting the prop keeps the old Level 1 default,
which is what "All levels" and the assembled-quiz call site both pass.
The field stays freely changeable before saving.

The catalog page's post-save `setLevel('all')` is now conditional: the
filter only opens up when the saved level differs from it, since a save at
the filtered level is already visible and resetting would throw away the
instructor's context between consecutive additions.