### PR TITLE
Multiple bug fixes

### DIFF
--- a/__tests__/api/instructor-assembled-quiz-catalog-detail.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-catalog-detail.test.ts
@@ -170,6 +170,36 @@ describe('GET /api/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]
 
     expect(h.state.deletes).toEqual([]);
   });
+
+  // llm-graded parity: prompts get the same excludedForQuiz annotation MCQ questions do, via
+  // listQuizCatalogUserStories (mirrors listQuizCatalogQuestions).
+  it('returns the catalog and its prompts, each annotated with this quiz\'s own exclusion state, for an llm-graded catalog', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('activity_type', {
+      data: { activity_type: 'CATALOG_LLM', quiz_name: 'Catalog LLM', description: null, grading_kind: 'llm-graded', creator_id: null, creator: null },
+      error: null,
+    });
+    queue('user_story', {
+      data: [
+        { user_story_id: 'story-1', story_text: 'As a user, I want X.', difficulty_level: 1, creator_id: null },
+        { user_story_id: 'story-2', story_text: 'As a user, I want Y.', difficulty_level: 1, creator_id: null },
+      ],
+      error: null,
+    });
+    queue('quiz_excluded_user_story', { data: [{ user_story_id: 'story-2' }], error: null });
+
+    const res = await getReq('quiz-1', 'CATALOG_LLM');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.catalog.gradingKind).toBe('llm-graded');
+    expect(body.questions).toEqual([]);
+    expect(body.userStories).toHaveLength(2);
+    expect(body.userStories.find((s: { id: string }) => s.id === 'story-1').excludedForQuiz).toBe(false);
+    expect(body.userStories.find((s: { id: string }) => s.id === 'story-2').excludedForQuiz).toBe(true);
+    expect(h.state.tables).not.toContain('question');
+  });
 });
 
 describe('DELETE /api/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]', () => {

--- a/__tests__/api/instructor-assembled-quiz-detail.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-detail.test.ts
@@ -162,13 +162,61 @@ describe('GET /api/instructor/assembled-quizzes/[quizId]', () => {
     });
 
     expect(body.catalogs).toEqual([
-      { activityType: 'CATALOG_A', name: 'Catalog A', description: 'About A', totalQuestions: 5, excludedCount: 1, activeCount: 4 },
+      {
+        activityType: 'CATALOG_A',
+        name: 'Catalog A',
+        description: 'About A',
+        gradingKind: 'mcq',
+        totalQuestions: 5,
+        excludedCount: 1,
+        activeCount: 4,
+      },
     ]);
 
     // Level 1 has 4 questions total, 1 excluded -> 3 available, below the 4 required.
     expect(body.levelCoverage).toContainEqual({ level: 1, available: 3, required: 4, sufficient: false });
     expect(body.levelCoverage).toContainEqual({ level: 2, available: 1, required: 4, sufficient: false });
     expect(body.levelCoverage).toContainEqual({ level: 3, available: 0, required: 4, sufficient: false });
+  });
+
+  // Regression test: getQuizComposition used to only ever query `question`, so an llm-graded
+  // catalog's prompt count and level coverage were always 0 regardless of how many user_story
+  // rows it actually had.
+  it('counts an llm-graded catalog\'s prompts from user_story, not question, with no exclusions applied', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('course', { data: { course_name: 'Software Requirements' }, error: null });
+    queue('assembled_quiz_catalog', {
+      data: [{ activity_type: 'CATALOG_LLM', catalog: { quiz_name: 'Catalog LLM', description: 'About LLM', grading_kind: 'llm-graded' } }],
+      error: null,
+    });
+    queue('question', { data: [], error: null });
+    queue('user_story', {
+      data: [
+        { user_story_id: 'us-1', activity_type: 'CATALOG_LLM', difficulty_level: 1 },
+        { user_story_id: 'us-2', activity_type: 'CATALOG_LLM', difficulty_level: 1 },
+      ],
+      error: null,
+    });
+    queue('quiz_excluded_question', { data: [], error: null });
+
+    const res = await req();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.catalogs).toEqual([
+      {
+        activityType: 'CATALOG_LLM',
+        name: 'Catalog LLM',
+        description: 'About LLM',
+        gradingKind: 'llm-graded',
+        totalQuestions: 2,
+        excludedCount: 0,
+        activeCount: 2,
+      },
+    ]);
+
+    expect(body.levelCoverage).toContainEqual({ level: 1, available: 2, required: 4, sufficient: false });
   });
 
   it('returns an empty composition for a quiz with no linked catalogs', async () => {

--- a/__tests__/api/instructor-assembled-quiz-excluded-user-stories.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-excluded-user-stories.test.ts
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    inserts: [] as { table: string; payload: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      eq: () => builder,
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { POST } from '../../app/api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function quizRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    assembled_quiz_id: 'quiz-1',
+    quiz_name: 'Sprint 1 Requirements Check',
+    description: null,
+    course_id: 'course-1',
+    creator_id: 'instructor-1',
+    created_at: '2026-08-14T10:00:00',
+    ...overrides,
+  };
+}
+
+function postRequest(body: unknown, token: string | null = 'valid-token', quizId = 'quiz-1') {
+  return POST(
+    new Request(`http://localhost/api/instructor/assembled-quizzes/${quizId}/excluded-user-stories`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+      body: JSON.stringify(body),
+    }),
+    { params: { quizId } },
+  );
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.inserts = [];
+});
+
+describe('POST /api/instructor/assembled-quizzes/[quizId]/excluded-user-stories', () => {
+  it('returns 401 without a token', async () => {
+    const res = await postRequest({ userStoryId: 'story-1' }, null);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await postRequest({ userStoryId: 'story-1' });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('returns 404 when the quiz does not exist', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: null, error: null });
+
+    const res = await postRequest({ userStoryId: 'story-1' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 with an empty body when the caller does not own the quiz', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow({ creator_id: 'someone-else' }), error: null });
+
+    const res = await postRequest({ userStoryId: 'story-1' });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('rejects a missing userStoryId with 400', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+
+    const res = await postRequest({});
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a prompt that belongs to a catalog this quiz is not linked to, with 400', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_catalog', { data: [{ activity_type: 'CATALOG_A' }], error: null });
+    queue('user_story', { data: { user_story_id: 'story-1', activity_type: 'CATALOG_B' }, error: null });
+
+    const res = await postRequest({ userStoryId: 'story-1' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe('This prompt is not part of this quiz.');
+    expect(h.state.tables).not.toContain('quiz_excluded_user_story');
+  });
+
+  it('rejects a userStoryId that matches no prompt, with 400', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_catalog', { data: [{ activity_type: 'CATALOG_A' }], error: null });
+    queue('user_story', { data: null, error: null });
+
+    const res = await postRequest({ userStoryId: 'does-not-exist' });
+    expect(res.status).toBe(400);
+  });
+
+  it('excludes the prompt without touching user_story — only writes to quiz_excluded_user_story', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_catalog', { data: [{ activity_type: 'CATALOG_A' }], error: null });
+    queue('user_story', { data: { user_story_id: 'story-1', activity_type: 'CATALOG_A' }, error: null });
+    queue('quiz_excluded_user_story', { data: null, error: null });
+
+    const res = await postRequest({ userStoryId: 'story-1' });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ userStoryId: 'story-1' });
+
+    expect(h.state.inserts).toEqual([
+      { table: 'quiz_excluded_user_story', payload: { assembled_quiz_id: 'quiz-1', user_story_id: 'story-1' } },
+    ]);
+    expect(h.state.inserts.some((i) => i.table === 'user_story')).toBe(false);
+  });
+
+  it('treats excluding an already-excluded prompt as success, not an error', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_catalog', { data: [{ activity_type: 'CATALOG_A' }], error: null });
+    queue('user_story', { data: { user_story_id: 'story-1', activity_type: 'CATALOG_A' }, error: null });
+    queue('quiz_excluded_user_story', { data: null, error: { message: 'duplicate key', code: '23505' } });
+
+    const res = await postRequest({ userStoryId: 'story-1' });
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/instructor-assembled-quiz-excluded-user-story-detail.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-excluded-user-story-detail.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        if (isDelete) state.deletes.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { DELETE } from '../../app/api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/[userStoryId]/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function quizRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    assembled_quiz_id: 'quiz-1',
+    quiz_name: 'Sprint 1 Requirements Check',
+    description: null,
+    course_id: 'course-1',
+    creator_id: 'instructor-1',
+    created_at: '2026-08-14T10:00:00',
+    ...overrides,
+  };
+}
+
+function delReq(quizId = 'quiz-1', userStoryId = 'story-1', token: string | null = 'valid-token') {
+  return DELETE(
+    new Request(`http://localhost/api/instructor/assembled-quizzes/${quizId}/excluded-user-stories/${userStoryId}`, {
+      method: 'DELETE',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    }),
+    { params: { quizId, userStoryId } },
+  );
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.deletes = [];
+});
+
+describe('DELETE /api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/[userStoryId]', () => {
+  it('returns 401 without a token', async () => {
+    const res = await delReq('quiz-1', 'story-1', null);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('returns 404 when the quiz does not exist', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: null, error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 with an empty body when the caller does not own the quiz', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow({ creator_id: 'someone-else' }), error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('re-includes the prompt, touching only quiz_excluded_user_story', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('quiz_excluded_user_story', { data: null, error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ userStoryId: 'story-1' });
+
+    expect(h.state.deletes).toContainEqual({ table: 'quiz_excluded_user_story', column: 'assembled_quiz_id', value: 'quiz-1' });
+    expect(h.state.deletes).toContainEqual({ table: 'quiz_excluded_user_story', column: 'user_story_id', value: 'story-1' });
+    expect(h.state.tables).not.toContain('user_story');
+  });
+
+  it('is idempotent: re-including a prompt that was never excluded is still 200', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('quiz_excluded_user_story', { data: null, error: null }); // delete matches 0 rows, still no error
+
+    const res = await delReq();
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/instructor-assembled-quiz-extra-user-stories.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-extra-user-stories.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    inserts: [] as { table: string; payload: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      eq: () => builder,
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { POST } from '../../app/api/instructor/assembled-quizzes/[quizId]/extra-user-stories/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function quizRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    assembled_quiz_id: 'quiz-1',
+    quiz_name: 'Sprint 1 Requirements Check',
+    description: null,
+    course_id: 'course-1',
+    creator_id: 'instructor-1',
+    created_at: '2026-08-14T10:00:00',
+    ...overrides,
+  };
+}
+
+function postRequest(body: unknown, token: string | null = 'valid-token', quizId = 'quiz-1') {
+  return POST(
+    new Request(`http://localhost/api/instructor/assembled-quizzes/${quizId}/extra-user-stories`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...(token ? { Authorization: `Bearer ${token}` } : {}) },
+      body: JSON.stringify(body),
+    }),
+    { params: { quizId } },
+  );
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.inserts = [];
+});
+
+describe('POST /api/instructor/assembled-quizzes/[quizId]/extra-user-stories', () => {
+  it('returns 401 without a token', async () => {
+    const res = await postRequest({ userStoryIds: ['story-1'] }, null);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await postRequest({ userStoryIds: ['story-1'] });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('returns 404 when the quiz does not exist', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: null, error: null });
+
+    const res = await postRequest({ userStoryIds: ['story-1'] });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 with an empty body when the caller does not own the quiz', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow({ creator_id: 'someone-else' }), error: null });
+
+    const res = await postRequest({ userStoryIds: ['story-1'] });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('rejects a missing userStoryIds with 400', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+
+    const res = await postRequest({});
+    expect(res.status).toBe(400);
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it('rejects an empty userStoryIds array with 400', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+
+    const res = await postRequest({ userStoryIds: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a userStoryIds array containing a blank entry with 400', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+
+    const res = await postRequest({ userStoryIds: ['story-1', '   '] });
+    expect(res.status).toBe(400);
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it(
+    'hand-picks a prompt onto the quiz without requiring its catalog to be linked — never touches assembled_quiz_catalog',
+    async () => {
+      queueRole('instructor');
+      queue('assembled_quiz', { data: quizRow(), error: null });
+      queue('assembled_quiz_extra_user_story', { data: null, error: null });
+
+      const res = await postRequest({ userStoryIds: ['story-1'] });
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body).toEqual({ userStoryIds: ['story-1'] });
+
+      expect(h.state.inserts).toEqual([
+        { table: 'assembled_quiz_extra_user_story', payload: { assembled_quiz_id: 'quiz-1', user_story_id: 'story-1' } },
+      ]);
+      expect(h.state.tables).not.toContain('assembled_quiz_catalog');
+    },
+  );
+
+  it('hand-picks several prompts in one request, one insert per prompt', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: null });
+
+    const res = await postRequest({ userStoryIds: ['story-1', 'story-2', 'story-3'] });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ userStoryIds: ['story-1', 'story-2', 'story-3'] });
+    expect(h.state.inserts.filter((i) => i.table === 'assembled_quiz_extra_user_story')).toHaveLength(3);
+  });
+
+  it('omits an already-picked prompt from the response instead of erroring (23505)', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: { code: '23505', message: 'duplicate' } });
+    queue('assembled_quiz_extra_user_story', { data: null, error: null });
+
+    const res = await postRequest({ userStoryIds: ['already-picked', 'story-2'] });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ userStoryIds: ['story-2'] });
+  });
+
+  it('returns 400 when a userStoryId matches no prompt row (23503 foreign key violation)', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: { code: '23503', message: 'fk violation' } });
+
+    const res = await postRequest({ userStoryIds: ['does-not-exist'] });
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 500 on an unexpected database error', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: { message: 'DB down' } });
+
+    const res = await postRequest({ userStoryIds: ['story-1'] });
+    expect(res.status).toBe(500);
+  });
+});

--- a/__tests__/api/instructor-assembled-quiz-extra-user-story-detail.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-extra-user-story-detail.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        if (isDelete) state.deletes.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { DELETE } from '../../app/api/instructor/assembled-quizzes/[quizId]/extra-user-stories/[userStoryId]/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function quizRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    assembled_quiz_id: 'quiz-1',
+    quiz_name: 'Sprint 1 Requirements Check',
+    description: null,
+    course_id: 'course-1',
+    creator_id: 'instructor-1',
+    created_at: '2026-08-14T10:00:00',
+    ...overrides,
+  };
+}
+
+function delReq(quizId = 'quiz-1', userStoryId = 'story-1', token: string | null = 'valid-token') {
+  return DELETE(
+    new Request(`http://localhost/api/instructor/assembled-quizzes/${quizId}/extra-user-stories/${userStoryId}`, {
+      method: 'DELETE',
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    }),
+    { params: { quizId, userStoryId } },
+  );
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.deletes = [];
+});
+
+describe('DELETE /api/instructor/assembled-quizzes/[quizId]/extra-user-stories/[userStoryId]', () => {
+  it('returns 401 without a token', async () => {
+    const res = await delReq('quiz-1', 'story-1', null);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('returns 404 when the quiz does not exist', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: null, error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 403 with an empty body when the caller does not own the quiz', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow({ creator_id: 'someone-else' }), error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+  });
+
+  it('removes only the assembled_quiz_extra_user_story link, scoped to this quiz — the original prompt is never touched', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: null });
+
+    const res = await delReq('quiz-1', 'story-1');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ userStoryId: 'story-1' });
+
+    expect(h.state.deletes).toContainEqual({ table: 'assembled_quiz_extra_user_story', column: 'assembled_quiz_id', value: 'quiz-1' });
+    expect(h.state.deletes).toContainEqual({ table: 'assembled_quiz_extra_user_story', column: 'user_story_id', value: 'story-1' });
+    expect(h.state.tables).not.toContain('user_story');
+  });
+
+  it('is idempotent: removing a prompt that was never hand-picked is still 200', async () => {
+    queueRole('instructor');
+    queue('assembled_quiz', { data: quizRow(), error: null });
+    queue('assembled_quiz_extra_user_story', { data: null, error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(200);
+  });
+});

--- a/__tests__/api/instructor-assembled-quiz-questions-picker.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-questions-picker.test.ts
@@ -7,12 +7,16 @@ const h = vi.hoisted(() => {
     queues: {} as Record<string, Result[]>,
     tables: [] as string[],
     orders: [] as { table: string; column: string; ascending: boolean }[],
+    filters: [] as { table: string; column: string; value: unknown }[],
   };
 
   function makeBuilder(table: string, result: Result) {
     const builder: Record<string, unknown> = {
       select: () => builder,
-      eq: () => builder,
+      eq: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });
         return builder;
@@ -63,6 +67,7 @@ beforeEach(() => {
   h.state.queues = {};
   h.state.tables = [];
   h.state.orders = [];
+  h.state.filters = [];
 });
 
 describe('GET /api/instructor/assembled-quizzes/questions', () => {
@@ -78,9 +83,10 @@ describe('GET /api/instructor/assembled-quizzes/questions', () => {
     expect(res.status).toBe(403);
     expect(await res.text()).toBe('');
     expect(h.state.tables).not.toContain('question');
+    expect(h.state.tables).not.toContain('user_story');
   });
 
-  it('returns every question across every catalog, any author, with its source catalog name', async () => {
+  it('returns only the caller\'s own questions, with each one\'s source catalog name', async () => {
     queueRole('instructor');
     queue('question', {
       data: [
@@ -110,6 +116,8 @@ describe('GET /api/instructor/assembled-quizzes/questions', () => {
       { id: 'q-1', questionText: 'Which story is weakest?', level: 1, catalogActivityType: 'IDENTIFY_WEAK_USER_STORIES', catalogName: 'Identify Weak User Stories' },
       { id: 'q-2', questionText: 'What is a stakeholder?', level: 2, catalogActivityType: 'CUSTOM_QUIZ', catalogName: 'My Custom Quiz' },
     ]);
+
+    expect(h.state.filters).toContainEqual({ table: 'question', column: 'user_id', value: 'instructor-1' });
   });
 
   it('returns an empty list when there are no questions', async () => {
@@ -131,9 +139,54 @@ describe('GET /api/instructor/assembled-quizzes/questions', () => {
     expect(h.state.orders).toContainEqual({ table: 'question', column: 'question_prompt', ascending: true });
   });
 
-  it('returns 500 when the query fails', async () => {
+  it('returns 500 when the question query fails', async () => {
     queueRole('instructor');
     queue('question', { data: null, error: { message: 'DB down' } });
+
+    const res = await GET(req());
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('DB down');
+  });
+
+  // llm-graded parity: the same picker also returns the caller's own prompts, scoped by
+  // creator_id (user_story's owner column — not user_id, which question uses).
+  it('returns only the caller\'s own prompts, with each one\'s source catalog name', async () => {
+    queueRole('instructor');
+    queue('question', { data: [], error: null });
+    queue('user_story', {
+      data: [
+        {
+          user_story_id: 'story-1',
+          story_text: 'As a shopper, I want a cart.',
+          difficulty_level: 1,
+          activity_type: 'WRITE_ACCEPTANCE_CRITERIA',
+          catalog: { quiz_name: 'Write Acceptance Criteria' },
+        },
+      ],
+      error: null,
+    });
+
+    const res = await GET(req());
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body.userStories).toEqual([
+      {
+        id: 'story-1',
+        storyText: 'As a shopper, I want a cart.',
+        level: 1,
+        catalogActivityType: 'WRITE_ACCEPTANCE_CRITERIA',
+        catalogName: 'Write Acceptance Criteria',
+      },
+    ]);
+    expect(h.state.filters).toContainEqual({ table: 'user_story', column: 'creator_id', value: 'instructor-1' });
+  });
+
+  it('returns 500 when the prompt query fails', async () => {
+    queueRole('instructor');
+    queue('question', { data: [], error: null });
+    queue('user_story', { data: null, error: { message: 'DB down' } });
 
     const res = await GET(req());
     expect(res.status).toBe(500);

--- a/__tests__/api/instructor-quiz-detail.test.ts
+++ b/__tests__/api/instructor-quiz-detail.test.ts
@@ -8,15 +8,27 @@ const h = vi.hoisted(() => {
     tables: [] as string[],
     orders: [] as { table: string; column: string; ascending: boolean }[],
     filters: [] as { table: string; column: string; value: unknown }[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
   };
 
   function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+
     const builder: Record<string, unknown> = {
       select: () => builder,
-      eq: (column: string, value: unknown) => {
-        state.filters.push({ table, column, value });
+      delete: () => {
+        isDelete = true;
         return builder;
       },
+      eq: (column: string, value: unknown) => {
+        (isDelete ? state.deletes : state.filters).push({ table, column, value });
+        return builder;
+      },
+      in: (column: string, value: unknown) => {
+        (isDelete ? state.deletes : state.filters).push({ table, column, value });
+        return builder;
+      },
+      limit: () => builder,
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });
         return builder;
@@ -51,7 +63,7 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
-import { GET } from '../../app/api/instructor/quizzes/[activityType]/route';
+import { DELETE, GET } from '../../app/api/instructor/quizzes/[activityType]/route';
 
 function queueRole(role: string) {
   queue('user', { data: { role }, error: null });
@@ -89,11 +101,19 @@ function req(activityType = 'IDENTIFY_WEAK_USER_STORIES', token: string | null =
   });
 }
 
+function delReq(activityType = 'IDENTIFY_WEAK_USER_STORIES', token: string | null = 'valid-token') {
+  return DELETE(
+    new Request(`http://localhost/api/instructor/quizzes/${activityType}`, { method: 'DELETE', headers: token ? { Authorization: `Bearer ${token}` } : {} }),
+    { params: { activityType } },
+  );
+}
+
 beforeEach(() => {
   h.state.queues = {};
   h.state.tables = [];
   h.state.orders = [];
   h.state.filters = [];
+  h.state.deletes = [];
 });
 
 describe('GET /api/instructor/quizzes/[activityType]', () => {
@@ -279,5 +299,154 @@ describe('GET /api/instructor/quizzes/[activityType] — llm-graded catalogs', (
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('DB down');
+  });
+});
+
+describe('DELETE /api/instructor/quizzes/[activityType]', () => {
+  it('returns 401 without a token', async () => {
+    const res = await delReq('IDENTIFY_WEAK_USER_STORIES', null);
+    expect(res.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('activity_type');
+  });
+
+  it('returns 404 when the activity type matches no catalog', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: null, error: null });
+
+    const res = await delReq('NOT_REAL');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe('Catalog not found.');
+    expect(h.state.tables).not.toContain('session_log');
+  });
+
+  it('returns 403 with an empty body when the catalog was created by another instructor', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ creator_id: 'instructor-2' }), error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('session_log');
+  });
+
+  it('returns 403 with an empty body for a built-in catalog (creator_id is null)', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null }); // default creator_id: null
+
+    const res = await delReq();
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.tables).not.toContain('session_log');
+  });
+
+  it('returns 409 and deletes nothing when a student has already started a session for this catalog', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
+    queue('session_log', { data: { session_id: 'session-1' }, error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe('This catalog has already been used by a student and cannot be deleted.');
+    expect(h.state.tables).not.toContain('question');
+    expect(h.state.deletes).toEqual([]);
+  });
+
+  // daily_challenge_attempt has no session_log/activity_type of its own, so a question can be
+  // "in use" there even with zero session_log rows for the catalog — the check this test locks in.
+  it('returns 409 when an mcq catalog\'s question has a daily_challenge_attempt, even with no session_log rows', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
+    queue('session_log', { data: null, error: null });
+    queue('question', { data: [{ question_id: 'q-1' }], error: null });
+    queue('daily_challenge_attempt', { data: { daily_challenge_attempt_id: 'attempt-1' }, error: null });
+
+    const res = await delReq();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe('This catalog has already been used by a student and cannot be deleted.');
+    expect(h.state.deletes).toEqual([]);
+  });
+
+  it('deletes an unused mcq catalog\'s questions/answers, unlinks it from every quiz, and deletes the catalog', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null }); // getQuizByActivityType
+    queue('session_log', { data: null, error: null });
+    queue('question', { data: [{ question_id: 'q-1' }, { question_id: 'q-2' }], error: null }); // select ids
+    queue('daily_challenge_attempt', { data: null, error: null });
+    queue('question_to_answer', { data: [{ answer_id: 'a-1' }, { answer_id: 'a-2' }], error: null }); // select answer ids
+    queue('question_to_answer', { data: null, error: null }); // delete
+    queue('answer', { data: null, error: null }); // delete
+    queue('question', { data: null, error: null }); // delete
+    queue('title_definition', { data: null, error: null }); // delete
+    queue('assembled_quiz_catalog', { data: null, error: null }); // delete
+    queue('activity_type', { data: null, error: null }); // delete
+
+    const res = await delReq();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ activityType: 'IDENTIFY_WEAK_USER_STORIES' });
+
+    expect(h.state.deletes).toContainEqual({ table: 'question_to_answer', column: 'question_id', value: ['q-1', 'q-2'] });
+    expect(h.state.deletes).toContainEqual({ table: 'answer', column: 'answer_id', value: ['a-1', 'a-2'] });
+    expect(h.state.deletes).toContainEqual({ table: 'question', column: 'question_id', value: ['q-1', 'q-2'] });
+    expect(h.state.deletes).toContainEqual({ table: 'title_definition', column: 'activity_type', value: 'IDENTIFY_WEAK_USER_STORIES' });
+    expect(h.state.deletes).toContainEqual({ table: 'assembled_quiz_catalog', column: 'activity_type', value: 'IDENTIFY_WEAK_USER_STORIES' });
+    expect(h.state.deletes).toContainEqual({ table: 'activity_type', column: 'activity_type', value: 'IDENTIFY_WEAK_USER_STORIES' });
+  });
+
+  it('deletes an unused llm-graded catalog\'s prompts, unlinks it from every quiz, and deletes the catalog', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
+    queue('session_log', { data: null, error: null });
+    queue('user_story', { data: null, error: null }); // delete
+    queue('title_definition', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: null, error: null });
+    queue('activity_type', { data: null, error: null }); // delete
+
+    const res = await delReq('WRITE_ACCEPTANCE_CRITERIA');
+    expect(res.status).toBe(200);
+
+    expect(h.state.deletes).toContainEqual({ table: 'user_story', column: 'activity_type', value: 'WRITE_ACCEPTANCE_CRITERIA' });
+    expect(h.state.deletes).toContainEqual({ table: 'assembled_quiz_catalog', column: 'activity_type', value: 'WRITE_ACCEPTANCE_CRITERIA' });
+    expect(h.state.tables).not.toContain('question');
+    expect(h.state.tables).not.toContain('daily_challenge_attempt');
+  });
+
+  it('returns 500 when the final delete fails for a reason other than a foreign key violation', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
+    queue('session_log', { data: null, error: null });
+    queue('user_story', { data: null, error: null });
+    queue('title_definition', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: null, error: null });
+    queue('activity_type', { data: null, error: { message: 'DB down' } });
+
+    const res = await delReq('WRITE_ACCEPTANCE_CRITERIA');
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe('DB down');
+  });
+
+  it('returns 409 (defense in depth) when the final delete hits a foreign key violation the earlier checks missed', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
+    queue('session_log', { data: null, error: null });
+    queue('user_story', { data: null, error: null });
+    queue('title_definition', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: null, error: null });
+    queue('activity_type', { data: null, error: { message: 'update or delete violates foreign key constraint', code: '23503' } });
+
+    const res = await delReq('WRITE_ACCEPTANCE_CRITERIA');
+    expect(res.status).toBe(409);
   });
 });

--- a/__tests__/lib/assembledQuizQueries.test.ts
+++ b/__tests__/lib/assembledQuizQueries.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
   addExtraQuestionToQuiz,
+  addExtraUserStoryToQuiz,
+  excludeUserStoryFromQuiz,
   getQuizComposition,
+  includeUserStoryInQuiz,
+  listQuizExcludedUserStoryIds,
   listQuizExtraQuestionIds,
+  listQuizExtraUserStoryIds,
   loadCatalogQuestionPool,
   pickRandomQuestions,
   removeExtraQuestionFromQuiz,
+  removeExtraUserStoryFromQuiz,
 } from '../../lib/assembledQuizQueries';
 
 type PoolItem = { question_id: string };
@@ -412,7 +418,9 @@ describe('getQuizComposition — hand-picked questions (GitHub #380)', () => {
         { level: 3, available: 0, required: 4, sufficient: false },
       ],
       extraQuestions: [],
+      extraUserStories: [],
       activeCatalogQuestionIds: [],
+      activeCatalogUserStoryIds: [],
       error: null,
     });
   });

--- a/app/api/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]/route.ts
+++ b/app/api/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]/route.ts
@@ -5,6 +5,7 @@ import {
   findOwnedAssembledQuiz,
   listQuizCatalogActivityTypes,
   listQuizCatalogQuestions,
+  listQuizCatalogUserStories,
   unlinkCatalogFromQuiz,
 } from '../../../../../../../lib/assembledQuizQueries';
 
@@ -54,8 +55,14 @@ async function authorize(request: Request, quizId: string) {
  * GET/POST/PATCH/DELETE /api/instructor/questions[/…]), never from here, so the original catalog
  * can never be reached through a quiz's composition screen.
  *
+ * Branches on the catalog's grading kind the same way GET /api/instructor/quizzes/{activityType}
+ * does — both pools always present, one always empty, rather than a discriminated union. An
+ * llm-graded catalog has no `question` rows at all (its content is `user_story`); its prompts are
+ * annotated with this quiz's own quiz_excluded_user_story state via listQuizCatalogUserStories,
+ * the exact same role listQuizCatalogQuestions plays for the mcq side.
+ *
  * - 404 quizId matches no quiz, OR activityType matches no catalog
- * - 200 { catalog: { activityType, name, description, authorName }, questions: QuizScopedQuestion[] }
+ * - 200 { catalog: { activityType, name, description, authorName, gradingKind }, questions: QuizScopedQuestion[], userStories: QuizScopedUserStory[] }
  */
 export async function GET(request: Request, { params }: { params: { quizId: string; activityType: string } }) {
   const auth = await authorize(request, params.quizId);
@@ -67,12 +74,20 @@ export async function GET(request: Request, { params }: { params: { quizId: stri
   if (catalogError) return Response.json({ error: catalogError.message }, { status: 500 });
   if (!catalog) return Response.json({ error: 'Catalog not found.' }, { status: 404 });
 
+  if (catalog.gradingKind === 'llm-graded') {
+    const { userStories, error: userStoriesError } = await listQuizCatalogUserStories(supabase, quiz.assembled_quiz_id, params.activityType);
+    if (userStoriesError || !userStories) {
+      return Response.json({ error: userStoriesError?.message ?? 'Could not load prompts.' }, { status: 500 });
+    }
+    return Response.json({ catalog, questions: [], userStories }, { status: 200 });
+  }
+
   const { questions, error: questionsError } = await listQuizCatalogQuestions(supabase, quiz.assembled_quiz_id, params.activityType);
   if (questionsError || !questions) {
     return Response.json({ error: questionsError?.message ?? 'Could not load questions.' }, { status: 500 });
   }
 
-  return Response.json({ catalog, questions }, { status: 200 });
+  return Response.json({ catalog, questions, userStories: [] }, { status: 200 });
 }
 
 /**

--- a/app/api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/[userStoryId]/route.ts
+++ b/app/api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/[userStoryId]/route.ts
@@ -1,0 +1,42 @@
+import { getSupabaseClient } from '../../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../../lib/instructorAuth';
+import { findOwnedAssembledQuiz, includeUserStoryInQuiz } from '../../../../../../../lib/assembledQuizQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * DELETE /api/instructor/assembled-quizzes/{quizId}/excluded-user-stories/{userStoryId} —
+ * re-includes a previously excluded prompt. The llm-graded counterpart of
+ * DELETE .../excluded-questions/{questionId}: idempotent, re-including a prompt that isn't
+ * currently excluded is still a 200.
+ *
+ * - 404 quizId matches no quiz
+ * - 200 { userStoryId }
+ */
+export async function DELETE(request: Request, { params }: { params: { quizId: string; userStoryId: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const found = await findOwnedAssembledQuiz(supabase, params.quizId, guard.user_id);
+  if (found.status === 'error') return Response.json({ error: found.error.message }, { status: 500 });
+  if (found.status === 'not_found') return Response.json({ error: 'Quiz not found.' }, { status: 404 });
+  if (found.status === 'forbidden') return new Response(null, { status: 403 });
+
+  const { error } = await includeUserStoryInQuiz(supabase, found.quiz.assembled_quiz_id, params.userStoryId);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ userStoryId: params.userStoryId }, { status: 200 });
+}

--- a/app/api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/route.ts
+++ b/app/api/instructor/assembled-quizzes/[quizId]/excluded-user-stories/route.ts
@@ -1,0 +1,73 @@
+import { getSupabaseClient } from '../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../lib/instructorAuth';
+import { excludeUserStoryFromQuiz, findOwnedAssembledQuiz, listQuizCatalogActivityTypes } from '../../../../../../lib/assembledQuizQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * POST /api/instructor/assembled-quizzes/{quizId}/excluded-user-stories — excludes one prompt
+ * from this quiz's draw pool. The llm-graded counterpart of POST .../excluded-questions, same
+ * shape throughout: body { userStoryId }, only inserts a quiz_excluded_user_story row (never
+ * touches `user_story` itself — see that table's comment in supabase/schema.sql), and the prompt
+ * must belong to one of the quiz's own linked catalogs.
+ *
+ * - 404 quizId matches no quiz
+ * - 400 missing userStoryId, or the prompt doesn't belong to any catalog this quiz is linked to
+ * - 200 { userStoryId } — 200 not 201: excluding an already-excluded prompt is a no-op success
+ *   (uq_quiz_excluded_user_story), not a second resource created
+ */
+export async function POST(request: Request, { params }: { params: { quizId: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const found = await findOwnedAssembledQuiz(supabase, params.quizId, guard.user_id);
+  if (found.status === 'error') return Response.json({ error: found.error.message }, { status: 500 });
+  if (found.status === 'not_found') return Response.json({ error: 'Quiz not found.' }, { status: 404 });
+  if (found.status === 'forbidden') return new Response(null, { status: 403 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { userStoryId } = (body ?? {}) as { userStoryId?: unknown };
+  if (typeof userStoryId !== 'string' || userStoryId.trim() === '') {
+    return Response.json({ error: 'userStoryId is required.' }, { status: 400 });
+  }
+
+  const { activityTypes, error: catalogsError } = await listQuizCatalogActivityTypes(supabase, found.quiz.assembled_quiz_id);
+  if (catalogsError || !activityTypes) {
+    return Response.json({ error: catalogsError?.message ?? 'Could not load quiz catalogs.' }, { status: 500 });
+  }
+
+  const { data: storyRow, error: storyError } = await supabase
+    .from('user_story')
+    .select('user_story_id, activity_type')
+    .eq('user_story_id', userStoryId)
+    .maybeSingle();
+
+  if (storyError) return Response.json({ error: storyError.message }, { status: 500 });
+  if (!storyRow || !activityTypes.includes((storyRow as { activity_type: string }).activity_type)) {
+    return Response.json({ error: 'This prompt is not part of this quiz.' }, { status: 400 });
+  }
+
+  const { error } = await excludeUserStoryFromQuiz(supabase, found.quiz.assembled_quiz_id, userStoryId);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ userStoryId }, { status: 200 });
+}

--- a/app/api/instructor/assembled-quizzes/[quizId]/extra-user-stories/[userStoryId]/route.ts
+++ b/app/api/instructor/assembled-quizzes/[quizId]/extra-user-stories/[userStoryId]/route.ts
@@ -1,0 +1,43 @@
+import { getSupabaseClient } from '../../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../../lib/instructorAuth';
+import { findOwnedAssembledQuiz, removeExtraUserStoryFromQuiz } from '../../../../../../../lib/assembledQuizQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * DELETE /api/instructor/assembled-quizzes/{quizId}/extra-user-stories/{userStoryId} — removes a
+ * hand-picked prompt from this quiz. The llm-graded counterpart of
+ * DELETE .../extra-questions/{questionId}: only the assembled_quiz_extra_user_story row is
+ * deleted; the original prompt, its catalog, and every other quiz that references it are
+ * untouched. Idempotent, matching DELETE .../excluded-user-stories/{userStoryId}.
+ *
+ * - 404 quizId matches no quiz
+ * - 200 { userStoryId }
+ */
+export async function DELETE(request: Request, { params }: { params: { quizId: string; userStoryId: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const found = await findOwnedAssembledQuiz(supabase, params.quizId, guard.user_id);
+  if (found.status === 'error') return Response.json({ error: found.error.message }, { status: 500 });
+  if (found.status === 'not_found') return Response.json({ error: 'Quiz not found.' }, { status: 404 });
+  if (found.status === 'forbidden') return new Response(null, { status: 403 });
+
+  const { error } = await removeExtraUserStoryFromQuiz(supabase, found.quiz.assembled_quiz_id, params.userStoryId);
+  if (error) return Response.json({ error: error.message }, { status: 500 });
+
+  return Response.json({ userStoryId: params.userStoryId }, { status: 200 });
+}

--- a/app/api/instructor/assembled-quizzes/[quizId]/extra-user-stories/route.ts
+++ b/app/api/instructor/assembled-quizzes/[quizId]/extra-user-stories/route.ts
@@ -1,0 +1,71 @@
+import { getSupabaseClient } from '../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../lib/instructorAuth';
+import { addExtraUserStoryToQuiz, findOwnedAssembledQuiz } from '../../../../../../lib/assembledQuizQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * POST /api/instructor/assembled-quizzes/{quizId}/extra-user-stories — hand-picks one or more
+ * prompts directly onto this quiz. The llm-graded counterpart of POST .../extra-questions, same
+ * shape: body { userStoryIds: string[] }, doesn't require the prompt's catalog to be one of the
+ * quiz's own linked catalogs (that's the entire point, same as the question side — see
+ * assembled_quiz_extra_user_story's own header comment in supabase/schema.sql), and inserted one
+ * at a time so an already-picked id (23505) doesn't abort the ones after it in the same request.
+ *
+ * - 400 missing/empty userStoryIds, or any entry isn't a non-empty string
+ * - 400 a userStoryId matches no user_story row (23503 on the FK)
+ * - 200 { userStoryIds: string[] } — the ids actually newly added; an already-picked id is
+ *   silently omitted, matching POST .../extra-questions
+ */
+export async function POST(request: Request, { params }: { params: { quizId: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const found = await findOwnedAssembledQuiz(supabase, params.quizId, guard.user_id);
+  if (found.status === 'error') return Response.json({ error: found.error.message }, { status: 500 });
+  if (found.status === 'not_found') return Response.json({ error: 'Quiz not found.' }, { status: 404 });
+  if (found.status === 'forbidden') return new Response(null, { status: 403 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { userStoryIds } = (body ?? {}) as { userStoryIds?: unknown };
+  if (
+    !Array.isArray(userStoryIds) ||
+    userStoryIds.length === 0 ||
+    userStoryIds.some((id) => typeof id !== 'string' || id.trim() === '')
+  ) {
+    return Response.json({ error: 'userStoryIds must be a non-empty array of user story ids.' }, { status: 400 });
+  }
+
+  const added: string[] = [];
+  for (const userStoryId of userStoryIds as string[]) {
+    const { alreadyPicked, error } = await addExtraUserStoryToQuiz(supabase, found.quiz.assembled_quiz_id, userStoryId);
+    if (error) {
+      if ((error as { code?: string }).code === '23503') {
+        return Response.json({ error: `Prompt ${userStoryId} does not exist.` }, { status: 400 });
+      }
+      return Response.json({ error: error.message }, { status: 500 });
+    }
+    if (!alreadyPicked) added.push(userStoryId);
+  }
+
+  return Response.json({ userStoryIds: added }, { status: 200 });
+}

--- a/app/api/instructor/assembled-quizzes/[quizId]/route.ts
+++ b/app/api/instructor/assembled-quizzes/[quizId]/route.ts
@@ -55,7 +55,7 @@ async function authorizeQuiz(request: Request, quizId: string) {
  * - 401 missing/invalid bearer token
  * - 403 caller isn't an instructor, or isn't this quiz's creator (no body either way)
  * - 404 quizId matches no quiz
- * - 200 { quiz: { id, name, description, courseId, courseName }, catalogs, levelCoverage, extraQuestions, activeCatalogQuestionIds }
+ * - 200 { quiz: { id, name, description, courseId, courseName }, catalogs, levelCoverage, extraQuestions, extraUserStories, activeCatalogQuestionIds, activeCatalogUserStoryIds }
  * - 500 Supabase not configured, or any of the composition queries fail
  */
 export async function GET(request: Request, { params }: { params: { quizId: string } }) {
@@ -71,10 +71,20 @@ export async function GET(request: Request, { params }: { params: { quizId: stri
     catalogs,
     levelCoverage,
     extraQuestions,
+    extraUserStories,
     activeCatalogQuestionIds,
+    activeCatalogUserStoryIds,
     error: compositionError,
   } = await getQuizComposition(supabase, quiz.assembled_quiz_id);
-  if (compositionError || !catalogs || !levelCoverage || !extraQuestions || !activeCatalogQuestionIds) {
+  if (
+    compositionError ||
+    !catalogs ||
+    !levelCoverage ||
+    !extraQuestions ||
+    !extraUserStories ||
+    !activeCatalogQuestionIds ||
+    !activeCatalogUserStoryIds
+  ) {
     return Response.json({ error: compositionError?.message ?? 'Could not load quiz composition.' }, { status: 500 });
   }
 
@@ -90,7 +100,9 @@ export async function GET(request: Request, { params }: { params: { quizId: stri
       catalogs,
       levelCoverage,
       extraQuestions,
+      extraUserStories,
       activeCatalogQuestionIds,
+      activeCatalogUserStoryIds,
     },
     { status: 200 },
   );

--- a/app/api/instructor/assembled-quizzes/questions/route.ts
+++ b/app/api/instructor/assembled-quizzes/questions/route.ts
@@ -1,6 +1,6 @@
 import { getSupabaseClient } from '../../../../../lib/supabase';
 import { requireInstructor } from '../../../../../lib/instructorAuth';
-import { listAllQuestionsForPicker } from '../../../../../lib/assembledQuizQueries';
+import { listAllQuestionsForPicker, listAllUserStoriesForPicker } from '../../../../../lib/assembledQuizQueries';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -8,26 +8,32 @@ function getToken(request: Request): string | null {
 }
 
 /**
- * GET /api/instructor/assembled-quizzes/questions — every MCQ question in the system, any
- * author, any catalog (GitHub #380). Backs the "Add individual questions" picker
- * (AddQuizQuestionsModal), which searches/filters this list client-side the same way
- * GET /api/instructor/quizzes' browse table already does for catalogs.
+ * GET /api/instructor/assembled-quizzes/questions — every MCQ question and every llm-graded
+ * prompt the calling instructor created, any of their own catalogs (GitHub #380, extended with
+ * llm-graded parity). Backs the "Add individual questions" picker (AddQuizQuestionsModal), which
+ * searches/filters this list client-side and renders the two kinds as separately-labeled,
+ * separately-selectable sections — the same "fetch once, filter in the browser" choice
+ * GET /api/instructor/quizzes' browse table already makes for catalogs.
+ *
+ * Both pools are always present in the response, one possibly empty, the same convention the
+ * catalog detail routes use — not a discriminated union, since the modal shows both kinds at once
+ * rather than picking one.
  *
  * Deliberately not nested under {quizId} even though its only caller today is quiz composition:
- * the list itself isn't quiz-scoped (which questions are already in a given quiz is computed by
- * the client from that quiz's own already-loaded composition), and a static `questions` segment
- * next to the dynamic `[quizId]` one is a supported Next.js route shape — the same reasoning
+ * the list itself isn't quiz-scoped (which items are already in a given quiz is computed by the
+ * client from that quiz's own already-loaded composition), and a static `questions` segment next
+ * to the dynamic `[quizId]` one is a supported Next.js route shape — the same reasoning
  * app/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]/page.tsx's nesting already
  * relies on elsewhere in this feature.
  *
- * Requires only requireInstructor, no per-quiz ownership check — same reasoning
- * GET /api/instructor/quizzes has none: catalogs (and therefore their questions) are globally
- * shared and browsable by any instructor, not scoped to one quiz's creator.
+ * Scoped to `creator_id = guard.user_id` for both pools, the same "mine only" convention
+ * GET /api/instructor/quizzes and GET /api/instructor/questions already use — a colleague's or a
+ * built-in catalog's content isn't this instructor's to hand-pick onto their own quiz.
  *
  * - 401 missing/invalid bearer token
  * - 403 caller isn't an instructor (no body)
- * - 200 { questions: PickableQuestion[] }
- * - 500 Supabase not configured, or the query fails
+ * - 200 { questions: PickableQuestion[], userStories: PickableUserStory[] }
+ * - 500 Supabase not configured, or either query fails
  */
 export async function GET(request: Request) {
   const supabase = getSupabaseClient();
@@ -43,10 +49,15 @@ export async function GET(request: Request) {
         );
   }
 
-  const { questions, error } = await listAllQuestionsForPicker(supabase);
-  if (error || !questions) {
-    return Response.json({ error: error?.message ?? 'Could not load questions.' }, { status: 500 });
+  const { questions, error: questionsError } = await listAllQuestionsForPicker(supabase, guard.user_id);
+  if (questionsError || !questions) {
+    return Response.json({ error: questionsError?.message ?? 'Could not load questions.' }, { status: 500 });
   }
 
-  return Response.json({ questions }, { status: 200 });
+  const { userStories, error: userStoriesError } = await listAllUserStoriesForPicker(supabase, guard.user_id);
+  if (userStoriesError || !userStories) {
+    return Response.json({ error: userStoriesError?.message ?? 'Could not load prompts.' }, { status: 500 });
+  }
+
+  return Response.json({ questions, userStories }, { status: 200 });
 }

--- a/app/api/instructor/quizzes/[activityType]/route.ts
+++ b/app/api/instructor/quizzes/[activityType]/route.ts
@@ -1,6 +1,7 @@
 import { getSupabaseClient } from '../../../../../lib/supabase';
 import { requireInstructor } from '../../../../../lib/instructorAuth';
 import {
+  deleteCatalog,
   getQuizByActivityType,
   listCatalogQuestions,
   listCatalogUserStories,
@@ -68,4 +69,48 @@ export async function GET(request: Request, { params }: { params: { activityType
   }
 
   return Response.json({ quiz, questions, userStories: [] }, { status: 200 });
+}
+
+/**
+ * DELETE /api/instructor/quizzes/:activityType — deletes a catalog the caller owns: its own
+ * questions/answers (mcq) or user_story prompts (llm-graded), and unlinks it from every assembled
+ * quiz that composed it (deleteCatalog, lib/activityTypeQueries.ts, has the exact cascade). Same
+ * 404-then-403 ownership check as GET above.
+ *
+ * - 401 missing/invalid bearer token
+ * - 403 caller isn't an instructor, or doesn't own this catalog (no body either way)
+ * - 404 activityType matches no catalog
+ * - 409 a student has already engaged with this catalog (deleteCatalog's own docblock has the
+ *   exact usage this checks) — the catalog is left untouched
+ * - 200 { activityType }
+ * - 500 Supabase not configured, or a query fails
+ */
+export async function DELETE(request: Request, { params }: { params: { activityType: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { activityType } = params;
+
+  const { quiz, creatorId, error: quizError } = await getQuizByActivityType(supabase, activityType);
+  if (quizError) return Response.json({ error: quizError.message }, { status: 500 });
+  if (!quiz) return Response.json({ error: 'Catalog not found.' }, { status: 404 });
+  if (creatorId !== guard.user_id) return new Response(null, { status: 403 });
+
+  const result = await deleteCatalog(supabase, activityType, quiz.gradingKind);
+  if (result.status === 'in_use') {
+    return Response.json({ error: 'This catalog has already been used by a student and cannot be deleted.' }, { status: 409 });
+  }
+  if (result.status === 'error') return Response.json({ error: result.error.message }, { status: 500 });
+
+  return Response.json({ activityType }, { status: 200 });
 }

--- a/app/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]/page.tsx
+++ b/app/instructor/assembled-quizzes/[quizId]/catalogs/[activityType]/page.tsx
@@ -5,12 +5,16 @@ import { useEffect, useState } from 'react';
 import { AppShell } from '../../../../../../components/AppShell';
 import {
   excludeQuestionFromQuiz,
+  excludeUserStoryFromQuiz,
   includeQuestionInQuiz,
+  includeUserStoryInQuiz,
   loadQuizCatalogQuestions,
   loadQuizDetail,
   type AssembledQuizDetail,
   type QuizScopedQuestion,
+  type QuizScopedUserStory,
 } from '../../../../../../lib/assembledQuizClient';
+import type { GradingKind } from '../../../../../../lib/activityTypes';
 import { useRequireRole } from '../../../../../../lib/useRequireRole';
 
 const LEVEL_LABEL: Record<1 | 2 | 3, string> = { 1: 'Easy', 2: 'Medium', 3: 'Hard' };
@@ -33,25 +37,40 @@ function IncludeIcon() {
 }
 
 /**
- * GitHub #361 requirement 3: one catalog's questions, in the context of one quiz — the "copy of
- * the catalog" the user story describes, implemented as the catalog's real questions annotated
- * with this quiz's own exclusion state rather than duplicated rows (see the quiz_excluded_question
- * table comment in supabase/schema.sql). Deliberately no edit/delete affordance here at all — a
- * question's content only ever changes through the real catalog (GitHub #359's
- * app/instructor/quizzes/[activityType]/page.tsx), so there is no path from this screen back to
- * the original catalog getting altered.
+ * GitHub #361 requirement 3: one catalog's questions or prompts, in the context of one quiz — the
+ * "copy of the catalog" the user story describes, implemented as the catalog's real content
+ * annotated with this quiz's own exclusion state rather than duplicated rows (see the
+ * quiz_excluded_question/quiz_excluded_user_story table comments in supabase/schema.sql).
+ * Deliberately no edit/delete affordance here at all, for either kind — content only ever changes
+ * through the real catalog (GitHub #359's app/instructor/quizzes/[activityType]/page.tsx), so
+ * there is no path from this screen back to the original catalog getting altered. Both kinds share
+ * the exact same Include/Exclude interaction, mirrored via a shared `pendingId` (question ids and
+ * user_story ids live in separate namespaces, so one shared pending-state id can't collide).
  */
 export default function QuizCatalogQuestionsPage({ params }: { params: { quizId: string; activityType: string } }) {
   const { token, loading, authorized } = useRequireRole('instructor');
 
   const [quiz, setQuiz] = useState<AssembledQuizDetail | null>(null);
   const [catalogName, setCatalogName] = useState<string | null>(null);
+  const [gradingKind, setGradingKind] = useState<GradingKind | null>(null);
   const [questions, setQuestions] = useState<QuizScopedQuestion[] | null>(null);
+  const [userStories, setUserStories] = useState<QuizScopedUserStory[] | null>(null);
   const [notFound, setNotFound] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
-  const [pendingQuestionId, setPendingQuestionId] = useState<string | null>(null);
+  const [pendingId, setPendingId] = useState<string | null>(null);
   const [error, setError] = useState('');
+
+  // See the sibling quiz composition page for why this is needed: browser back/forward restores
+  // the previously-rendered tree instead of remounting it, so the mount-time fetch below would
+  // otherwise never re-run after navigating away to edit this catalog's questions and back.
+  useEffect(() => {
+    function handlePopState() {
+      setRetryCount((count) => count + 1);
+    }
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
 
   useEffect(() => {
     if (!token) return;
@@ -77,7 +96,9 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
 
         setQuiz(quizResult.data.quiz);
         setCatalogName(catalogResult.data.catalog.name);
+        setGradingKind(catalogResult.data.catalog.gradingKind);
         setQuestions(catalogResult.data.questions);
+        setUserStories(catalogResult.data.userStories);
       },
     );
 
@@ -90,16 +111,16 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
   if (!token) return null;
 
   async function toggleExclusion(question: QuizScopedQuestion) {
-    if (!token || pendingQuestionId) return;
+    if (!token || pendingId) return;
 
-    setPendingQuestionId(question.id);
+    setPendingId(question.id);
     setError('');
 
     const result = question.excludedForQuiz
       ? await includeQuestionInQuiz(token, params.quizId, question.id)
       : await excludeQuestionFromQuiz(token, params.quizId, question.id);
 
-    setPendingQuestionId(null);
+    setPendingId(null);
 
     if (!result.ok) {
       setError(result.error);
@@ -108,6 +129,28 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
 
     setQuestions((current) =>
       (current ?? []).map((q) => (q.id === question.id ? { ...q, excludedForQuiz: !question.excludedForQuiz } : q)),
+    );
+  }
+
+  async function toggleUserStoryExclusion(story: QuizScopedUserStory) {
+    if (!token || pendingId) return;
+
+    setPendingId(story.id);
+    setError('');
+
+    const result = story.excludedForQuiz
+      ? await includeUserStoryInQuiz(token, params.quizId, story.id)
+      : await excludeUserStoryFromQuiz(token, params.quizId, story.id);
+
+    setPendingId(null);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    setUserStories((current) =>
+      (current ?? []).map((s) => (s.id === story.id ? { ...s, excludedForQuiz: !story.excludedForQuiz } : s)),
     );
   }
 
@@ -136,13 +179,14 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
               Retry
             </button>
           </div>
-        ) : !quiz || catalogName === null || questions === null ? (
+        ) : !quiz || catalogName === null || gradingKind === null || questions === null || userStories === null ? (
           <p className="mt-6 text-sm font-semibold text-gray-500">Loading…</p>
         ) : (
           <>
             <h1 className="mb-1.5 text-2xl font-extrabold text-brand-navy">{catalogName}</h1>
             <p className="mb-1 text-sm font-semibold text-gray-500">
-              Showing this catalog&apos;s questions as they apply to <span className="font-extrabold text-gray-700">{quiz.name}</span>.
+              Showing this catalog&apos;s {gradingKind === 'llm-graded' ? 'prompts' : 'questions'} as they apply to{' '}
+              <span className="font-extrabold text-gray-700">{quiz.name}</span>.
             </p>
             <p className="mb-6 text-xs font-bold uppercase tracking-wide text-brand-purple">
               Exclusions apply to this quiz only — the original catalog is never changed here.
@@ -154,6 +198,55 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
               </p>
             ) : null}
 
+            {gradingKind === 'llm-graded' ? (
+              <div className="space-y-4">
+                {userStories.length === 0 ? (
+                  <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
+                    This catalog has no prompts yet.
+                  </p>
+                ) : (
+                  userStories.map((story) => (
+                    <div
+                      key={story.id}
+                      className={`rounded-brand-lg border p-5 transition ${
+                        story.excludedForQuiz ? 'border-gray-200 bg-gray-100 opacity-60' : 'border-gray-100 bg-gray-50'
+                      }`}
+                    >
+                      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="inline-block rounded-full bg-white px-2.5 py-1 text-xs font-extrabold text-gray-500">
+                            {LEVEL_LABEL[story.level]} · Level {story.level}
+                          </span>
+                          {story.excludedForQuiz ? (
+                            <span className="inline-flex items-center gap-1 rounded-full bg-gray-300 px-2.5 py-1 text-[11px] font-extrabold text-gray-600">
+                              Excluded
+                            </span>
+                          ) : null}
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => toggleUserStoryExclusion(story)}
+                          disabled={pendingId === story.id}
+                          aria-label={story.excludedForQuiz ? 'Include this prompt in the quiz' : 'Exclude this prompt from the quiz'}
+                          title={story.excludedForQuiz ? 'Include in this quiz' : 'Exclude from this quiz'}
+                          className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-extrabold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                            story.excludedForQuiz
+                              ? 'border-brand-teal/40 bg-white text-brand-teal-dark hover:border-brand-teal'
+                              : 'border-gray-300 bg-white text-gray-600 hover:border-brand-danger hover:text-brand-danger'
+                          }`}
+                        >
+                          {story.excludedForQuiz ? <IncludeIcon /> : <ExcludeIcon />}
+                          {pendingId === story.id ? '…' : story.excludedForQuiz ? 'Include' : 'Exclude'}
+                        </button>
+                      </div>
+                      <p className={`whitespace-pre-wrap text-sm font-bold ${story.excludedForQuiz ? 'text-gray-500' : 'text-brand-navy'}`}>
+                        {story.storyText}
+                      </p>
+                    </div>
+                  ))
+                )}
+              </div>
+            ) : (
             <div className="space-y-4">
               {questions.length === 0 ? (
                 <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
@@ -181,7 +274,7 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
                       <button
                         type="button"
                         onClick={() => toggleExclusion(question)}
-                        disabled={pendingQuestionId === question.id}
+                        disabled={pendingId === question.id}
                         aria-label={question.excludedForQuiz ? 'Include this question in the quiz' : 'Exclude this question from the quiz'}
                         title={question.excludedForQuiz ? 'Include in this quiz' : 'Exclude from this quiz'}
                         className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-extrabold transition disabled:cursor-not-allowed disabled:opacity-50 ${
@@ -191,7 +284,7 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
                         }`}
                       >
                         {question.excludedForQuiz ? <IncludeIcon /> : <ExcludeIcon />}
-                        {pendingQuestionId === question.id ? '…' : question.excludedForQuiz ? 'Include' : 'Exclude'}
+                        {pendingId === question.id ? '…' : question.excludedForQuiz ? 'Include' : 'Exclude'}
                       </button>
                     </div>
                     <p className={`mb-4 text-sm font-bold ${question.excludedForQuiz ? 'text-gray-500' : 'text-brand-navy'}`}>
@@ -226,6 +319,7 @@ export default function QuizCatalogQuestionsPage({ params }: { params: { quizId:
                 ))
               )}
             </div>
+            )}
           </>
         )}
       </div>

--- a/app/instructor/assembled-quizzes/[quizId]/page.tsx
+++ b/app/instructor/assembled-quizzes/[quizId]/page.tsx
@@ -13,10 +13,12 @@ import {
   linkCatalogToQuiz,
   loadQuizDetail,
   removeExtraQuestionFromQuiz,
+  removeExtraUserStoryFromQuiz,
   unlinkCatalogFromQuiz,
   type AssembledQuizDetail,
   type QuizCatalogComposition,
   type QuizExtraQuestionSummary,
+  type QuizExtraUserStorySummary,
   type QuizLevelCoverage,
 } from '../../../../lib/assembledQuizClient';
 import { loadQuizzes, type QuizSummary } from '../../../../lib/quizClient';
@@ -50,7 +52,9 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
   const [catalogs, setCatalogs] = useState<QuizCatalogComposition[] | null>(null);
   const [levelCoverage, setLevelCoverage] = useState<QuizLevelCoverage[] | null>(null);
   const [extraQuestions, setExtraQuestions] = useState<QuizExtraQuestionSummary[] | null>(null);
+  const [extraUserStories, setExtraUserStories] = useState<QuizExtraUserStorySummary[] | null>(null);
   const [activeCatalogQuestionIds, setActiveCatalogQuestionIds] = useState<string[] | null>(null);
+  const [activeCatalogUserStoryIds, setActiveCatalogUserStoryIds] = useState<string[] | null>(null);
   const [allCatalogs, setAllCatalogs] = useState<QuizSummary[] | null>(null);
   const [notFound, setNotFound] = useState(false);
   const [loadFailed, setLoadFailed] = useState(false);
@@ -64,6 +68,19 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
   const [showAddQuestionsModal, setShowAddQuestionsModal] = useState(false);
   const [showCreateQuestionModal, setShowCreateQuestionModal] = useState(false);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+
+  // Browser back/forward restores the previously-rendered component tree instead of remounting
+  // it (Next's restoreReducer reuses state.cache directly and never re-checks staleTimes), so the
+  // mount-time fetch below never re-runs on its own after navigating away to edit a linked
+  // catalog's questions and back. Bumping retryCount on `popstate` forces a fresh fetch on every
+  // back/forward visit regardless of that caching behavior.
+  useEffect(() => {
+    function handlePopState() {
+      setRetryCount((count) => count + 1);
+    }
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
 
   useEffect(() => {
     if (!token) return;
@@ -89,7 +106,9 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
       setCatalogs(detailResult.data.catalogs);
       setLevelCoverage(detailResult.data.levelCoverage);
       setExtraQuestions(detailResult.data.extraQuestions);
+      setExtraUserStories(detailResult.data.extraUserStories);
       setActiveCatalogQuestionIds(detailResult.data.activeCatalogQuestionIds);
+      setActiveCatalogUserStoryIds(detailResult.data.activeCatalogUserStoryIds);
       setAllCatalogs(catalogsResult.data.quizzes);
     });
 
@@ -130,6 +149,9 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
         activityType: selectedCatalogToAdd,
         name: added?.name ?? selectedCatalogToAdd,
         description: added?.description ?? null,
+        // added.gradingKind/questionCount already account for the catalog's kind (lib/quizClient.ts's
+        // QuizSummary — questionCount is prompts for llm-graded, questions for mcq).
+        gradingKind: added?.gradingKind ?? 'mcq',
         totalQuestions: added?.questionCount ?? 0,
         excludedCount: 0,
         activeCount: added?.questionCount ?? 0,
@@ -155,15 +177,37 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
     setRetryCount((count) => count + 1); // re-fetch level coverage now that a hand-picked question is gone from the pool
   }
 
+  async function handleRemoveExtraUserStory(story: QuizExtraUserStorySummary) {
+    if (!token) return;
+    if (!confirm(`Remove "${story.storyText}" from this quiz?`)) return;
+
+    const result = await removeExtraUserStoryFromQuiz(token, params.quizId, story.userStoryId);
+    if (!result.ok) {
+      showToast(result.error);
+      return;
+    }
+
+    setExtraUserStories((current) => (current ?? []).filter((s) => s.userStoryId !== story.userStoryId));
+    showToast('Prompt removed from this quiz.');
+    setRetryCount((count) => count + 1); // re-fetch level coverage now that a hand-picked prompt is gone from the pool
+  }
+
   // GitHub #380 extension: catalog choices offered by the reused QuestionFormModal when creating
   // a brand-new question from this page — the quiz's own linked catalogs when it has any (so the
   // instructor's most likely target is already selected), falling back to every catalog the
   // instructor owns when it has none (a question must always belong to a catalog, so this choice
-  // can never be skipped, only defaulted).
+  // can never be skipped, only defaulted). Filtered to 'mcq' catalogs only — QuestionFormModal
+  // creates `question` rows, and an llm-graded catalog's pool is `user_story`; nothing validates
+  // that server-side (POST /api/instructor/questions only checks the activityType exists, not its
+  // grading_kind), so this filter is the only thing stopping an MCQ question from ending up
+  // permanently invisible under a prompt-only catalog.
+  const mcqCatalogs = (catalogs ?? []).filter((catalog) => catalog.gradingKind === 'mcq');
   const catalogOptionsForCreate: { value: ActivityType; label: string }[] =
-    catalogs && catalogs.length > 0
-      ? catalogs.map((catalog) => ({ value: catalog.activityType as ActivityType, label: catalog.name }))
-      : (allCatalogs ?? []).map((catalog) => ({ value: catalog.activityType as ActivityType, label: catalog.name }));
+    mcqCatalogs.length > 0
+      ? mcqCatalogs.map((catalog) => ({ value: catalog.activityType as ActivityType, label: catalog.name }))
+      : (allCatalogs ?? [])
+          .filter((catalog) => catalog.gradingKind === 'mcq')
+          .map((catalog) => ({ value: catalog.activityType as ActivityType, label: catalog.name }));
 
   async function handleCreateAndPickQuestion(question: QuizQuestion): Promise<{ ok: true } | { ok: false; error: string }> {
     if (!token) return { ok: false, error: 'Your session has expired. Please sign in again.' };
@@ -199,7 +243,14 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
               Retry
             </button>
           </div>
-        ) : !quiz || !catalogs || !levelCoverage || !extraQuestions || !activeCatalogQuestionIds || !allCatalogs ? (
+        ) : !quiz ||
+          !catalogs ||
+          !levelCoverage ||
+          !extraQuestions ||
+          !extraUserStories ||
+          !activeCatalogQuestionIds ||
+          !activeCatalogUserStoryIds ||
+          !allCatalogs ? (
           <p className="mt-6 text-sm font-semibold text-gray-500">Loading…</p>
         ) : (
           <>
@@ -280,7 +331,7 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
                       <p className="font-extrabold text-brand-navy hover:text-brand-purple hover:underline">{catalog.name}</p>
                       {catalog.description ? <p className="mt-0.5 text-xs font-semibold text-gray-500">{catalog.description}</p> : null}
                       <p className="mt-1 text-xs font-bold text-gray-600">
-                        {catalog.activeCount} of {catalog.totalQuestions} questions active
+                        {catalog.activeCount} of {catalog.totalQuestions} {catalog.gradingKind === 'llm-graded' ? 'prompts' : 'questions'} active
                         {catalog.excludedCount > 0 ? ` · ${catalog.excludedCount} excluded for this quiz` : ''}
                       </p>
                     </Link>
@@ -324,7 +375,7 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
             {addError ? <p className="mt-2 text-xs font-bold text-brand-danger">{addError}</p> : null}
 
             <div className="mb-3 mt-8 flex flex-wrap items-center justify-between gap-2">
-              <p className="text-xs font-extrabold uppercase tracking-wide text-gray-400">Individually added questions</p>
+              <p className="text-xs font-extrabold uppercase tracking-wide text-gray-400">Individually added items</p>
               <div className="flex flex-none flex-wrap gap-2">
                 <button
                   type="button"
@@ -340,45 +391,89 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
                   onClick={() => setShowAddQuestionsModal(true)}
                   className="flex-none rounded-full border border-brand-purple/40 px-4 py-1.5 text-xs font-extrabold text-brand-purple transition hover:bg-brand-purple/10"
                 >
-                  Add individual questions
+                  Add individual items
                 </button>
               </div>
             </div>
             <p className="mb-4 text-xs font-semibold text-gray-500">
-              Questions picked here count toward this quiz&apos;s pool regardless of whether their own catalog is
-              linked above. Removing one only drops it from this quiz — the original question, its catalog, and
-              every other quiz are unaffected.
+              Questions and prompts picked here count toward this quiz&apos;s pool regardless of whether their own
+              catalog is linked above. Removing one only drops it from this quiz — the original item, its catalog,
+              and every other quiz are unaffected.
             </p>
 
             <div className="space-y-3">
-              {extraQuestions.length === 0 ? (
+              {extraQuestions.length === 0 && extraUserStories.length === 0 ? (
                 <p className="rounded-brand-lg border border-gray-100 bg-gray-50 p-6 text-center text-sm font-semibold text-gray-500">
-                  No individually added questions yet.
+                  No individually added items yet.
                 </p>
               ) : (
-                extraQuestions.map((question) => (
-                  <div
-                    key={question.questionId}
-                    className="flex flex-wrap items-center justify-between gap-3 rounded-brand-lg border border-gray-100 bg-gray-50 p-4"
-                  >
-                    <div className="min-w-0 flex-1">
-                      <p className="font-semibold text-brand-navy">{question.questionText}</p>
-                      <p className="mt-1 flex flex-wrap items-center gap-2 text-xs font-bold text-gray-500">
-                        <span className="rounded-full bg-white px-2 py-0.5">{question.catalogName}</span>
-                        <span className="rounded-full bg-white px-2 py-0.5">{LEVEL_LABEL[question.level]}</span>
+                <>
+                  {extraQuestions.length > 0 ? (
+                    <div>
+                      <p className="mb-2 text-[11px] font-extrabold uppercase tracking-wide text-gray-400">
+                        Multiple Choice ({extraQuestions.length})
                       </p>
+                      <div className="space-y-3">
+                        {extraQuestions.map((question) => (
+                          <div
+                            key={question.questionId}
+                            className="flex flex-wrap items-center justify-between gap-3 rounded-brand-lg border border-gray-100 bg-gray-50 p-4"
+                          >
+                            <div className="min-w-0 flex-1">
+                              <p className="font-semibold text-brand-navy">{question.questionText}</p>
+                              <p className="mt-1 flex flex-wrap items-center gap-2 text-xs font-bold text-gray-500">
+                                <span className="rounded-full bg-white px-2 py-0.5">{question.catalogName}</span>
+                                <span className="rounded-full bg-white px-2 py-0.5">{LEVEL_LABEL[question.level]}</span>
+                              </p>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveExtraQuestion(question)}
+                              aria-label={`Remove "${question.questionText}" from this quiz`}
+                              title="Remove from this quiz"
+                              className="flex h-9 w-9 flex-none items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 transition hover:border-brand-danger hover:text-brand-danger"
+                            >
+                              <RemoveIcon />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => handleRemoveExtraQuestion(question)}
-                      aria-label={`Remove "${question.questionText}" from this quiz`}
-                      title="Remove from this quiz"
-                      className="flex h-9 w-9 flex-none items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 transition hover:border-brand-danger hover:text-brand-danger"
-                    >
-                      <RemoveIcon />
-                    </button>
-                  </div>
-                ))
+                  ) : null}
+
+                  {extraUserStories.length > 0 ? (
+                    <div className={extraQuestions.length > 0 ? 'mt-6' : ''}>
+                      <p className="mb-2 text-[11px] font-extrabold uppercase tracking-wide text-gray-400">
+                        LLM-Graded ({extraUserStories.length})
+                      </p>
+                      <div className="space-y-3">
+                        {extraUserStories.map((story) => (
+                          <div
+                            key={story.userStoryId}
+                            className="flex flex-wrap items-center justify-between gap-3 rounded-brand-lg border border-gray-100 bg-gray-50 p-4"
+                          >
+                            <div className="min-w-0 flex-1">
+                              <p className="font-semibold text-brand-navy">{story.storyText}</p>
+                              <p className="mt-1 flex flex-wrap items-center gap-2 text-xs font-bold text-gray-500">
+                                <span className="rounded-full bg-white px-2 py-0.5">{story.catalogName}</span>
+                                <span className="rounded-full bg-white px-2 py-0.5">{LEVEL_LABEL[story.level]}</span>
+                              </p>
+                            </div>
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveExtraUserStory(story)}
+                              aria-label={`Remove "${story.storyText}" from this quiz`}
+                              title="Remove from this quiz"
+                              className="flex h-9 w-9 flex-none items-center justify-center rounded-full border border-gray-200 bg-white text-gray-400 transition hover:border-brand-danger hover:text-brand-danger"
+                            >
+                              <RemoveIcon />
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+                </>
               )}
             </div>
           </>
@@ -439,13 +534,23 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
         <AddQuizQuestionsModal
           token={token}
           quizId={params.quizId}
-          // Already-included regardless of source: every question currently active through a
-          // linked catalog (not excluded) plus every question already hand-picked — see
-          // getQuizComposition's own docblock for why activeCatalogQuestionIds exists.
-          alreadyIncludedIds={new Set([...(activeCatalogQuestionIds ?? []), ...(extraQuestions ?? []).map((q) => q.questionId)])}
+          // Already-included regardless of source: every question/prompt currently active through
+          // a linked catalog (not excluded) plus every question/prompt already hand-picked — see
+          // getQuizComposition's own docblock for why activeCatalogQuestionIds/
+          // activeCatalogUserStoryIds exist. Question ids and user_story ids live in separate
+          // namespaces, so unioning them into one Set can't collide.
+          alreadyIncludedIds={
+            new Set([
+              ...(activeCatalogQuestionIds ?? []),
+              ...(extraQuestions ?? []).map((q) => q.questionId),
+              ...(activeCatalogUserStoryIds ?? []),
+              ...(extraUserStories ?? []).map((s) => s.userStoryId),
+            ])
+          }
           onClose={() => setShowAddQuestionsModal(false)}
-          onAdded={(questionIds) => {
-            showToast(`${questionIds.length} question${questionIds.length === 1 ? '' : 's'} added to this quiz.`);
+          onAdded={({ questionIds, userStoryIds }) => {
+            const total = questionIds.length + userStoryIds.length;
+            showToast(`${total} item${total === 1 ? '' : 's'} added to this quiz.`);
             setRetryCount((count) => count + 1); // re-fetch composition + level coverage with the new hand-picks included
           }}
           onCreateNew={

--- a/app/instructor/quizzes/[activityType]/page.tsx
+++ b/app/instructor/quizzes/[activityType]/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { AppShell } from '../../../../components/AppShell';
 import { CatalogPromptCard } from '../../../../components/CatalogPromptCard';
@@ -8,7 +9,7 @@ import { ConfirmModal } from '../../../../components/ConfirmModal';
 import { DeleteQuestionModal } from '../../../../components/DeleteQuestionModal';
 import { PromptFormModal } from '../../../../components/PromptFormModal';
 import { QuestionFormModal } from '../../../../components/QuestionFormModal';
-import { loadQuizDetail, type QuizMeta } from '../../../../lib/quizClient';
+import { deleteCatalog, loadQuizDetail, type QuizMeta } from '../../../../lib/quizClient';
 import { createQuestion, updateQuestion } from '../../../../lib/sessionClient';
 import {
   createUserStory,
@@ -77,6 +78,7 @@ function shortLevels(prompts: CatalogUserStory[]): (1 | 2 | 3)[] {
  */
 export default function CatalogDetailPage({ params }: { params: { activityType: string } }) {
   const { token, profile, loading, authorized } = useRequireRole('instructor');
+  const router = useRouter();
 
   const [quiz, setQuiz] = useState<QuizMeta | null>(null);
   const [questions, setQuestions] = useState<CatalogQuestion[] | null>(null);
@@ -94,6 +96,7 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
   const [promptDeleteTarget, setPromptDeleteTarget] = useState<CatalogUserStory | null>(null);
   const [highlight, setHighlight] = useState<{ id: string; label: string } | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
+  const [showDeleteCatalog, setShowDeleteCatalog] = useState(false);
 
   useEffect(() => {
     if (!token) return;
@@ -235,6 +238,18 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
     window.setTimeout(() => setToastMessage(null), TOAST_MS);
   }
 
+  async function handleDeleteCatalog(): Promise<{ ok: true } | { ok: false; error: string }> {
+    if (!token) return { ok: false, error: 'Your session has expired. Please sign in again.' };
+
+    // A 409 ("already used by a student") arrives here with the route's own wording and keeps
+    // the dialog open, same contract as handleDeletePrompt above.
+    const result = await deleteCatalog(token, params.activityType);
+    if (!result.ok) return { ok: false, error: result.error };
+
+    router.push('/instructor/quizzes');
+    return { ok: true };
+  }
+
   return (
     <AppShell active="instructor-quizzes">
       <div className="mx-auto max-w-3xl">
@@ -297,6 +312,15 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
                   }`}
                 >
                   {editMode ? 'Done' : 'Edit'}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDeleteCatalog(true)}
+                  aria-label="Delete this catalog"
+                  title="Delete this catalog"
+                  className="flex h-10 w-10 flex-none items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 transition hover:border-brand-danger hover:text-brand-danger"
+                >
+                  <TrashIcon />
                 </button>
               </div>
             </div>
@@ -497,6 +521,26 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
           confirmingLabel="Deleting…"
           onClose={() => setPromptDeleteTarget(null)}
           onConfirm={handleDeletePrompt}
+        />
+      ) : null}
+
+      {showDeleteCatalog ? (
+        <ConfirmModal
+          kicker="Question Catalogs"
+          title="Delete this catalog?"
+          message={
+            <>
+              <span className="block font-bold text-brand-ink">{quiz?.name ?? 'This catalog'}</span>
+              <span className="mt-2 block">
+                This permanently deletes every {llmGraded ? 'prompt' : 'question'} in this catalog and removes it
+                from any quiz it&apos;s linked to. This can&apos;t be undone.
+              </span>
+            </>
+          }
+          confirmLabel="Delete catalog"
+          confirmingLabel="Deleting…"
+          onClose={() => setShowDeleteCatalog(false)}
+          onConfirm={handleDeleteCatalog}
         />
       ) : null}
     </AppShell>

--- a/components/AddQuizQuestionsModal.tsx
+++ b/components/AddQuizQuestionsModal.tsx
@@ -1,35 +1,93 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { addExtraQuestionsToQuiz, loadAllQuestionsForPicker, type PickableQuestion } from '../lib/assembledQuizClient';
+import {
+  addExtraQuestionsToQuiz,
+  addExtraUserStoriesToQuiz,
+  loadAllQuestionsForPicker,
+  type PickableQuestion,
+  type PickableUserStory,
+} from '../lib/assembledQuizClient';
 import { useModalDismiss } from './useModalDismiss';
 
 const LEVEL_LABEL: Record<1 | 2 | 3, string> = { 1: 'Easy', 2: 'Medium', 3: 'Hard' };
 const ALL_CATALOGS = 'all';
 const ALL_LEVELS = 'all';
+const ALL_TYPES = 'all';
+
+type PickerType = 'mcq' | 'llm-graded';
+
+function PickerRow({
+  id,
+  text,
+  level,
+  catalogName,
+  typeLabel,
+  alreadyIn,
+  selected,
+  onToggle,
+}: {
+  id: string;
+  text: string;
+  level: 1 | 2 | 3;
+  catalogName: string;
+  typeLabel: string;
+  alreadyIn: boolean;
+  selected: boolean;
+  onToggle: (id: string) => void;
+}) {
+  return (
+    <li>
+      <label className={`flex items-start gap-3 px-4 py-3 text-sm ${alreadyIn ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-brand-navy'}`}>
+        <input
+          type="checkbox"
+          checked={alreadyIn || selected}
+          disabled={alreadyIn}
+          onChange={() => onToggle(id)}
+          className="mt-0.5 h-4 w-4 flex-none rounded border-brand-navy-border text-brand-purple focus:ring-brand-purple"
+        />
+        <span className="min-w-0 flex-1">
+          <span className="block font-semibold text-brand-ink">{text}</span>
+          <span className="mt-1 flex flex-wrap items-center gap-2 text-xs font-bold text-brand-ink-muted">
+            <span className="rounded-full bg-brand-purple/20 px-2 py-0.5 text-brand-purple">{typeLabel}</span>
+            <span className="rounded-full bg-brand-navy px-2 py-0.5">{catalogName}</span>
+            <span className="rounded-full bg-brand-navy px-2 py-0.5">{LEVEL_LABEL[level]}</span>
+            {alreadyIn ? <span className="rounded-full bg-brand-teal/20 px-2 py-0.5 text-brand-teal-dark">Already in quiz</span> : null}
+          </span>
+        </span>
+      </label>
+    </li>
+  );
+}
 
 /**
- * The popup that hand-picks individual questions onto an assembled quiz (GitHub #380), from any
- * catalog, without requiring that catalog to be linked to the quiz as a whole — see
- * assembled_quiz_extra_question's own header comment in supabase/schema.sql for why this is a
+ * The popup that hand-picks individual questions and prompts onto an assembled quiz (GitHub #380,
+ * extended with llm-graded parity), from any of the caller's own catalogs, without requiring that
+ * catalog to be linked to the quiz as a whole — see assembled_quiz_extra_question/
+ * assembled_quiz_extra_user_story's own header comments in supabase/schema.sql for why this is a
  * genuinely separate mechanism from "add a catalog". Same overlay/panel/header/footer chrome and
  * useModalDismiss wiring as CreateQuizModal/CreateCatalogModal.
  *
- * Fetches the whole system-wide question list once (loadAllQuestionsForPicker) and
+ * Fetches the whole picker list once (loadAllQuestionsForPicker, both pools) and
  * searches/filters it client-side, the same "fetch once, filter in the browser" choice
  * GET /api/instructor/quizzes' browse table already makes for catalogs — the picker route isn't
  * quiz-scoped, so `alreadyIncludedIds` (computed by the parent page from this quiz's own already-
- * loaded composition: active catalog questions plus existing hand-picks) is what marks a row as
- * already in the quiz, not anything the server returns.
+ * loaded composition: active catalog items plus existing hand-picks, both kinds) is what marks a
+ * row as already in the quiz, not anything the server returns.
  *
- * Selecting several questions and submitting once calls POST .../extra-questions with the whole
- * batch — one round trip, not one per checkbox.
+ * MCQ questions and LLM-graded prompts are rendered as two separately-headed, separately-counted
+ * sections (plus a Type filter to view just one) rather than one undifferentiated list — a badge
+ * per row alone wasn't enough to keep the two kinds visually apart once a catalog mixes both. The
+ * two kinds are always submitted through their own endpoint (POST .../extra-questions vs.
+ * POST .../extra-user-stories) since they're genuinely different tables; selecting one of each and
+ * submitting once still costs only two round trips total, not one per item.
  *
  * onCreateNew is the second entry point into GitHub #380's "create a brand-new question" flow —
  * a "Can't find it? Create a new question" link rather than a full form embedded here, since the
  * actual form is the existing QuestionFormModal, owned and rendered by the composition page
  * itself (not this modal); triggering it means handing control back to the parent, which closes
- * this modal and opens that one. Optional so this component doesn't require the capability if a
+ * this modal and opens that one. MCQ-only for now (llm-graded prompts have no equivalent
+ * create-and-hand-pick route yet). Optional so this component doesn't require the capability if a
  * future caller doesn't want it.
  */
 export function AddQuizQuestionsModal({
@@ -44,14 +102,16 @@ export function AddQuizQuestionsModal({
   quizId: string;
   alreadyIncludedIds: Set<string>;
   onClose: () => void;
-  onAdded: (questionIds: string[]) => void;
+  onAdded: (result: { questionIds: string[]; userStoryIds: string[] }) => void;
   onCreateNew?: () => void;
 }) {
   const [questions, setQuestions] = useState<PickableQuestion[] | null>(null);
+  const [userStories, setUserStories] = useState<PickableUserStory[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [query, setQuery] = useState('');
   const [catalogFilter, setCatalogFilter] = useState(ALL_CATALOGS);
   const [levelFilter, setLevelFilter] = useState<typeof ALL_LEVELS | 1 | 2 | 3>(ALL_LEVELS);
+  const [typeFilter, setTypeFilter] = useState<typeof ALL_TYPES | PickerType>(ALL_TYPES);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState('');
@@ -65,8 +125,12 @@ export function AddQuizQuestionsModal({
     let cancelled = false;
     loadAllQuestionsForPicker(token).then((result) => {
       if (cancelled) return;
-      if (result.ok) setQuestions(result.data.questions);
-      else setLoadFailed(true);
+      if (result.ok) {
+        setQuestions(result.data.questions);
+        setUserStories(result.data.userStories);
+      } else {
+        setLoadFailed(true);
+      }
     });
     return () => {
       cancelled = true;
@@ -76,10 +140,12 @@ export function AddQuizQuestionsModal({
   const catalogs = useMemo(() => {
     const seen = new Map<string, string>();
     for (const question of questions ?? []) seen.set(question.catalogActivityType, question.catalogName);
+    for (const story of userStories ?? []) seen.set(story.catalogActivityType, story.catalogName);
     return Array.from(seen.entries()).sort((a, b) => a[1].localeCompare(b[1]));
-  }, [questions]);
+  }, [questions, userStories]);
 
   const visibleQuestions = useMemo(() => {
+    if (typeFilter === 'llm-graded') return [];
     const q = query.trim().toLowerCase();
     return (questions ?? []).filter((question) => {
       if (q && !question.questionText.toLowerCase().includes(q)) return false;
@@ -87,14 +153,25 @@ export function AddQuizQuestionsModal({
       if (levelFilter !== ALL_LEVELS && question.level !== levelFilter) return false;
       return true;
     });
-  }, [questions, query, catalogFilter, levelFilter]);
+  }, [questions, query, catalogFilter, levelFilter, typeFilter]);
 
-  function toggle(questionId: string) {
-    if (alreadyIncludedIds.has(questionId)) return;
+  const visibleUserStories = useMemo(() => {
+    if (typeFilter === 'mcq') return [];
+    const q = query.trim().toLowerCase();
+    return (userStories ?? []).filter((story) => {
+      if (q && !story.storyText.toLowerCase().includes(q)) return false;
+      if (catalogFilter !== ALL_CATALOGS && story.catalogActivityType !== catalogFilter) return false;
+      if (levelFilter !== ALL_LEVELS && story.level !== levelFilter) return false;
+      return true;
+    });
+  }, [userStories, query, catalogFilter, levelFilter, typeFilter]);
+
+  function toggle(id: string) {
+    if (alreadyIncludedIds.has(id)) return;
     setSelected((current) => {
       const next = new Set(current);
-      if (next.has(questionId)) next.delete(questionId);
-      else next.add(questionId);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
       return next;
     });
   }
@@ -105,17 +182,35 @@ export function AddQuizQuestionsModal({
     setSubmitting(true);
     setError('');
 
-    const result = await addExtraQuestionsToQuiz(token, quizId, Array.from(selected));
+    const selectedQuestionIds = (questions ?? []).filter((question) => selected.has(question.id)).map((question) => question.id);
+    const selectedUserStoryIds = (userStories ?? []).filter((story) => selected.has(story.id)).map((story) => story.id);
+
+    const [questionResult, userStoryResult] = await Promise.all([
+      selectedQuestionIds.length > 0
+        ? addExtraQuestionsToQuiz(token, quizId, selectedQuestionIds)
+        : Promise.resolve({ ok: true as const, data: { questionIds: [] as string[] } }),
+      selectedUserStoryIds.length > 0
+        ? addExtraUserStoriesToQuiz(token, quizId, selectedUserStoryIds)
+        : Promise.resolve({ ok: true as const, data: { userStoryIds: [] as string[] } }),
+    ]);
+
     setSubmitting(false);
 
-    if (!result.ok) {
-      setError(result.error);
+    if (!questionResult.ok) {
+      setError(questionResult.error);
+      return;
+    }
+    if (!userStoryResult.ok) {
+      setError(userStoryResult.error);
       return;
     }
 
-    onAdded(result.data.questionIds);
+    onAdded({ questionIds: questionResult.data.questionIds, userStoryIds: userStoryResult.data.userStoryIds });
     requestClose();
   }
+
+  const loading = questions === null || userStories === null;
+  const nothingVisible = !loading && visibleQuestions.length === 0 && visibleUserStories.length === 0;
 
   return (
     <div
@@ -159,9 +254,22 @@ export function AddQuizQuestionsModal({
               type="text"
               value={query}
               onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search question text…"
+              placeholder="Search question or prompt text…"
               className="mt-1.5 block w-full rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
             />
+          </label>
+
+          <label className="text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+            Type
+            <select
+              value={typeFilter}
+              onChange={(event) => setTypeFilter(event.target.value === ALL_TYPES ? ALL_TYPES : (event.target.value as PickerType))}
+              className="mt-1.5 block w-full rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple sm:w-44"
+            >
+              <option value={ALL_TYPES}>All types</option>
+              <option value="mcq">Multiple choice</option>
+              <option value="llm-graded">LLM-graded</option>
+            </select>
           </label>
 
           <label className="text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
@@ -198,40 +306,58 @@ export function AddQuizQuestionsModal({
         <div className="min-h-0 flex-1 overflow-y-auto rounded-brand-md border border-brand-navy-border bg-brand-navy-2">
           {loadFailed ? (
             <p className="p-4 text-center text-sm font-semibold text-brand-danger">Failed to load questions.</p>
-          ) : questions === null ? (
+          ) : loading ? (
             <p className="p-4 text-center text-sm font-semibold text-brand-ink-muted">Loading…</p>
-          ) : visibleQuestions.length === 0 ? (
-            <p className="p-4 text-center text-sm font-semibold text-brand-ink-muted">No questions match this filter.</p>
+          ) : nothingVisible ? (
+            <p className="p-4 text-center text-sm font-semibold text-brand-ink-muted">No questions or prompts match this filter.</p>
           ) : (
-            <ul className="divide-y divide-brand-navy-border">
-              {visibleQuestions.map((question) => {
-                const alreadyIn = alreadyIncludedIds.has(question.id);
-                const isSelected = selected.has(question.id);
-                return (
-                  <li key={question.id}>
-                    <label
-                      className={`flex items-start gap-3 px-4 py-3 text-sm ${alreadyIn ? 'cursor-not-allowed opacity-50' : 'cursor-pointer hover:bg-brand-navy'}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={alreadyIn || isSelected}
-                        disabled={alreadyIn}
-                        onChange={() => toggle(question.id)}
-                        className="mt-0.5 h-4 w-4 flex-none rounded border-brand-navy-border text-brand-purple focus:ring-brand-purple"
+            <>
+              {visibleQuestions.length > 0 ? (
+                <div>
+                  <p className="sticky top-0 border-b border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+                    Multiple Choice Questions ({visibleQuestions.length})
+                  </p>
+                  <ul className="divide-y divide-brand-navy-border">
+                    {visibleQuestions.map((question) => (
+                      <PickerRow
+                        key={question.id}
+                        id={question.id}
+                        text={question.questionText}
+                        level={question.level}
+                        catalogName={question.catalogName}
+                        typeLabel="MCQ"
+                        alreadyIn={alreadyIncludedIds.has(question.id)}
+                        selected={selected.has(question.id)}
+                        onToggle={toggle}
                       />
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-semibold text-brand-ink">{question.questionText}</span>
-                        <span className="mt-1 flex flex-wrap items-center gap-2 text-xs font-bold text-brand-ink-muted">
-                          <span className="rounded-full bg-brand-navy px-2 py-0.5">{question.catalogName}</span>
-                          <span className="rounded-full bg-brand-navy px-2 py-0.5">{LEVEL_LABEL[question.level]}</span>
-                          {alreadyIn ? <span className="rounded-full bg-brand-teal/20 px-2 py-0.5 text-brand-teal-dark">Already in quiz</span> : null}
-                        </span>
-                      </span>
-                    </label>
-                  </li>
-                );
-              })}
-            </ul>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              {visibleUserStories.length > 0 ? (
+                <div>
+                  <p className="sticky top-0 border-b border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+                    LLM-Graded Prompts ({visibleUserStories.length})
+                  </p>
+                  <ul className="divide-y divide-brand-navy-border">
+                    {visibleUserStories.map((story) => (
+                      <PickerRow
+                        key={story.id}
+                        id={story.id}
+                        text={story.storyText}
+                        level={story.level}
+                        catalogName={story.catalogName}
+                        typeLabel="LLM-Graded"
+                        alreadyIn={alreadyIncludedIds.has(story.id)}
+                        selected={selected.has(story.id)}
+                        onToggle={toggle}
+                      />
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </>
           )}
         </div>
 
@@ -265,7 +391,7 @@ export function AddQuizQuestionsModal({
               disabled={selected.size === 0 || submitting}
               className="rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
             >
-              {submitting ? 'Adding…' : `Add ${selected.size} question${selected.size === 1 ? '' : 's'}`}
+              {submitting ? 'Adding…' : `Add ${selected.size} item${selected.size === 1 ? '' : 's'}`}
             </button>
           </div>
         </div>

--- a/lib/activityTypeQueries.ts
+++ b/lib/activityTypeQueries.ts
@@ -294,3 +294,97 @@ export async function listCatalogUserStories(supabase: SupabaseClient, activityT
 
   return { userStories, error: null };
 }
+
+export type DeleteCatalogResult = { status: 'ok' } | { status: 'in_use' } | { status: 'error'; error: { message: string } };
+
+/**
+ * Deletes a catalog (activity_type row) entirely: its own questions/answers (mcq) or user_story
+ * prompts (llm-graded), and every assembled_quiz_catalog link that referenced it — a link to a
+ * catalog that no longer exists is meaningless, so this is what removes a deleted catalog from
+ * any quiz it was composed into. quiz_excluded_question and assembled_quiz_extra_question rows
+ * cascade automatically (their FK to question is ON DELETE CASCADE, see supabase/schema.sql); no
+ * manual cleanup needed for those.
+ *
+ * Refuses with 'in_use' instead of deleting anything if a student has ever engaged with this
+ * catalog: a session_log row for this activity_type — which a session_to_question or
+ * session_to_user_story row always implies by construction, since a session only ever draws from
+ * its own activity_type's pool — or, for an mcq catalog specifically, a daily_challenge_attempt
+ * row for one of its questions (that table has no session_log/activity_type of its own to check
+ * instead, unlike every other student-history table). None of session_to_question/
+ * session_to_user_story/answered_question_log/submission/daily_challenge_attempt has an ON DELETE
+ * clause on its FK into question/user_story, so a physical delete would either fail outright or,
+ * attempted piecemeal, orphan a student's history — checking first avoids both, the same reasoning
+ * DELETE /api/instructor/questions/{questionId} already documents for a single question.
+ *
+ * Not transactional (the Supabase JS client offers none, same limitation every other multi-step
+ * write in this codebase accepts) — ordered children-before-parents so a failure partway through
+ * leaves the catalog missing some content rather than a broken half-deleted row. The final delete
+ * additionally treats a foreign_key_violation (23503) as 'in_use' rather than a raw error — defense
+ * in depth in case some usage isn't one of the tables checked above.
+ */
+export async function deleteCatalog(supabase: SupabaseClient, activityType: string, gradingKind: GradingKind): Promise<DeleteCatalogResult> {
+  const { data: sessionUsage, error: sessionUsageError } = await supabase
+    .from('session_log')
+    .select('session_id')
+    .eq('activity_type', activityType)
+    .limit(1)
+    .maybeSingle();
+  if (sessionUsageError) return { status: 'error', error: sessionUsageError };
+  if (sessionUsage) return { status: 'in_use' };
+
+  if (gradingKind === 'llm-graded') {
+    const { error: deleteStoriesError } = await supabase.from('user_story').delete().eq('activity_type', activityType);
+    if (deleteStoriesError) return { status: 'error', error: deleteStoriesError };
+  } else {
+    const { data: questionRows, error: questionsError } = await supabase
+      .from('question')
+      .select('question_id')
+      .eq('activity_type', activityType);
+    if (questionsError) return { status: 'error', error: questionsError };
+
+    const questionIds = ((questionRows ?? []) as { question_id: string }[]).map((row) => row.question_id);
+
+    if (questionIds.length > 0) {
+      const { data: dailyUsage, error: dailyUsageError } = await supabase
+        .from('daily_challenge_attempt')
+        .select('daily_challenge_attempt_id')
+        .in('question_id', questionIds)
+        .limit(1)
+        .maybeSingle();
+      if (dailyUsageError) return { status: 'error', error: dailyUsageError };
+      if (dailyUsage) return { status: 'in_use' };
+
+      const { data: linkRows, error: linkFetchError } = await supabase
+        .from('question_to_answer')
+        .select('answer_id')
+        .in('question_id', questionIds);
+      if (linkFetchError) return { status: 'error', error: linkFetchError };
+      const answerIds = ((linkRows ?? []) as { answer_id: string }[]).map((row) => row.answer_id);
+
+      const { error: unlinkError } = await supabase.from('question_to_answer').delete().in('question_id', questionIds);
+      if (unlinkError) return { status: 'error', error: unlinkError };
+
+      if (answerIds.length > 0) {
+        const { error: answerDeleteError } = await supabase.from('answer').delete().in('answer_id', answerIds);
+        if (answerDeleteError) return { status: 'error', error: answerDeleteError };
+      }
+
+      const { error: questionDeleteError } = await supabase.from('question').delete().in('question_id', questionIds);
+      if (questionDeleteError) return { status: 'error', error: questionDeleteError };
+    }
+  }
+
+  const { error: titleDeleteError } = await supabase.from('title_definition').delete().eq('activity_type', activityType);
+  if (titleDeleteError) return { status: 'error', error: titleDeleteError };
+
+  const { error: unlinkQuizError } = await supabase.from('assembled_quiz_catalog').delete().eq('activity_type', activityType);
+  if (unlinkQuizError) return { status: 'error', error: unlinkQuizError };
+
+  const { error: deleteError } = await supabase.from('activity_type').delete().eq('activity_type', activityType);
+  if (deleteError) {
+    if ((deleteError as { code?: string }).code === '23503') return { status: 'in_use' };
+    return { status: 'error', error: deleteError };
+  }
+
+  return { status: 'ok' };
+}

--- a/lib/assembledQuizClient.ts
+++ b/lib/assembledQuizClient.ts
@@ -9,6 +9,8 @@
 // that path with a differently-named dynamic segment; Next.js can't have both).
 
 import type { CatalogQuestion, QuizQuestion } from './quizQuestionTypes';
+import type { CatalogUserStory } from './llmActivityTypes';
+import type { GradingKind } from './activityTypes';
 
 export type AssembledQuizSummary = {
   id: string;
@@ -33,6 +35,9 @@ export type QuizCatalogComposition = {
   activityType: string;
   name: string;
   description: string | null;
+  /** Which pool totalQuestions/activeCount are counted from — 'mcq' (question rows) or
+   *  'llm-graded' (user_story rows). Both kinds support per-quiz exclusion. */
+  gradingKind: GradingKind;
   totalQuestions: number;
   excludedCount: number;
   activeCount: number;
@@ -43,6 +48,9 @@ export type QuizLevelCoverage = { level: 1 | 2 | 3; available: number; required:
 /** One question in a quiz-scoped catalog view (GitHub #361) — a CatalogQuestion plus whether *this quiz* currently excludes it. */
 export type QuizScopedQuestion = CatalogQuestion & { excludedForQuiz: boolean };
 
+/** The llm-graded counterpart of QuizScopedQuestion — a CatalogUserStory plus whether *this quiz* currently excludes it. */
+export type QuizScopedUserStory = CatalogUserStory & { excludedForQuiz: boolean };
+
 /** One individually hand-picked question on a quiz (GitHub #380), with its source catalog for display. */
 export type QuizExtraQuestionSummary = {
   questionId: string;
@@ -52,10 +60,28 @@ export type QuizExtraQuestionSummary = {
   catalogName: string;
 };
 
+/** The llm-graded counterpart of QuizExtraQuestionSummary — one hand-picked prompt, with its source catalog for display. */
+export type QuizExtraUserStorySummary = {
+  userStoryId: string;
+  storyText: string;
+  level: 1 | 2 | 3;
+  catalogActivityType: string;
+  catalogName: string;
+};
+
 /** One question as the "Add individual questions" picker (GitHub #380) lists it, any catalog. */
 export type PickableQuestion = {
   id: string;
   questionText: string;
+  level: 1 | 2 | 3;
+  catalogActivityType: string;
+  catalogName: string;
+};
+
+/** The llm-graded counterpart of PickableQuestion — one prompt as the picker lists it, any catalog. */
+export type PickableUserStory = {
+  id: string;
+  storyText: string;
   level: 1 | 2 | 3;
   catalogActivityType: string;
   catalogName: string;
@@ -120,8 +146,9 @@ function quizPath(quizId: string, suffix = ''): string {
 
 /**
  * One quiz's full composition (GET /api/instructor/assembled-quizzes/{quizId}, GitHub #361,
- * extended by GitHub #380) — meta, every linked catalog with its genuinely-active question count,
- * every individually hand-picked question, and per-level coverage against the round size.
+ * extended by GitHub #380 and by llm-graded parity) — meta, every linked catalog with its
+ * genuinely-active question or prompt count, every individually hand-picked question and prompt,
+ * and per-level coverage against the round size.
  */
 export function loadQuizDetail(
   token: string,
@@ -132,8 +159,10 @@ export function loadQuizDetail(
     catalogs: QuizCatalogComposition[];
     levelCoverage: QuizLevelCoverage[];
     extraQuestions: QuizExtraQuestionSummary[];
+    extraUserStories: QuizExtraUserStorySummary[];
     /** Bare ids behind `catalogs`' per-catalog counts — what AddQuizQuestionsModal marks as already in the quiz. */
     activeCatalogQuestionIds: string[];
+    activeCatalogUserStoryIds: string[];
   }>
 > {
   return request<{
@@ -141,7 +170,9 @@ export function loadQuizDetail(
     catalogs: QuizCatalogComposition[];
     levelCoverage: QuizLevelCoverage[];
     extraQuestions: QuizExtraQuestionSummary[];
+    extraUserStories: QuizExtraUserStorySummary[];
     activeCatalogQuestionIds: string[];
+    activeCatalogUserStoryIds: string[];
   }>(quizPath(quizId), { method: 'GET' }, token);
 }
 
@@ -168,18 +199,24 @@ export function unlinkCatalogFromQuiz(token: string, quizId: string, activityTyp
   );
 }
 
+/** One linked catalog's own metadata, in the context of this quiz — the sibling of QuizMeta (lib/quizClient.ts) that also carries gradingKind. */
+export type QuizScopedCatalogMeta = { activityType: string; name: string; description: string | null; authorName: string; gradingKind: GradingKind };
+
 /**
- * One linked catalog's questions, in the context of this quiz
- * (GET /api/instructor/assembled-quizzes/{quizId}/catalogs/{activityType}, GitHub #361) — each
- * annotated with whether this quiz currently excludes it. Read-only: editing/deleting a question
- * happens only through the real catalog (lib/quizClient.ts's loadQuizDetail, GitHub #359).
+ * One linked catalog's questions or prompts, in the context of this quiz
+ * (GET /api/instructor/assembled-quizzes/{quizId}/catalogs/{activityType}, GitHub #361, extended
+ * to llm-graded catalogs). Both pools are always present, one always empty, same "discriminated
+ * by gradingKind, not by shape" convention lib/quizClient.ts's loadQuizDetail uses — each item is
+ * annotated with whether *this quiz* currently excludes it, the same way for both kinds. Content
+ * itself is read-only either way: editing/deleting happens only through the real catalog
+ * (lib/quizClient.ts's loadQuizDetail, GitHub #359).
  */
 export function loadQuizCatalogQuestions(
   token: string,
   quizId: string,
   activityType: string,
-): Promise<ApiResult<{ catalog: { activityType: string; name: string; description: string | null; authorName: string }; questions: QuizScopedQuestion[] }>> {
-  return request<{ catalog: { activityType: string; name: string; description: string | null; authorName: string }; questions: QuizScopedQuestion[] }>(
+): Promise<ApiResult<{ catalog: QuizScopedCatalogMeta; questions: QuizScopedQuestion[]; userStories: QuizScopedUserStory[] }>> {
+  return request<{ catalog: QuizScopedCatalogMeta; questions: QuizScopedQuestion[]; userStories: QuizScopedUserStory[] }>(
     quizPath(quizId, `/catalogs/${encodeURIComponent(activityType)}`),
     { method: 'GET' },
     token,
@@ -231,14 +268,67 @@ export function removeExtraQuestionFromQuiz(token: string, quizId: string, quest
 }
 
 /**
- * Every MCQ question in the system, any author, any catalog
- * (GET /api/instructor/assembled-quizzes/questions, GitHub #380) — the pool the "Add individual
- * questions" picker (AddQuizQuestionsModal) searches/filters client-side. Not quiz-scoped; the
- * caller cross-references against a specific quiz's own already-loaded composition to mark rows
- * as already included.
+ * Excludes one prompt from this quiz's draw pool
+ * (POST /api/instructor/assembled-quizzes/{quizId}/excluded-user-stories) — the llm-graded
+ * counterpart of excludeQuestionFromQuiz. Never touches the original user_story row.
  */
-export function loadAllQuestionsForPicker(token: string): Promise<ApiResult<{ questions: PickableQuestion[] }>> {
-  return request<{ questions: PickableQuestion[] }>('/api/instructor/assembled-quizzes/questions', { method: 'GET' }, token);
+export function excludeUserStoryFromQuiz(token: string, quizId: string, userStoryId: string): Promise<ApiResult<{ userStoryId: string }>> {
+  return request<{ userStoryId: string }>(quizPath(quizId, '/excluded-user-stories'), postJson({ userStoryId }), token);
+}
+
+/**
+ * Re-includes a previously excluded prompt
+ * (DELETE /api/instructor/assembled-quizzes/{quizId}/excluded-user-stories/{userStoryId}) — the
+ * llm-graded counterpart of includeQuestionInQuiz.
+ */
+export function includeUserStoryInQuiz(token: string, quizId: string, userStoryId: string): Promise<ApiResult<{ userStoryId: string }>> {
+  return request<{ userStoryId: string }>(
+    quizPath(quizId, `/excluded-user-stories/${encodeURIComponent(userStoryId)}`),
+    { method: 'DELETE' },
+    token,
+  );
+}
+
+/**
+ * Hand-picks one or more prompts directly onto this quiz
+ * (POST /api/instructor/assembled-quizzes/{quizId}/extra-user-stories) — the llm-graded
+ * counterpart of addExtraQuestionsToQuiz, independent of whether their catalogs are linked to the
+ * quiz at all. Returns the ids actually newly added (already-picked ones are silently omitted).
+ */
+export function addExtraUserStoriesToQuiz(token: string, quizId: string, userStoryIds: string[]): Promise<ApiResult<{ userStoryIds: string[] }>> {
+  return request<{ userStoryIds: string[] }>(quizPath(quizId, '/extra-user-stories'), postJson({ userStoryIds }), token);
+}
+
+/**
+ * Removes a hand-picked prompt from this quiz
+ * (DELETE /api/instructor/assembled-quizzes/{quizId}/extra-user-stories/{userStoryId}) — the
+ * llm-graded counterpart of removeExtraQuestionFromQuiz. The original user_story row, its
+ * catalog, and every other quiz are untouched.
+ */
+export function removeExtraUserStoryFromQuiz(token: string, quizId: string, userStoryId: string): Promise<ApiResult<{ userStoryId: string }>> {
+  return request<{ userStoryId: string }>(
+    quizPath(quizId, `/extra-user-stories/${encodeURIComponent(userStoryId)}`),
+    { method: 'DELETE' },
+    token,
+  );
+}
+
+/**
+ * Every MCQ question and every llm-graded prompt the calling instructor created, any of their own
+ * catalogs (GET /api/instructor/assembled-quizzes/questions, GitHub #380, extended with
+ * llm-graded parity) — the pool the "Add individual questions" picker (AddQuizQuestionsModal)
+ * searches/filters client-side, rendering the two kinds as separate sections. Not quiz-scoped;
+ * the caller cross-references against a specific quiz's own already-loaded composition to mark
+ * rows as already included.
+ */
+export function loadAllQuestionsForPicker(
+  token: string,
+): Promise<ApiResult<{ questions: PickableQuestion[]; userStories: PickableUserStory[] }>> {
+  return request<{ questions: PickableQuestion[]; userStories: PickableUserStory[] }>(
+    '/api/instructor/assembled-quizzes/questions',
+    { method: 'GET' },
+    token,
+  );
 }
 
 /**

--- a/lib/assembledQuizQueries.ts
+++ b/lib/assembledQuizQueries.ts
@@ -15,8 +15,10 @@
 import type { SupabaseClient } from './sessionQueries';
 import { shuffleArray } from './shuffleArray';
 import { QUESTIONS_PER_SESSION } from './sessionRules';
-import { listCatalogQuestions } from './activityTypeQueries';
+import { listCatalogQuestions, listCatalogUserStories } from './activityTypeQueries';
 import type { CatalogQuestion } from './quizQuestionTypes';
+import type { CatalogUserStory } from './llmActivityTypes';
+import type { GradingKind } from './activityTypes';
 
 const UNIQUE_VIOLATION = '23505';
 
@@ -369,6 +371,60 @@ export async function removeExtraQuestionFromQuiz(supabase: SupabaseClient, quiz
 }
 
 /**
+ * Every user_story this quiz currently excludes, as bare ids — the llm-graded counterpart of
+ * listQuizExcludedQuestionIds, same subtraction-set role for the composition view (no live draw
+ * pool exists for llm-graded quizzes yet, so this has no loadCatalogQuestionPool counterpart).
+ */
+export async function listQuizExcludedUserStoryIds(supabase: SupabaseClient, quizId: string) {
+  const { data, error } = await supabase.from('quiz_excluded_user_story').select('user_story_id').eq('assembled_quiz_id', quizId);
+  if (error) return { excludedIds: null, error };
+  return { excludedIds: ((data ?? []) as { user_story_id: string }[]).map((row) => row.user_story_id), error: null };
+}
+
+/** Excludes one user_story from one quiz. Mirrors excludeQuestionFromQuiz — never touches `user_story` itself, idempotent on a repeat exclude (uq_quiz_excluded_user_story, 23505). */
+export async function excludeUserStoryFromQuiz(supabase: SupabaseClient, quizId: string, userStoryId: string) {
+  const { error } = await supabase.from('quiz_excluded_user_story').insert({ assembled_quiz_id: quizId, user_story_id: userStoryId });
+  if (!error) return { alreadyExcluded: false, error: null };
+  if (error.code === UNIQUE_VIOLATION) return { alreadyExcluded: true, error: null };
+  return { alreadyExcluded: false, error };
+}
+
+/** Re-includes a previously excluded user_story. Idempotent: nothing to remove is still success. */
+export async function includeUserStoryInQuiz(supabase: SupabaseClient, quizId: string, userStoryId: string) {
+  const { error } = await supabase.from('quiz_excluded_user_story').delete().eq('assembled_quiz_id', quizId).eq('user_story_id', userStoryId);
+  return { error };
+}
+
+/** Every user_story this quiz has hand-picked directly (assembled_quiz_extra_user_story), as bare ids. */
+export async function listQuizExtraUserStoryIds(supabase: SupabaseClient, quizId: string) {
+  const { data, error } = await supabase.from('assembled_quiz_extra_user_story').select('user_story_id').eq('assembled_quiz_id', quizId);
+  if (error) return { extraIds: null, error };
+  return { extraIds: ((data ?? []) as { user_story_id: string }[]).map((row) => row.user_story_id), error: null };
+}
+
+/**
+ * Hand-picks one user_story directly onto a quiz, independent of whether its catalog is one of
+ * the quiz's linked catalogs at all — the llm-graded counterpart of addExtraQuestionToQuiz. Never
+ * touches `user_story`, idempotent on a repeat pick (uq_assembled_quiz_extra_user_story, 23505).
+ */
+export async function addExtraUserStoryToQuiz(supabase: SupabaseClient, quizId: string, userStoryId: string) {
+  const { error } = await supabase.from('assembled_quiz_extra_user_story').insert({ assembled_quiz_id: quizId, user_story_id: userStoryId });
+  if (!error) return { alreadyPicked: false, error: null };
+  if (error.code === UNIQUE_VIOLATION) return { alreadyPicked: true, error: null };
+  return { alreadyPicked: false, error };
+}
+
+/**
+ * Removes a hand-picked user_story from a quiz — only the assembled_quiz_extra_user_story row.
+ * The original user_story row, its catalog, and every other quiz that references it are
+ * untouched. Idempotent, matching removeExtraQuestionFromQuiz.
+ */
+export async function removeExtraUserStoryFromQuiz(supabase: SupabaseClient, quizId: string, userStoryId: string) {
+  const { error } = await supabase.from('assembled_quiz_extra_user_story').delete().eq('assembled_quiz_id', quizId).eq('user_story_id', userStoryId);
+  return { error };
+}
+
+/**
  * Fetches one question's display summary (question text, level, source catalog) by id — used by
  * GitHub #380's create-and-hand-pick route to hand the freshly created, freshly hand-picked
  * question straight back to the caller in the same shape as getQuizComposition's `extraQuestions`,
@@ -400,6 +456,9 @@ export type QuizCatalogComposition = {
   activityType: string;
   name: string;
   description: string | null;
+  /** Which pool totalQuestions/activeCount are counted from — question rows for 'mcq', user_story
+   *  rows for 'llm-graded'. A catalog only ever fills one pool, same as QuizSummary's own field. */
+  gradingKind: GradingKind;
   totalQuestions: number;
   excludedCount: number;
   activeCount: number;
@@ -414,8 +473,12 @@ function buildLevelCoverage(availableQuestions: readonly { difficulty_level: num
   });
 }
 
-type LinkedCatalogRow = { activity_type: string; catalog: { quiz_name: string; description: string | null } | null };
+type LinkedCatalogRow = {
+  activity_type: string;
+  catalog: { quiz_name: string; description: string | null; grading_kind: string } | null;
+};
 type PoolQuestionRow = { question_id: string; activity_type: string; difficulty_level: number };
+type PoolUserStoryRow = { user_story_id: string; activity_type: string; difficulty_level: number };
 
 export type QuizExtraQuestionSummary = {
   questionId: string;
@@ -433,39 +496,91 @@ type ExtraQuestionRow = {
   catalog: { quiz_name: string } | null;
 };
 
+/** The llm-graded counterpart of QuizExtraQuestionSummary — one hand-picked prompt, with its source catalog for display. */
+export type QuizExtraUserStorySummary = {
+  userStoryId: string;
+  storyText: string;
+  level: 1 | 2 | 3;
+  catalogActivityType: string;
+  catalogName: string;
+};
+
+type ExtraUserStoryRow = {
+  user_story_id: string;
+  story_text: string;
+  difficulty_level: number;
+  activity_type: string;
+  catalog: { quiz_name: string } | null;
+};
+
+type GetQuizCompositionResult = {
+  catalogs: QuizCatalogComposition[] | null;
+  levelCoverage: QuizLevelCoverage[] | null;
+  extraQuestions: QuizExtraQuestionSummary[] | null;
+  extraUserStories: QuizExtraUserStorySummary[] | null;
+  activeCatalogQuestionIds: string[] | null;
+  activeCatalogUserStoryIds: string[] | null;
+  error: { message: string } | null;
+};
+
+function compositionFailure(error: { message: string }): GetQuizCompositionResult {
+  return {
+    catalogs: null,
+    levelCoverage: null,
+    extraQuestions: null,
+    extraUserStories: null,
+    activeCatalogQuestionIds: null,
+    activeCatalogUserStoryIds: null,
+    error,
+  };
+}
+
 /**
- * The quiz's full composition (GitHub #361 requirement 2, extended by GitHub #380): every linked
- * catalog with its genuinely-active question count (total minus this quiz's own exclusions —
- * never the catalog's or any other quiz's), every individually hand-picked question with its
- * source catalog for display, and per-level coverage against QUESTIONS_PER_SESSION so the detail
- * page can warn *before* a student ever hits a level with too few questions left to draw a round
- * (requirement 4) — now counting hand-picked questions toward that coverage too, since they are
- * genuinely drawable (see loadCatalogQuestionPool's own docblock for the identical pool formula).
+ * The quiz's full composition (GitHub #361 requirement 2, extended by GitHub #380 and by the
+ * llm-graded parity that added quiz_excluded_user_story/assembled_quiz_extra_user_story): every
+ * linked catalog with its genuinely-active question or prompt count (total minus this quiz's own
+ * exclusions — never the catalog's or any other quiz's), every individually hand-picked question
+ * or prompt with its source catalog for display, and per-level coverage against
+ * QUESTIONS_PER_SESSION so the detail page can warn *before* a student ever hits a level with too
+ * few questions left to draw a round (requirement 4) — counting hand-picked items toward that
+ * coverage too, since they are genuinely drawable (see loadCatalogQuestionPool's own docblock for
+ * the identical MCQ pool formula; no equivalent draw exists yet for llm-graded quizzes).
  *
- * Hand-picked questions are fetched and returned independent of whether the quiz has any linked
+ * mcq and llm-graded are handled by fully parallel code paths throughout — question/
+ * quiz_excluded_question/assembled_quiz_extra_question on one side, user_story/
+ * quiz_excluded_user_story/assembled_quiz_extra_user_story on the other — rather than one
+ * generalized path, because the two pools live in different tables with different FKs; a linked
+ * catalog is always exactly one kind (activity_type.grading_kind), never both.
+ *
+ * Hand-picked items are fetched and returned independent of whether the quiz has any linked
  * catalogs at all (AC: "Ein Catalog muss dafür NICHT als Ganzes mit dem Quiz verknüpft sein") —
- * the early return below only skips the *catalog*-derived question query, never the extra-question
- * one.
+ * the early return below only skips the *catalog*-derived queries, never the extra-item ones.
  *
- * activeCatalogQuestionIds is the bare ids behind `catalogs`' per-catalog counts — the "Add
- * individual questions" picker (AddQuizQuestionsModal) needs individual ids, not aggregate
- * numbers, to mark a catalog-sourced question as already in the quiz; reusing the same
- * already-fetched `catalogActive` array here avoids a second query just for that.
+ * activeCatalogQuestionIds/activeCatalogUserStoryIds are the bare ids behind `catalogs`'
+ * per-catalog counts — the "Add individual questions" picker (AddQuizQuestionsModal) needs
+ * individual ids, not aggregate numbers, to mark a catalog-sourced item as already in the quiz;
+ * reusing the already-fetched catalogActiveQuestions/catalogActiveUserStories arrays here avoids a
+ * second query just for that.
  */
-export async function getQuizComposition(supabase: SupabaseClient, quizId: string) {
+export async function getQuizComposition(supabase: SupabaseClient, quizId: string): Promise<GetQuizCompositionResult> {
   const { data: linkRows, error: linkError } = await supabase
     .from('assembled_quiz_catalog')
-    .select('activity_type, catalog:activity_type(quiz_name, description)')
+    .select('activity_type, catalog:activity_type(quiz_name, description, grading_kind)')
     .eq('assembled_quiz_id', quizId);
 
-  if (linkError) return { catalogs: null, levelCoverage: null, extraQuestions: null, activeCatalogQuestionIds: null, error: linkError };
+  if (linkError) return compositionFailure(linkError);
 
   const links = (linkRows ?? []) as unknown as LinkedCatalogRow[];
   const catalogActivityTypes = links.map((link) => link.activity_type);
+  const llmActivityTypes = links
+    .filter((link) => link.catalog?.grading_kind === 'llm-graded')
+    .map((link) => link.activity_type);
 
   let questions: PoolQuestionRow[] = [];
+  let userStories: PoolUserStoryRow[] = [];
   let catalogs: QuizCatalogComposition[] = [];
-  let excludedSet = new Set<string>();
+  let excludedQuestionSet = new Set<string>();
+  let excludedUserStorySet = new Set<string>();
 
   if (catalogActivityTypes.length > 0) {
     const { data: questionRows, error: questionError } = await supabase
@@ -473,22 +588,55 @@ export async function getQuizComposition(supabase: SupabaseClient, quizId: strin
       .select('question_id, activity_type, difficulty_level')
       .in('activity_type', catalogActivityTypes);
 
-    if (questionError) return { catalogs: null, levelCoverage: null, extraQuestions: null, activeCatalogQuestionIds: null, error: questionError };
+    if (questionError) return compositionFailure(questionError);
 
-    const { excludedIds, error: excludedError } = await listQuizExcludedQuestionIds(supabase, quizId);
-    if (excludedError) return { catalogs: null, levelCoverage: null, extraQuestions: null, activeCatalogQuestionIds: null, error: excludedError };
+    const { excludedIds: excludedQuestionIds, error: excludedQuestionError } = await listQuizExcludedQuestionIds(supabase, quizId);
+    if (excludedQuestionError) return compositionFailure(excludedQuestionError);
 
     questions = (questionRows ?? []) as PoolQuestionRow[];
-    excludedSet = new Set(excludedIds ?? []);
+    excludedQuestionSet = new Set(excludedQuestionIds ?? []);
+
+    if (llmActivityTypes.length > 0) {
+      const { data: userStoryRows, error: userStoryError } = await supabase
+        .from('user_story')
+        .select('user_story_id, activity_type, difficulty_level')
+        .in('activity_type', llmActivityTypes);
+
+      if (userStoryError) return compositionFailure(userStoryError);
+
+      const { excludedIds: excludedUserStoryIds, error: excludedUserStoryError } = await listQuizExcludedUserStoryIds(supabase, quizId);
+      if (excludedUserStoryError) return compositionFailure(excludedUserStoryError);
+
+      userStories = (userStoryRows ?? []) as PoolUserStoryRow[];
+      excludedUserStorySet = new Set(excludedUserStoryIds ?? []);
+    }
 
     catalogs = links.map((link) => {
+      const gradingKind: GradingKind = link.catalog?.grading_kind === 'llm-graded' ? 'llm-graded' : 'mcq';
+
+      if (gradingKind === 'llm-graded') {
+        const catalogStories = userStories.filter((s) => s.activity_type === link.activity_type);
+        const excludedCount = catalogStories.filter((s) => excludedUserStorySet.has(s.user_story_id)).length;
+
+        return {
+          activityType: link.activity_type,
+          name: link.catalog?.quiz_name ?? link.activity_type,
+          description: link.catalog?.description ?? null,
+          gradingKind,
+          totalQuestions: catalogStories.length,
+          excludedCount,
+          activeCount: catalogStories.length - excludedCount,
+        };
+      }
+
       const catalogQuestions = questions.filter((q) => q.activity_type === link.activity_type);
-      const excludedCount = catalogQuestions.filter((q) => excludedSet.has(q.question_id)).length;
+      const excludedCount = catalogQuestions.filter((q) => excludedQuestionSet.has(q.question_id)).length;
 
       return {
         activityType: link.activity_type,
         name: link.catalog?.quiz_name ?? link.activity_type,
         description: link.catalog?.description ?? null,
+        gradingKind,
         totalQuestions: catalogQuestions.length,
         excludedCount,
         activeCount: catalogQuestions.length - excludedCount,
@@ -496,17 +644,17 @@ export async function getQuizComposition(supabase: SupabaseClient, quizId: strin
     });
   }
 
-  const { extraIds, error: extraIdsError } = await listQuizExtraQuestionIds(supabase, quizId);
-  if (extraIdsError) return { catalogs: null, levelCoverage: null, extraQuestions: null, activeCatalogQuestionIds: null, error: extraIdsError };
+  const { extraIds: extraQuestionIds, error: extraQuestionIdsError } = await listQuizExtraQuestionIds(supabase, quizId);
+  if (extraQuestionIdsError) return compositionFailure(extraQuestionIdsError);
 
   let extraQuestions: QuizExtraQuestionSummary[] = [];
-  if ((extraIds ?? []).length > 0) {
+  if ((extraQuestionIds ?? []).length > 0) {
     const { data: extraRows, error: extraRowsError } = await supabase
       .from('question')
       .select('question_id, question_prompt, difficulty_level, activity_type, catalog:activity_type(quiz_name)')
-      .in('question_id', extraIds ?? []);
+      .in('question_id', extraQuestionIds ?? []);
 
-    if (extraRowsError) return { catalogs: null, levelCoverage: null, extraQuestions: null, activeCatalogQuestionIds: null, error: extraRowsError };
+    if (extraRowsError) return compositionFailure(extraRowsError);
 
     extraQuestions = ((extraRows ?? []) as unknown as ExtraQuestionRow[]).map((row) => ({
       questionId: row.question_id,
@@ -517,23 +665,65 @@ export async function getQuizComposition(supabase: SupabaseClient, quizId: strin
     }));
   }
 
+  const { extraIds: extraUserStoryIds, error: extraUserStoryIdsError } = await listQuizExtraUserStoryIds(supabase, quizId);
+  if (extraUserStoryIdsError) return compositionFailure(extraUserStoryIdsError);
+
+  let extraUserStories: QuizExtraUserStorySummary[] = [];
+  if ((extraUserStoryIds ?? []).length > 0) {
+    const { data: extraStoryRows, error: extraStoryRowsError } = await supabase
+      .from('user_story')
+      .select('user_story_id, story_text, difficulty_level, activity_type, catalog:activity_type(quiz_name)')
+      .in('user_story_id', extraUserStoryIds ?? []);
+
+    if (extraStoryRowsError) return compositionFailure(extraStoryRowsError);
+
+    extraUserStories = ((extraStoryRows ?? []) as unknown as ExtraUserStoryRow[]).map((row) => ({
+      userStoryId: row.user_story_id,
+      storyText: row.story_text,
+      level: row.difficulty_level as 1 | 2 | 3,
+      catalogActivityType: row.activity_type,
+      catalogName: row.catalog?.quiz_name ?? row.activity_type,
+    }));
+  }
+
   // The exact same union-and-dedupe formula loadCatalogQuestionPool uses for a real draw: the
   // catalog-derived set minus exclusions, plus hand-picked questions, deduplicated by
   // question_id — a question reachable both ways (linked catalog, not excluded, and also
   // hand-picked) must not double-count toward "available".
-  const catalogActive = questions.filter((q) => !excludedSet.has(q.question_id));
-  const activeIds = new Set(catalogActive.map((q) => q.question_id));
-  const combinedForCoverage: { difficulty_level: number }[] = [...catalogActive];
+  const catalogActiveQuestions = questions.filter((q) => !excludedQuestionSet.has(q.question_id));
+  const activeQuestionIds = new Set(catalogActiveQuestions.map((q) => q.question_id));
+  const combinedForCoverage: { difficulty_level: number }[] = [...catalogActiveQuestions];
   for (const extra of extraQuestions) {
-    if (!activeIds.has(extra.questionId)) {
-      activeIds.add(extra.questionId);
+    if (!activeQuestionIds.has(extra.questionId)) {
+      activeQuestionIds.add(extra.questionId);
+      combinedForCoverage.push({ difficulty_level: extra.level });
+    }
+  }
+
+  // Same formula, user_story side (a separate id namespace from question, so no cross-dedup
+  // needed between the two): catalog-derived minus this quiz's own exclusions, plus hand-picked
+  // prompts, deduplicated by user_story_id.
+  const catalogActiveUserStories = userStories.filter((s) => !excludedUserStorySet.has(s.user_story_id));
+  const activeUserStoryIds = new Set(catalogActiveUserStories.map((s) => s.user_story_id));
+  combinedForCoverage.push(...catalogActiveUserStories);
+  for (const extra of extraUserStories) {
+    if (!activeUserStoryIds.has(extra.userStoryId)) {
+      activeUserStoryIds.add(extra.userStoryId);
       combinedForCoverage.push({ difficulty_level: extra.level });
     }
   }
 
   const levelCoverage = buildLevelCoverage(combinedForCoverage);
 
-  return { catalogs, levelCoverage, extraQuestions, activeCatalogQuestionIds: catalogActive.map((q) => q.question_id), error: null };
+  return {
+    catalogs,
+    levelCoverage,
+    extraQuestions,
+    extraUserStories,
+    activeCatalogQuestionIds: catalogActiveQuestions.map((q) => q.question_id),
+    activeCatalogUserStoryIds: catalogActiveUserStories.map((s) => s.user_story_id),
+    error: null,
+  };
 }
 
 export type QuizScopedQuestion = CatalogQuestion & { excludedForQuiz: boolean };
@@ -556,6 +746,28 @@ export async function listQuizCatalogQuestions(supabase: SupabaseClient, quizId:
   const scoped: QuizScopedQuestion[] = questions.map((question) => ({ ...question, excludedForQuiz: excludedSet.has(question.id) }));
 
   return { questions: scoped, error: null };
+}
+
+export type QuizScopedUserStory = CatalogUserStory & { excludedForQuiz: boolean };
+
+/**
+ * One linked catalog's prompts, annotated per-prompt with whether *this quiz* currently excludes
+ * it — the llm-graded counterpart of listQuizCatalogQuestions, same "copy of the catalog, in the
+ * context of this quiz" role. Delegates the actual prompt read to lib/activityTypeQueries.ts's
+ * listCatalogUserStories so the two views (this one and the real catalog's own detail page) can
+ * never disagree about what a catalog's prompts look like.
+ */
+export async function listQuizCatalogUserStories(supabase: SupabaseClient, quizId: string, activityType: string) {
+  const { userStories, error: userStoriesError } = await listCatalogUserStories(supabase, activityType);
+  if (userStoriesError || !userStories) return { userStories: null, error: userStoriesError };
+
+  const { excludedIds, error: excludedError } = await listQuizExcludedUserStoryIds(supabase, quizId);
+  if (excludedError) return { userStories: null, error: excludedError };
+
+  const excludedSet = new Set(excludedIds ?? []);
+  const scoped: QuizScopedUserStory[] = userStories.map((story) => ({ ...story, excludedForQuiz: excludedSet.has(story.id) }));
+
+  return { userStories: scoped, error: null };
 }
 
 /**
@@ -644,22 +856,27 @@ export type PickableQuestion = {
 };
 
 /**
- * Every MCQ question in the system, any author, any catalog — the pool the "Add individual
- * questions" picker (GitHub #380, AddQuizQuestionsModal) searches/filters client-side, the same
- * "fetch the full list once, filter in the browser" choice GET /api/instructor/quizzes already
- * makes for browsing catalogs. Not quiz-scoped: which of these are already in a given quiz is
- * computed by the caller from that quiz's own composition (linked-catalog-active-questions +
- * extraQuestions, both already in hand from loadQuizDetail) rather than asked of this query, so
- * the same fetched list can back the picker for any quiz without re-fetching per quiz.
+ * Every MCQ question the calling instructor created, any of their own catalogs — the pool the
+ * "Add individual questions" picker (GitHub #380, AddQuizQuestionsModal) searches/filters
+ * client-side, the same "fetch the full list once, filter in the browser" choice
+ * GET /api/instructor/quizzes already makes for browsing catalogs. Scoped by creator_id the same
+ * "mine only" way that route's own listQuizzesWithAuthorAndCount is (GitHub #.. follow-up) — a
+ * colleague's or a built-in catalog's questions aren't this instructor's to hand-pick, matching
+ * GET /api/instructor/questions' existing `.eq('user_id', ...)` scoping. Not quiz-scoped otherwise:
+ * which of these are already in a given quiz is computed by the caller from that quiz's own
+ * composition (linked-catalog-active-questions + extraQuestions, both already in hand from
+ * loadQuizDetail) rather than asked of this query, so the same fetched list can back the picker
+ * for any quiz without re-fetching per quiz.
  *
  * llm-graded catalogs never appear here structurally, without needing a grading_kind filter:
  * their prompts live in `user_story`, not `question`, so a catalog with no MCQ questions simply
  * contributes no rows.
  */
-export async function listAllQuestionsForPicker(supabase: SupabaseClient) {
+export async function listAllQuestionsForPicker(supabase: SupabaseClient, instructorId: string) {
   const { data, error } = await supabase
     .from('question')
     .select('question_id, question_prompt, difficulty_level, activity_type, catalog:activity_type(quiz_name)')
+    .eq('user_id', instructorId)
     .order('question_prompt', { ascending: true });
 
   if (error) return { questions: null, error };
@@ -675,17 +892,55 @@ export async function listAllQuestionsForPicker(supabase: SupabaseClient) {
   return { questions, error: null };
 }
 
+export type PickableUserStory = {
+  id: string;
+  storyText: string;
+  level: 1 | 2 | 3;
+  catalogActivityType: string;
+  catalogName: string;
+};
+
+/**
+ * Every llm-graded prompt the calling instructor created, any of their own catalogs — the
+ * user_story counterpart of listAllQuestionsForPicker, same "mine only" scoping (creator_id, not
+ * user_id — user_story's owner column is named differently, see listCatalogUserStories) and same
+ * "fetch once, filter client-side" shape. mcq catalogs never appear here structurally: their
+ * questions live in `question`, not `user_story`, so a catalog with no prompts simply contributes
+ * no rows.
+ */
+export async function listAllUserStoriesForPicker(supabase: SupabaseClient, instructorId: string) {
+  const { data, error } = await supabase
+    .from('user_story')
+    .select('user_story_id, story_text, difficulty_level, activity_type, catalog:activity_type(quiz_name)')
+    .eq('creator_id', instructorId)
+    .order('story_text', { ascending: true });
+
+  if (error) return { userStories: null, error };
+
+  const userStories: PickableUserStory[] = ((data ?? []) as unknown as ExtraUserStoryRow[]).map((row) => ({
+    id: row.user_story_id,
+    storyText: row.story_text,
+    level: row.difficulty_level as 1 | 2 | 3,
+    catalogActivityType: row.activity_type,
+    catalogName: row.catalog?.quiz_name ?? row.activity_type,
+  }));
+
+  return { userStories, error: null };
+}
+
 /**
  * GitHub #362: copies every assembled_quiz belonging to `sourceCourseId` onto `targetCourseId` —
  * same quiz_name/description, the same linked catalogs (assembled_quiz_catalog), the same
- * per-quiz question exclusions (quiz_excluded_question), and the same individually hand-picked
- * questions (assembled_quiz_extra_question, GitHub #380), all re-pointed at freshly generated
- * assembled_quiz ids. Reuses createAssembledQuiz rather than inserting assembled_quiz/
+ * per-quiz question exclusions (quiz_excluded_question) and hand-picked questions
+ * (assembled_quiz_extra_question, GitHub #380), and the same llm-graded prompt exclusions/
+ * hand-picks (quiz_excluded_user_story/assembled_quiz_extra_user_story), all re-pointed at freshly
+ * generated assembled_quiz ids. Reuses createAssembledQuiz rather than inserting assembled_quiz/
  * assembled_quiz_catalog by hand, so a link-insert failure for one copied quiz already self-cleans
  * (see that function's own docblock) — the caller only has to roll back the quizzes that *did*
  * fully insert, which the route above does by deleting the new course itself: fk_assembled_quiz_course
  * cascades, taking every assembled_quiz/assembled_quiz_catalog/quiz_excluded_question/
- * assembled_quiz_extra_question row this function has written so far with it.
+ * assembled_quiz_extra_question/quiz_excluded_user_story/assembled_quiz_extra_user_story row this
+ * function has written so far with it.
  *
  * Deliberately never touches student_course, session_log, or any attempt/score table — those
  * aren't reachable from a course anywhere in this schema (see CLAUDE.md's Courses section), so
@@ -716,6 +971,12 @@ export async function duplicateQuizzesForCourse(
     const { extraIds, error: extraIdsError } = await listQuizExtraQuestionIds(supabase, sourceQuiz.assembled_quiz_id);
     if (extraIdsError) return { copiedCount, error: extraIdsError };
 
+    const { excludedIds: excludedUserStoryIds, error: excludedUserStoryError } = await listQuizExcludedUserStoryIds(supabase, sourceQuiz.assembled_quiz_id);
+    if (excludedUserStoryError) return { copiedCount, error: excludedUserStoryError };
+
+    const { extraIds: extraUserStoryIds, error: extraUserStoryIdsError } = await listQuizExtraUserStoryIds(supabase, sourceQuiz.assembled_quiz_id);
+    if (extraUserStoryIdsError) return { copiedCount, error: extraUserStoryIdsError };
+
     const { quiz: newQuiz, error: createError } = await createAssembledQuiz(supabase, {
       name: sourceQuiz.quiz_name,
       description: sourceQuiz.description,
@@ -735,6 +996,20 @@ export async function duplicateQuizzesForCourse(
     if ((extraIds ?? []).length > 0) {
       const { error: extraError } = await supabase.from('assembled_quiz_extra_question').insert(
         (extraIds ?? []).map((questionId) => ({ assembled_quiz_id: newQuiz.id, question_id: questionId })),
+      );
+      if (extraError) return { copiedCount, error: extraError };
+    }
+
+    if ((excludedUserStoryIds ?? []).length > 0) {
+      const { error: exclusionsError } = await supabase.from('quiz_excluded_user_story').insert(
+        (excludedUserStoryIds ?? []).map((userStoryId) => ({ assembled_quiz_id: newQuiz.id, user_story_id: userStoryId })),
+      );
+      if (exclusionsError) return { copiedCount, error: exclusionsError };
+    }
+
+    if ((extraUserStoryIds ?? []).length > 0) {
+      const { error: extraError } = await supabase.from('assembled_quiz_extra_user_story').insert(
+        (extraUserStoryIds ?? []).map((userStoryId) => ({ assembled_quiz_id: newQuiz.id, user_story_id: userStoryId })),
       );
       if (extraError) return { copiedCount, error: extraError };
     }

--- a/lib/quizClient.ts
+++ b/lib/quizClient.ts
@@ -104,3 +104,16 @@ export function loadQuizDetail(token: string, activityType: string): Promise<Api
     token,
   );
 }
+
+/**
+ * Deletes a catalog and unlinks it from every assembled quiz it was composed into
+ * (DELETE /api/instructor/quizzes/{activityType}). Refuses with a 409 (surfaced as `error`) if a
+ * student has already engaged with it.
+ */
+export function deleteCatalog(token: string, activityType: string): Promise<ApiResult<{ activityType: string }>> {
+  return request<{ activityType: string }>(
+    `/api/instructor/quizzes/${encodeURIComponent(activityType)}`,
+    { method: 'DELETE' },
+    token,
+  );
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,17 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Disables the client Router Cache's default 30s reuse window for dynamic routes. Several
+  // instructor pages (e.g. the assembled-quiz composition views) fetch their own data in a
+  // mount-time useEffect with no cache-busting of their own; without this, navigating away and
+  // back within that window (via <Link> or the browser back button) reuses the previously
+  // rendered segment instead of remounting, so a mutation made on another page (e.g. adding
+  // questions to a linked catalog) doesn't show up until the window expires or a hard reload.
+  experimental: {
+    staleTimes: {
+      dynamic: 0,
+    },
+  },
 };
 
 module.exports = nextConfig;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -328,6 +328,33 @@ CREATE TABLE assembled_quiz_extra_question (
     question_id                       uuid   NOT NULL,
     PRIMARY KEY (assembled_quiz_extra_question_id));
 
+-- ---------------------------------------------------------------------
+-- Quiz Excluded User Story / Assembled Quiz Extra User Story
+--
+-- The llm-graded counterpart of quiz_excluded_question / assembled_quiz_extra_question above —
+-- same two-table split (exclude vs. hand-pick are different questions, per that pair's own header
+-- comment), same reasoning, just naming user_story instead of question because a linked
+-- llm-graded catalog's pool lives there, not in `question` (activity_type.grading_kind decides
+-- which one, see that column's own comment). Before these two tables, an llm-graded catalog's
+-- exclude/hand-pick support was silently absent: getQuizComposition only ever queried `question`,
+-- so a linked llm-graded catalog's prompt count and per-quiz exclusion state had no way to exist.
+--
+-- Both FKs cascade on both tables, same reasoning as their question-table counterparts: a row
+-- here means nothing once either the quiz or the user_story it names is gone, and there is no
+-- student attempt history tied to an assembled_quiz for a cascade to endanger.
+-- ---------------------------------------------------------------------
+CREATE TABLE quiz_excluded_user_story (
+    quiz_excluded_user_story_id SERIAL NOT NULL,
+    assembled_quiz_id           uuid   NOT NULL,
+    user_story_id                uuid   NOT NULL,
+    PRIMARY KEY (quiz_excluded_user_story_id));
+
+CREATE TABLE assembled_quiz_extra_user_story (
+    assembled_quiz_extra_user_story_id SERIAL NOT NULL,
+    assembled_quiz_id                   uuid   NOT NULL,
+    user_story_id                        uuid   NOT NULL,
+    PRIMARY KEY (assembled_quiz_extra_user_story_id));
+
 
 -- =====================================================================
 -- REQ-DL-3 / REQ-PL-2.1: Session Log
@@ -482,6 +509,14 @@ ALTER TABLE quiz_excluded_question ADD CONSTRAINT fk_quiz_excluded_question_ques
 ALTER TABLE assembled_quiz_extra_question ADD CONSTRAINT fk_assembled_quiz_extra_question_quiz FOREIGN KEY (assembled_quiz_id) REFERENCES assembled_quiz (assembled_quiz_id) ON DELETE CASCADE;
 ALTER TABLE assembled_quiz_extra_question ADD CONSTRAINT fk_assembled_quiz_extra_question_question FOREIGN KEY (question_id) REFERENCES question (question_id) ON DELETE CASCADE;
 
+-- Same cascade reasoning as fk_quiz_excluded_question_quiz/_question — see
+-- quiz_excluded_user_story's own header comment.
+ALTER TABLE quiz_excluded_user_story ADD CONSTRAINT fk_quiz_excluded_user_story_quiz FOREIGN KEY (assembled_quiz_id) REFERENCES assembled_quiz (assembled_quiz_id) ON DELETE CASCADE;
+ALTER TABLE quiz_excluded_user_story ADD CONSTRAINT fk_quiz_excluded_user_story_user_story FOREIGN KEY (user_story_id) REFERENCES user_story (user_story_id) ON DELETE CASCADE;
+
+ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT fk_assembled_quiz_extra_user_story_quiz FOREIGN KEY (assembled_quiz_id) REFERENCES assembled_quiz (assembled_quiz_id) ON DELETE CASCADE;
+ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT fk_assembled_quiz_extra_user_story_user_story FOREIGN KEY (user_story_id) REFERENCES user_story (user_story_id) ON DELETE CASCADE;
+
 ALTER TABLE title_definition ADD CONSTRAINT fk_title_definition_activity_type FOREIGN KEY (activity_type) REFERENCES activity_type (activity_type);
 -- Who authored the story, for attribution/moderation.
 ALTER TABLE user_story ADD CONSTRAINT fk_user_story_user FOREIGN KEY (creator_id) REFERENCES "user" (user_id);
@@ -611,6 +646,14 @@ CREATE INDEX ix_quiz_excluded_question_quiz_id ON quiz_excluded_question (assemb
 ALTER TABLE assembled_quiz_extra_question ADD CONSTRAINT uq_assembled_quiz_extra_question UNIQUE (assembled_quiz_id, question_id);
 CREATE INDEX ix_assembled_quiz_extra_question_quiz_id ON assembled_quiz_extra_question (assembled_quiz_id);
 
+-- Same two guarantees as uq_quiz_excluded_question/uq_assembled_quiz_extra_question, mirrored for
+-- user_story.
+ALTER TABLE quiz_excluded_user_story ADD CONSTRAINT uq_quiz_excluded_user_story UNIQUE (assembled_quiz_id, user_story_id);
+CREATE INDEX ix_quiz_excluded_user_story_quiz_id ON quiz_excluded_user_story (assembled_quiz_id);
+
+ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT uq_assembled_quiz_extra_user_story UNIQUE (assembled_quiz_id, user_story_id);
+CREATE INDEX ix_assembled_quiz_extra_user_story_quiz_id ON assembled_quiz_extra_user_story (assembled_quiz_id);
+
 -- At most one running session per student and activity type. This is what
 -- makes POST /api/sessions idempotent: "start" and "resume" are the same
 -- call, and two devices cannot build up independent state.
@@ -729,6 +772,8 @@ ALTER TABLE assembled_quiz ENABLE ROW LEVEL SECURITY;
 ALTER TABLE assembled_quiz_catalog ENABLE ROW LEVEL SECURITY;
 ALTER TABLE quiz_excluded_question ENABLE ROW LEVEL SECURITY;
 ALTER TABLE assembled_quiz_extra_question ENABLE ROW LEVEL SECURITY;
+ALTER TABLE quiz_excluded_user_story ENABLE ROW LEVEL SECURITY;
+ALTER TABLE assembled_quiz_extra_user_story ENABLE ROW LEVEL SECURITY;
 
 ALTER TABLE session_log ENABLE ROW LEVEL SECURITY;
 ALTER TABLE answered_question_log ENABLE ROW LEVEL SECURITY;
@@ -1078,3 +1123,28 @@ CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
 -- database:
 --
 --   CREATE INDEX IF NOT EXISTS ix_student_course_course_id ON student_course (course_id);
+
+-- Quiz Excluded User Story / Assembled Quiz Extra User Story: the llm-graded counterpart of
+-- quiz_excluded_question/assembled_quiz_extra_question (GitHub #361/#380) — an assembled quiz's
+-- llm-graded catalogs previously had no per-quiz exclude or hand-pick support at all, since both
+-- of those tables only ever FK'd to `question`. Two brand new tables, same no-rename/no-backfill
+-- path as their question-table counterparts — run each CREATE TABLE statement, its two FKs, its
+-- unique constraint and index, and its ENABLE ROW LEVEL SECURITY:
+--
+--   CREATE TABLE quiz_excluded_user_story (...);
+--   ALTER TABLE quiz_excluded_user_story ADD CONSTRAINT fk_quiz_excluded_user_story_quiz ...;
+--   ALTER TABLE quiz_excluded_user_story ADD CONSTRAINT fk_quiz_excluded_user_story_user_story ...;
+--   ALTER TABLE quiz_excluded_user_story ADD CONSTRAINT uq_quiz_excluded_user_story ...;
+--   CREATE INDEX ix_quiz_excluded_user_story_quiz_id ...;
+--   ALTER TABLE quiz_excluded_user_story ENABLE ROW LEVEL SECURITY;
+--
+--   CREATE TABLE assembled_quiz_extra_user_story (...);
+--   ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT fk_assembled_quiz_extra_user_story_quiz ...;
+--   ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT fk_assembled_quiz_extra_user_story_user_story ...;
+--   ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT uq_assembled_quiz_extra_user_story ...;
+--   CREATE INDEX ix_assembled_quiz_extra_user_story_quiz_id ...;
+--   ALTER TABLE assembled_quiz_extra_user_story ENABLE ROW LEVEL SECURITY;
+--
+-- No existing table's shape changes, and every quiz created before this migration keeps drawing
+-- exactly the pool it already had — both tables start empty, which is the correct "nothing
+-- excluded or hand-picked yet" state, not a gap to backfill.


### PR DESCRIPTION
## Summary

Four independent fixes/features to the assembled-quiz composition flow, all under `Question Catalogs` / `Quizzes`:

1. **Fix stale composition data on back/forward navigation** — Next's client Router Cache was reusing a previously-rendered assembled-quiz page instead of refetching, so editing a linked catalog's questions and navigating back showed stale counts/coverage.
2. **Delete a question catalog** — new route + button, with the required cascade cleanup.
3. **LLM-graded prompt parity (backend)** — llm-graded catalogs can now be excluded/hand-picked per-quiz, same as MCQ questions always could.
4. **LLM-graded prompt parity (frontend)** — the composition UI now shows and manages both kinds, clearly differentiated.

## Changes

### 1. Router Cache staleness fix
- `next.config.js`: `experimental.staleTimes.dynamic = 0` disables the 30s reuse window for dynamic routes, so soft navigation always refetches.
- (Follow-up defense-in-depth, bundled into commit 4 below): both assembled-quiz page components also listen for `popstate` and force a refetch, since browser back/forward bypasses the Router Cache config entirely (`restoreReducer` reuses the cached tree unconditionally).

### 2. Delete a question catalog
- `DELETE /api/instructor/quizzes/{activityType}` — deletes a catalog the caller owns: its own questions/answers (or `user_story` prompts for an llm-graded catalog), and unlinks it from every assembled quiz it was composed into.
- Refuses with `409` if a student has already engaged with it (checked via `session_log`, plus `daily_challenge_attempt` for mcq catalogs specifically, since that table has no `session_log` link of its own).
- New trash-icon button on the catalog detail page, behind a `ConfirmModal`.

### 3. LLM-graded prompt parity — backend
Previously, per-quiz exclusion and individual hand-picking only existed for MCQ questions; an llm-graded catalog's prompts couldn't be excluded or hand-picked at all, and `getQuizComposition` only ever queried `question`, so a linked llm-graded catalog's count/coverage were structurally wrong.

- **New tables**: `quiz_excluded_user_story`, `assembled_quiz_extra_user_story` — exact mirrors of `quiz_excluded_question` / `assembled_quiz_extra_question` (same cascade rules, unique constraints, indexes, RLS).
- `lib/assembledQuizQueries.ts`: full query-layer mirror for `user_story` (exclude/include, hand-pick add/remove, quiz-scoped listing, picker query), `getQuizComposition` now computes real exclusion-aware counts and per-level coverage for both kinds, `duplicateQuizzesForCourse` copies the new rows when a course is duplicated.
- New routes: `POST`/`DELETE /api/instructor/assembled-quizzes/{quizId}/excluded-user-stories[/…]` and `.../extra-user-stories[/…]`.
- `GET /api/instructor/assembled-quizzes/questions` (the picker) now returns both pools, each scoped to the caller's own content.
- `GET /api/instructor/assembled-quizzes/{quizId}/catalogs/{activityType}` annotates llm-graded prompts with exclusion state the same way mcq questions already were.

### 4. LLM-graded prompt parity — frontend
- **`AddQuizQuestionsModal`** ("Add individual questions") now shows MCQ questions and LLM-graded prompts as separately-headed, separately-selectable sections, plus a Type filter — previously it only ever listed MCQ questions.
- The catalog-in-quiz page's llm-graded branch changed from a read-only prompt list to a fully interactive Include/Exclude view, matching MCQ.
- The quiz composition page renders hand-picked prompts alongside hand-picked questions, each independently removable.


`getQuizComposition` now unconditionally queries the two new tables for **every** quiz, not just ones with llm-graded catalogs. **Until the migration runs, this breaks the existing MCQ composition page too** (confirmed against a live dev database — 500 `Could not find the table 'public.assembled_quiz_extra_user_story'`).

Run the new `CREATE TABLE` statements (plus their FKs, unique constraints, indexes, and RLS) from the bottom of `supabase/schema.sql` in the Supabase SQL editor **before** deploying this branch.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (34 new tests added, mirroring existing MCQ route test coverage 1:1 for the new user_story routes)
- [x] Empirically verified end-to-end against a real Supabase dev database: catalog delete cascades correctly, MCQ exclude/hand-pick still works, LLM-graded exclude/hand-pick works, composition counts update correctly for both kinds
- [x] Migration applied to target database before merge

resolve #418 