### PR TITLE
Students don't get shown on instructor dashboard

### DIFF
--- a/app/instructor/page.tsx
+++ b/app/instructor/page.tsx
@@ -159,7 +159,19 @@ function InstructorDashboardContent() {
     return () => { cancelled = true; };
   }, [token, profile?.user_id]);
 
-  const roster = useMemo(() => summarizeStudents(entries ?? []), [entries]);
+  // Merges in allStudents so an enrolled student with zero attempts still gets a card here,
+  // the same fix app/instructor/students/page.tsx already applies — without this, the dashboard
+  // roster silently drops every student who hasn't started an activity yet (GitHub #415).
+  const rosterEntries = useMemo(
+    () =>
+      (allStudents ?? []).map((s) => ({
+        studentId: s.userId,
+        studentName: `${s.firstName} ${s.lastName}`.trim() || s.username,
+      })),
+    [allStudents],
+  );
+
+  const roster = useMemo(() => summarizeStudents(entries ?? [], rosterEntries), [entries, rosterEntries]);
 
   // Used by ActivityLogTable to resolve a student name for each attempt row.
   const studentNameById = useMemo(

--- a/lib/activityLogTypes.ts
+++ b/lib/activityLogTypes.ts
@@ -107,8 +107,10 @@ export type StudentAggregate = {
  * Pass `roster` (GET /api/instructor/students, GitHub #175) to include students with no attempts
  * at all: deriving the list from `entries` alone silently drops every enrolled student who never
  * started an activity. They come out with attempts 0 and averageScore null, which compareByScore
- * already sorts to the end in both directions. Callers that deliberately want the attempts-only
- * view — the dashboard's roster preview — just omit it.
+ * already sorts to the end in both directions. The Instructor Dashboard's roster preview used to
+ * omit `roster` deliberately, which was exactly the GitHub #415 bug — a student who hadn't
+ * attempted anything yet was invisible even in the "needs the most attention" preview. Every
+ * caller now passes it.
  */
 export function summarizeStudents(
   entries: StudentActivitySummary[],


### PR DESCRIPTION
On the instructor dashboard there should a maximum of six students be shown (the students that need the most attention)


The rest of the students should be visible after clicking on view all students
-Resolve #415 
