### PR TITLE
Respect assembled-quiz exclusions when drawing a student session

### DIFF
--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -116,7 +116,9 @@ function req(body?: object, token: string | null = 'valid-token') {
 function queueEnrolled() {
   queue('student_course', { data: [{ course_id: 'course-1' }], error: null });
   queue('assembled_quiz_catalog', {
-    data: [{ assembled_quiz: { course_id: 'course-1', course: { course_name: 'Software Requirements' } } }],
+    data: [{
+      assembled_quiz: { assembled_quiz_id: 'quiz-1', course_id: 'course-1', course: { course_name: 'Software Requirements' } },
+    }],
     error: null,
   });
 }
@@ -219,6 +221,43 @@ describe('POST /api/sessions', () => {
     const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
 
     expect(response.status).toBe(400);
+    expect(h.state.inserts).toHaveLength(0);
+  });
+
+  // Regression: the draw used to query `question` straight from the catalog with no awareness of
+  // any assembled quiz's quiz_excluded_question rows, so an excluded question kept getting drawn
+  // (and counted toward AC 5's minimum) even after an instructor excluded it (GitHub #361).
+  it('never draws a question the granting quiz has excluded', async () => {
+    queueFreshSessionStart();
+    queue('question', { data: pool, error: null }); // 6 in the catalog
+    queue('quiz_excluded_question', { data: [{ question_id: 'q-5' }, { question_id: 'q-6' }], error: null });
+    queue('session_log', { data: sessionRow, error: null });
+    queue('session_to_question', { data: null, error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
+
+    expect(response.status).toBe(201);
+    const [{ payload }] = h.state.inserts.filter((i) => i.table === 'session_to_question');
+    const drawnIds = (payload as { question_id: string }[]).map((row) => row.question_id);
+    expect(drawnIds).not.toContain('q-5');
+    expect(drawnIds).not.toContain('q-6');
+  });
+
+  it('returns 400 when exclusions push the catalog below the minimum, even though it has 4+ questions total', async () => {
+    queueFreshSessionStart();
+    queue('question', { data: pool, error: null }); // 6 in the catalog
+    // Only 3 remain once the granting quiz's exclusions are applied.
+    queue('quiz_excluded_question', {
+      data: [{ question_id: 'q-1' }, { question_id: 'q-2' }, { question_id: 'q-3' }],
+      error: null,
+    });
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/at least \d+ questions/i);
     expect(h.state.inserts).toHaveLength(0);
   });
 

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,6 +1,7 @@
 import { getSupabaseClient } from '../../../lib/supabase';
 import { isActivityType } from '../../../lib/activityTypes';
-import { checkActivityAccess } from '../../../lib/activityCourseQueries';
+import { getAccessibleCourseForActivity } from '../../../lib/activityCourseQueries';
+import { listQuizExcludedQuestionIds } from '../../../lib/assembledQuizQueries';
 import {
   DEFAULT_QUESTION_MAX_SCORE,
   QUESTIONS_PER_SESSION,
@@ -160,12 +161,15 @@ export async function POST(request: Request) {
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
   // A catalog has no course of its own — it's reachable only through an assembled quiz that
-  // references it and belongs to a course (lib/activityCourseQueries.ts's checkActivityAccess).
-  // Checked here rather than folded into isActivityType above: "does this exist" and "can this
-  // caller see it" are different questions, and only the second one needs the caller's identity.
-  const access = await checkActivityAccess(supabase, activityType, user.id);
-  if (access.status === 'error') return Response.json({ error: access.error.message }, { status: 500 });
-  if (access.status === 'forbidden') {
+  // references it and belongs to a course (lib/activityCourseQueries.ts's
+  // getAccessibleCourseForActivity). Checked here rather than folded into isActivityType above:
+  // "does this exist" and "can this caller see it" are different questions, and only the second
+  // one needs the caller's identity. Resolved via the richer link (not the plain
+  // checkActivityAccess wrapper) because the draw below needs assembledQuizId to know which
+  // quiz's exclusions/hand-picks govern this catalog's pool for this caller.
+  const { link: accessLink, error: accessError } = await getAccessibleCourseForActivity(supabase, activityType, user.id);
+  if (accessError) return Response.json({ error: accessError.message }, { status: 500 });
+  if (!accessLink) {
     return Response.json({ error: 'You are not enrolled in a course that offers this activity.' }, { status: 403 });
   }
 
@@ -194,7 +198,7 @@ export async function POST(request: Request) {
   // AC 1: draw QUESTIONS_PER_SESSION questions matching activity type and the computed level.
   // GitHub #124: filtered through an inner join against the activity_type table (#122/#123)
   // instead of a plain equality check on the free-text column.
-  const { data: pool, error: poolError } = await supabase
+  const { data: rawPool, error: poolError } = await supabase
     .from('question')
     .select('question_id, max_score, activity:activity_type!inner ( activity_type )')
     .eq('activity.activity_type', activityType)
@@ -202,16 +206,29 @@ export async function POST(request: Request) {
 
   if (poolError) return Response.json({ error: poolError.message }, { status: 500 });
 
+  // A question this catalog's questions have been drawn from can still be individually excluded
+  // from the assembled quiz that granted access (quiz_excluded_question, GitHub #361) — the
+  // catalog itself is unaffected, but this specific quiz must never draw an excluded question,
+  // and an excluded question must not count toward whether there are enough to draw from either.
+  // This was previously missing entirely: the draw queried `question` straight from the catalog
+  // with no awareness of any quiz's exclusions, so an "excluded" question kept being served to
+  // students, and the AC-5 count check below was counting questions that could never be drawn.
+  const { excludedIds, error: excludedError } = await listQuizExcludedQuestionIds(supabase, accessLink.assembledQuizId);
+  if (excludedError) return Response.json({ error: excludedError.message }, { status: 500 });
+
+  const excludedSet = new Set(excludedIds);
+  const pool = ((rawPool ?? []) as { question_id: string; max_score: number | null }[])
+    .filter((question) => !excludedSet.has(question.question_id));
+
   // AC 5: too small a question bank is a client error, not an empty session.
-  if (!pool || pool.length < QUESTIONS_PER_SESSION) {
+  if (pool.length < QUESTIONS_PER_SESSION) {
     return Response.json(
       { error: `At least ${QUESTIONS_PER_SESSION} questions are required for this activity type and difficulty level.` },
       { status: 400 },
     );
   }
 
-  const picked = shuffle(pool as { question_id: string; max_score: number | null }[])
-    .slice(0, QUESTIONS_PER_SESSION);
+  const picked = shuffle(pool).slice(0, QUESTIONS_PER_SESSION);
 
   // Keep max_score consistent with the questions actually drawn — 4 x 25 = the 100 from AC 2.
   const maxScore = picked.reduce((sum, q) => sum + (q.max_score ?? DEFAULT_QUESTION_MAX_SCORE), 0);

--- a/lib/activityCourseQueries.ts
+++ b/lib/activityCourseQueries.ts
@@ -9,10 +9,17 @@ import type { SupabaseClient } from './sessionQueries';
 import { getEnrolledCourseIds } from './courseQueries';
 import { isGradingKind, type GradingKind } from './activityTypes';
 
-export type ActivityCourseLink = { courseId: string; courseName: string; name: string; description: string | null };
+export type ActivityCourseLink = {
+  courseId: string;
+  courseName: string;
+  name: string;
+  description: string | null;
+  assembledQuizId: string;
+};
 
 type GrantingQuizRow = {
   assembled_quiz: {
+    assembled_quiz_id: string;
     course_id: string;
     quiz_name: string;
     description: string | null;
@@ -35,6 +42,12 @@ type GrantingQuizRow = {
  * trip) purely as a fallback for assembled_quiz.description being nullable; assembled_quiz's own
  * quiz_name is NOT NULL, so its catalog fallback is defensive rather than a reachable path.
  *
+ * assembledQuizId is also returned (not just used to derive display fields): POST /api/sessions
+ * and GET /api/activities/{activityType}/questions both need it to know which quiz's
+ * quiz_excluded_question/assembled_quiz_extra_question rows apply to the draw pool they build —
+ * "which course grants access" and "which quiz's composition governs the draw" are answered by
+ * the same row, so there is no reason to make either caller resolve it a second time.
+ *
  * Two queries (enrolled course ids, then the quiz-catalog join filtered to them) rather than one
  * three-way join, matching the shape getCourseForActivityType + isEnrolledInAnyCourse used to
  * have as two separate calls — no round-trip regression, just a different second query.
@@ -51,7 +64,7 @@ export async function getAccessibleCourseForActivity(
   const { data, error } = await supabase
     .from('assembled_quiz_catalog')
     .select(
-      'assembled_quiz:assembled_quiz_id!inner(course_id, quiz_name, description, course:course_id(course_name)), catalog:activity_type(quiz_name, description)',
+      'assembled_quiz:assembled_quiz_id!inner(assembled_quiz_id, course_id, quiz_name, description, course:course_id(course_name)), catalog:activity_type(quiz_name, description)',
     )
     .eq('activity_type', activityType)
     .in('assembled_quiz.course_id', courseIds)
@@ -68,6 +81,7 @@ export async function getAccessibleCourseForActivity(
       courseName: row.assembled_quiz.course?.course_name ?? 'Unknown course',
       name: row.assembled_quiz.quiz_name ?? row.catalog?.quiz_name ?? activityType,
       description: row.assembled_quiz.description ?? row.catalog?.description ?? null,
+      assembledQuizId: row.assembled_quiz.assembled_quiz_id,
     },
     error: null,
   };


### PR DESCRIPTION
## Summary

Fixes a bug where excluding a question from a quiz (as an instructor) had no effect on the live student session: excluded questions were still drawn, and a quiz whose active question count dropped below the 4-question minimum could still be started.

**Root cause:** `POST /api/sessions` drew its question pool directly from the catalog (`question` table, filtered by `activity_type` + `difficulty_level`), with no awareness of the assembled quiz's `quiz_excluded_question` exclusion list. That exclusion mechanism is already fully wired into the instructor-facing quiz composition UI, but the live student-facing draw never consulted it — so:
1. An excluded question could still end up in a student's session.
2. The "at least 4 questions required" check was validated against the *unfiltered* pool, so it didn't catch the case where exclusions had pushed the real available count below 4.

## Fix

- `getAccessibleCourseForActivity` (`lib/activityCourseQueries.ts`) now also returns the `assembledQuizId` that granted the student access to the catalog — it already resolved this row internally to build the access link, it just didn't expose the id.
- `POST /api/sessions` (`app/api/sessions/route.ts`) now uses that link to fetch the granting quiz's excluded question ids and filters them out of the draw pool *before* both the random draw and the 4-question minimum check.

## Test plan

- [x] Added regression test: excluded questions are never drawn into a session.
- [x] Added regression test: starting a session returns 400 once exclusions drop the available count below the minimum, even though the underlying catalog still has enough questions.
- [x] `npx vitest run` — all tests pass except one pre-existing, unrelated snapshot failure on `main` (verified via `git stash` that it fails identically without this change).
- [x] `npm run build` (this repo's typecheck) passes clean.

## Known follow-up (not in scope here)

`GET /api/activities/{activityType}/questions` has the same unfiltered-pool pattern, but it currently has no caller (dead code) — worth applying the same fix if/when it's wired up.

resolve #429 