### PR TITLE
Add quiz type to quiz overview

### DIFF
--- a/app/instructor/assembled-quizzes/page.tsx
+++ b/app/instructor/assembled-quizzes/page.tsx
@@ -8,8 +8,21 @@ import { loadAssembledQuizzes, type AssembledQuizSummary } from '../../../lib/as
 import { loadCourses, type CourseSummary } from '../../../lib/courseClient';
 import { loadQuizzes, type QuizSummary } from '../../../lib/quizClient';
 import { useRequireRole } from '../../../lib/useRequireRole';
+import type { GradingKind } from '../../../lib/activityTypes';
 
 const TOAST_MS = 3200;
+
+/**
+ * A quiz's catalogs can be a mix of MCQ and LLM-graded (nothing stops composing both kinds into
+ * one quiz), so its "type" is derived from the distinct set of gradingKinds among its linked
+ * catalogs rather than assumed to be one value.
+ */
+function quizTypeLabel(catalogs: { gradingKind: GradingKind }[]): string {
+  const kinds = new Set(catalogs.map((c) => c.gradingKind));
+  if (kinds.size === 0) return '—';
+  if (kinds.size > 1) return 'Mixed';
+  return kinds.has('llm-graded') ? 'LLM-graded' : 'Multiple choice';
+}
 
 /**
  * GitHub #360: compose a quiz from one or more question catalogs (GitHub #347/#359) for one of
@@ -62,7 +75,7 @@ export default function InstructorAssembledQuizzesPage() {
   if (loading || !authorized) return null;
   if (!token) return null;
 
-  function handleCreated(quiz: { id: string; name: string; description: string | null; courseId: string; catalogs: { activityType: string; name: string }[]; catalogNames: string[] }) {
+  function handleCreated(quiz: { id: string; name: string; description: string | null; courseId: string; catalogs: { activityType: string; name: string; gradingKind: GradingKind }[]; catalogNames: string[] }) {
     const course = (courses ?? []).find((c) => c.id === quiz.courseId);
 
     setQuizzes((current) => [
@@ -146,13 +159,14 @@ export default function InstructorAssembledQuizzesPage() {
                     <tr className="bg-brand-navy text-brand-ink-muted">
                       <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Name</th>
                       <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Course</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Type</th>
                       <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Catalogs</th>
                     </tr>
                   </thead>
                   <tbody>
                     {quizzes.length === 0 ? (
                       <tr>
-                        <td colSpan={3} className="bg-brand-navy-2 px-4 py-10 text-center text-sm font-semibold text-brand-ink-muted">
+                        <td colSpan={4} className="bg-brand-navy-2 px-4 py-10 text-center text-sm font-semibold text-brand-ink-muted">
                           You haven&apos;t created a quiz yet.
                         </td>
                       </tr>
@@ -165,6 +179,24 @@ export default function InstructorAssembledQuizzesPage() {
                             </Link>
                           </td>
                           <td className="whitespace-nowrap px-4 py-3 text-gray-500">{quiz.courseName}</td>
+                          <td className="whitespace-nowrap px-4 py-3">
+                            {(() => {
+                              const label = quizTypeLabel(quiz.catalogs);
+                              const kinds = new Set(quiz.catalogs.map((c) => c.gradingKind));
+                              const isLlmGraded = kinds.size === 1 && kinds.has('llm-graded');
+                              return (
+                                <span
+                                  className={`rounded-full px-2.5 py-1 text-xs font-extrabold ${
+                                    isLlmGraded
+                                      ? 'bg-brand-teal/15 text-brand-teal-dark'
+                                      : 'bg-brand-purple/10 text-brand-purple-dark'
+                                  }`}
+                                >
+                                  {label}
+                                </span>
+                              );
+                            })()}
+                          </td>
                           <td className="px-4 py-3 text-gray-500">{quiz.catalogNames.join(', ') || '—'}</td>
                         </tr>
                       ))

--- a/components/CreateQuizModal.tsx
+++ b/components/CreateQuizModal.tsx
@@ -32,7 +32,7 @@ export function CreateQuizModal({
    * only echoes ids, not display names — the modal already has the mapping (via its own `catalogs`
    * prop) that the page's optimistic-insert row needs to render immediately.
    */
-  onCreated: (quiz: { id: string; name: string; description: string | null; courseId: string; catalogs: { activityType: string; name: string }[]; catalogNames: string[] }) => void;
+  onCreated: (quiz: { id: string; name: string; description: string | null; courseId: string; catalogs: { activityType: string; name: string; gradingKind: QuizSummary['gradingKind'] }[]; catalogNames: string[] }) => void;
 }) {
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
@@ -81,9 +81,9 @@ export function CreateQuizModal({
     const resolvedCatalogs = selectedCatalogs
       .map((activityType) => {
         const found = catalogs.find((c) => c.activityType === activityType);
-        return found ? { activityType, name: found.name } : null;
+        return found ? { activityType, name: found.name, gradingKind: found.gradingKind } : null;
       })
-      .filter((c): c is { activityType: string; name: string } => c !== null);
+      .filter((c): c is { activityType: string; name: string; gradingKind: QuizSummary['gradingKind'] } => c !== null);
 
     onCreated({ ...result.data.quiz, catalogs: resolvedCatalogs, catalogNames: resolvedCatalogs.map((c) => c.name) });
     requestClose();

--- a/lib/assembledQuizClient.ts
+++ b/lib/assembledQuizClient.ts
@@ -18,7 +18,7 @@ export type AssembledQuizSummary = {
   description: string | null;
   courseId: string;
   courseName: string;
-  catalogs: { activityType: string; name: string }[];
+  catalogs: { activityType: string; name: string; gradingKind: GradingKind }[];
   catalogNames: string[];
   createdAt: string;
 };

--- a/lib/assembledQuizQueries.ts
+++ b/lib/assembledQuizQueries.ts
@@ -28,7 +28,7 @@ export type AssembledQuizSummary = {
   description: string | null;
   courseId: string;
   courseName: string;
-  catalogs: { activityType: string; name: string }[];
+  catalogs: { activityType: string; name: string; gradingKind: GradingKind }[];
   catalogNames: string[];
   createdAt: string;
 };
@@ -40,16 +40,17 @@ type AssembledQuizRow = {
   course_id: string;
   created_at: string;
   course: { course_name: string } | null;
-  assembled_quiz_catalog: { activity_type: string; catalog: { quiz_name: string } | null }[] | null;
+  assembled_quiz_catalog: { activity_type: string; catalog: { quiz_name: string; grading_kind: string } | null }[] | null;
 };
 
 const ASSEMBLED_QUIZ_SUMMARY_SELECT =
-  'assembled_quiz_id, quiz_name, description, course_id, created_at, course:course_id(course_name), assembled_quiz_catalog(activity_type, catalog:activity_type(quiz_name))';
+  'assembled_quiz_id, quiz_name, description, course_id, created_at, course:course_id(course_name), assembled_quiz_catalog(activity_type, catalog:activity_type(quiz_name, grading_kind))';
 
 function mapAssembledQuizRow(row: AssembledQuizRow): AssembledQuizSummary {
   const catalogs = (row.assembled_quiz_catalog ?? []).map((link) => ({
     activityType: link.activity_type,
     name: link.catalog?.quiz_name ?? 'Unknown catalog',
+    gradingKind: (link.catalog?.grading_kind === 'llm-graded' ? 'llm-graded' : 'mcq') as GradingKind,
   }));
   return {
     id: row.assembled_quiz_id,


### PR DESCRIPTION
Since a quiz can compose both MCQ and LLM-graded catalogs at once, the new "Type" column derives the label live from each linked catalog's grading_kind (Multiple choice / LLM-graded / Mixed) instead of storing it, so it can never drift from the actual catalogs.
-Resolve #438 