### PR TITLE
After join course, student count not updated.

### DIFF
--- a/app/courses/page.tsx
+++ b/app/courses/page.tsx
@@ -65,11 +65,17 @@ export default function BrowseCoursesPage() {
   if (!token || !profile) return null;
 
   function handleJoined(courseId: string) {
-    setCourses((current) => current?.map((c) => (c.id === courseId ? { ...c, alreadyMember: true } : c)) ?? current);
+    setCourses(
+      (current) =>
+        current?.map((c) => (c.id === courseId ? { ...c, alreadyMember: true, studentCount: c.studentCount + 1 } : c)) ?? current,
+    );
   }
 
   function handleLeft(courseId: string) {
-    setCourses((current) => current?.map((c) => (c.id === courseId ? { ...c, alreadyMember: false } : c)) ?? current);
+    setCourses(
+      (current) =>
+        current?.map((c) => (c.id === courseId ? { ...c, alreadyMember: false, studentCount: c.studentCount - 1 } : c)) ?? current,
+    );
   }
 
   return (


### PR DESCRIPTION
I just joined a class. Before joining the count was 1 student. After joining, the page did not refresh with the new count of students. A low priority bug, but a bug.
-Resolve #434 