### PR TITLE
Rename Courses nav to Course Browser, generalize LLM writing screen

### DIFF
--- a/components/AcceptanceCriteriaWritingScreen.tsx
+++ b/components/AcceptanceCriteriaWritingScreen.tsx
@@ -38,7 +38,7 @@ export function AcceptanceCriteriaWritingScreen({
 
       <form onSubmit={handleSubmit} className="rounded-brand-lg border border-brand-navy-border bg-brand-navy p-6">
         <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted" htmlFor="acceptance-criteria-input">
-          Your acceptance criteria
+          Your answer
         </label>
         <textarea
           id="acceptance-criteria-input"
@@ -46,12 +46,8 @@ export function AcceptanceCriteriaWritingScreen({
           onChange={(event) => setText(event.target.value)}
           disabled={submitting}
           rows={8}
-          placeholder="Given ..., when ..., then ..."
-          className="block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm leading-relaxed text-brand-ink outline-none transition focus:border-brand-purple disabled:cursor-not-allowed disabled:opacity-60"
+          className="mb-5 block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm leading-relaxed text-brand-ink outline-none transition focus:border-brand-purple disabled:cursor-not-allowed disabled:opacity-60"
         />
-        <p className="mb-5 mt-1.5 text-xs font-semibold text-brand-ink-muted">
-          Write one or more Given/When/Then criteria. Aim for criteria that are specific, testable, and clearly connected to the story above.
-        </p>
 
         <button
           type="submit"

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -36,7 +36,7 @@ type NavKey =
 const STUDENT_NAV_ITEMS: { key: NavKey; label: string; href: string }[] = [
   { key: 'dashboard', label: 'Dashboard', href: '/dashboard' },
   { key: 'activities', label: 'My Courses', href: '/activities' },
-  { key: 'courses', label: 'Courses', href: '/courses' },
+  { key: 'courses', label: 'Course Browser', href: '/courses' },
   { key: 'leaderboard', label: 'Leaderboard', href: '/leaderboard' },
   { key: 'profile', label: 'Profile', href: '/profile' },
 ];

--- a/lib/onboardingTourSteps.ts
+++ b/lib/onboardingTourSteps.ts
@@ -25,7 +25,7 @@ export const studentTourSteps: TourStep[] = [
   },
   {
     target: 'nav-courses',
-    title: 'Courses',
+    title: 'Course Browser',
     description:
       'Join your instructor’s course here — search by course name, code, or instructor, and enter a course code (and enrollment key, if required) to get started.',
   },


### PR DESCRIPTION
## Summary
- Renamed the student sidebar's "Courses" tab to "Course Browser" (`/courses`, the browse-by-name/join-by-code page) — distinct from the instructor's separate "Courses" tab (roster management), which is unchanged. Updated the matching onboarding-tour step title to match.
- Removed acceptance-criteria-specific copy from the free-text answer screen used by **every** LLM-graded activity (not just the seeded "Write Acceptance Criteria" one): the "Your acceptance criteria" label is now "Your answer", the `Given ..., when ..., then ...` placeholder is gone, and the "Write one or more Given/When/Then criteria..." helper paragraph is removed.

resolve #445 