### PR TITLE
resolve #430

### DIFF
--- a/__tests__/api/available-titles.test.ts
+++ b/__tests__/api/available-titles.test.ts
@@ -114,8 +114,8 @@ describe('GET /api/students/{studentId}/available-titles', () => {
     // Only levels 1 and 2 have a title_definition row — level 3 has none yet.
     queue('title_definition', {
       data: [
-        { activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, title_name: 'Story Apprentice' },
-        { activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 2, title_name: 'Story Analyst' },
+        { title_definition_id: 'title-1', activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, title_name: 'Story Apprentice' },
+        { title_definition_id: 'title-2', activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 2, title_name: 'Story Analyst' },
       ],
       error: null,
     });
@@ -130,10 +130,12 @@ describe('GET /api/students/{studentId}/available-titles', () => {
         activityName: 'Identify Weak User Stories',
         courseId: 'course-1',
         courseName: 'Software Requirements',
+        // titleDefinitionId travels with each rung so the profile page's title dropdown can store
+        // the student's pick by id; it is null exactly where the title is.
         titles: [
-          { difficultyLevel: 1, title: 'Story Apprentice' },
-          { difficultyLevel: 2, title: 'Story Analyst' },
-          { difficultyLevel: 3, title: null },
+          { difficultyLevel: 1, titleDefinitionId: 'title-1', title: 'Story Apprentice' },
+          { difficultyLevel: 2, titleDefinitionId: 'title-2', title: 'Story Analyst' },
+          { difficultyLevel: 3, titleDefinitionId: null, title: null },
         ],
       },
     ]);

--- a/__tests__/api/courses-leaderboard.test.ts
+++ b/__tests__/api/courses-leaderboard.test.ts
@@ -128,7 +128,12 @@ describe('GET /api/courses/{courseId}/leaderboard', () => {
     queue('course', { data: { course_id: COURSE_ID }, error: null });
     queue('student_course', { data: [{ course_id: COURSE_ID }], error: null }); // membership check
     queue('student_course', {
-      data: [{ user_id: 'student-1', student: { username: 'ada', avatar_url: null, role: 'student' } }],
+      data: [
+        {
+          user_id: 'student-1',
+          student: { username: 'ada', avatar_url: null, role: 'student', selected_title: { title_name: 'Story Analyst' } },
+        },
+      ],
       error: null,
     }); // roster
     queue('session_log', {
@@ -149,7 +154,9 @@ describe('GET /api/courses/{courseId}/leaderboard', () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.entries).toEqual([{ rank: 1, studentId: 'student-1', username: 'ada', avatarUrl: null, points: 100, streak: 1 }]);
+    expect(body.entries).toEqual([
+      { rank: 1, studentId: 'student-1', username: 'ada', avatarUrl: null, points: 100, streak: 1, title: 'Story Analyst' },
+    ]);
   });
 
   it('returns 500 when the course lookup fails', async () => {

--- a/__tests__/api/profile.test.ts
+++ b/__tests__/api/profile.test.ts
@@ -11,6 +11,25 @@ const mockBuilder = {
   single: vi.fn(async () => ({ data: mockProfile, error: null })),
 };
 
+// PATCH with selected_title_definition_id reaches into canWearTitle (lib/titleQueries.ts), which
+// reads title_definition and session_log — tables the single shared mockBuilder above can't answer
+// for, since it resolves everything to a profile row. These two are per-table and thenable, matching
+// the queue-per-table style the other route tests use.
+const titleState = {
+  definition: null as { activity_type: string; difficulty_level: number } | null,
+  sessions: [] as { activity_type: string; difficulty_level: number; passed: boolean }[],
+};
+
+function makeTitleBuilder(rows: unknown, single: unknown) {
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: () => builder,
+    maybeSingle: async () => ({ data: single, error: null }),
+    then: (onOk: (r: unknown) => unknown) => Promise.resolve({ data: rows, error: null }).then(onOk),
+  };
+  return builder;
+}
+
 vi.mock('../../lib/supabase', () => ({
   getSupabaseClient: vi.fn(() => ({
     auth: {
@@ -24,7 +43,11 @@ vi.mock('../../lib/supabase', () => ({
         return { data: { user: null }, error: { message: 'Invalid token' } };
       }),
     },
-    from: vi.fn(() => mockBuilder),
+    from: vi.fn((table: string) => {
+      if (table === 'title_definition') return makeTitleBuilder(null, titleState.definition);
+      if (table === 'session_log') return makeTitleBuilder(titleState.sessions, null);
+      return mockBuilder;
+    }),
   })),
 }));
 
@@ -50,6 +73,8 @@ describe('Profile API routes', () => {
     mockBuilder.insert.mockReturnThis();
     mockBuilder.maybeSingle.mockResolvedValue({ data: mockProfile, error: null });
     mockBuilder.single.mockResolvedValue({ data: mockProfile, error: null });
+    titleState.definition = null;
+    titleState.sessions = [];
   });
 
   it('GET returns profile for authenticated user', async () => {
@@ -130,5 +155,51 @@ describe('Profile API routes', () => {
   it('PATCH sends has_seen_onboarding_tour through to the update call', async () => {
     await PATCH(req('PATCH', { has_seen_onboarding_tour: true }));
     expect(mockBuilder.update).toHaveBeenCalledWith(expect.objectContaining({ has_seen_onboarding_tour: true }));
+  });
+
+  // The mastery title a student wears. Which titles they may pick is decided against their own
+  // session history, never against the request body — see canWearTitle (lib/titleQueries.ts).
+  describe('PATCH selected_title_definition_id', () => {
+    it('stores a title for a level the caller has passed', async () => {
+      titleState.definition = { activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 2 };
+      titleState.sessions = [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 2, passed: true }];
+
+      const response = await PATCH(req('PATCH', { selected_title_definition_id: 'title-2' }));
+
+      expect(response.status).toBe(200);
+      expect(mockBuilder.update).toHaveBeenCalledWith(
+        expect.objectContaining({ selected_title_definition_id: 'title-2' }),
+      );
+    });
+
+    it('returns 400 and writes nothing for a title the caller has not earned', async () => {
+      titleState.definition = { activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 3 };
+      titleState.sessions = [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, passed: true }];
+
+      const response = await PATCH(req('PATCH', { selected_title_definition_id: 'title-3' }));
+
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: 'You have not earned that title yet.' });
+      expect(mockBuilder.update).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a title_definition_id that does not exist', async () => {
+      titleState.definition = null;
+
+      const response = await PATCH(req('PATCH', { selected_title_definition_id: 'nope' }));
+
+      expect(response.status).toBe(400);
+      expect(mockBuilder.update).not.toHaveBeenCalled();
+    });
+
+    // Taking a title off needs no check — nobody has to have earned "no title".
+    it('clears the title on null without consulting session history', async () => {
+      const response = await PATCH(req('PATCH', { selected_title_definition_id: null }));
+
+      expect(response.status).toBe(200);
+      expect(mockBuilder.update).toHaveBeenCalledWith(
+        expect.objectContaining({ selected_title_definition_id: null }),
+      );
+    });
   });
 });

--- a/__tests__/api/students-public-profile.test.ts
+++ b/__tests__/api/students-public-profile.test.ts
@@ -68,7 +68,15 @@ function req(token: string | null = 'valid-token') {
 const ctx = { params: { studentId: TARGET_ID } };
 
 function targetRow(overrides: Partial<Record<string, unknown>> = {}) {
-  return { username: 'ada', avatar_url: null, biography: 'Hello!', role: 'student', ...overrides };
+  return {
+    username: 'ada',
+    avatar_url: null,
+    biography: 'Hello!',
+    role: 'student',
+    // The fk_user_title_definition embed: null when this student wears no title.
+    selected_title: null,
+    ...overrides,
+  };
 }
 
 /** Queues the full happy-path chain: target row, target's courses, shared course, score, titles, ladder. */
@@ -85,7 +93,14 @@ function queueHappyPath(options: { targetCourseIds?: string[]; sharedCourseIds?:
     error: null,
   });
   queue('title_definition', {
-    data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, title_name: 'Requirements Novice' }],
+    data: [
+      {
+        title_definition_id: 'title-1',
+        activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+        difficulty_level: 1,
+        title_name: 'Requirements Novice',
+      },
+    ],
     error: null,
   });
   // availableTitles: the target's own course-scoped activity list, plus its full ladder.
@@ -100,7 +115,14 @@ function queueHappyPath(options: { targetCourseIds?: string[]; sharedCourseIds?:
     error: null,
   });
   queue('title_definition', {
-    data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, title_name: 'Requirements Novice' }],
+    data: [
+      {
+        title_definition_id: 'title-1',
+        activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+        difficulty_level: 1,
+        title_name: 'Requirements Novice',
+      },
+    ],
     error: null,
   });
 }
@@ -177,6 +199,7 @@ describe('GET /api/students/{studentId}/public-profile', () => {
       username: 'ada',
       avatarUrl: null,
       biography: 'Hello!',
+      selectedTitle: null,
       score: 100,
       titles: [{ activityType: 'IDENTIFY_WEAK_USER_STORIES', difficultyLevel: 1, title: 'Requirements Novice' }],
       availableTitles: [
@@ -186,9 +209,9 @@ describe('GET /api/students/{studentId}/public-profile', () => {
           courseId: 'course-1',
           courseName: 'Course 1',
           titles: [
-            { difficultyLevel: 1, title: 'Requirements Novice' },
-            { difficultyLevel: 2, title: null },
-            { difficultyLevel: 3, title: null },
+            { difficultyLevel: 1, titleDefinitionId: 'title-1', title: 'Requirements Novice' },
+            { difficultyLevel: 2, titleDefinitionId: null, title: null },
+            { difficultyLevel: 3, titleDefinitionId: null, title: null },
           ],
         },
       ],

--- a/__tests__/lib/leaderboardQueries.test.ts
+++ b/__tests__/lib/leaderboardQueries.test.ts
@@ -45,8 +45,24 @@ function makeSupabase() {
   } as any;
 }
 
-function rosterRow(userId: string, username: string, avatarUrl: string | null = null, role = 'student') {
-  return { user_id: userId, student: { username, avatar_url: avatarUrl, role } };
+function rosterRow(
+  userId: string,
+  username: string,
+  avatarUrl: string | null = null,
+  role = 'student',
+  selectedTitle: string | null = null,
+) {
+  return {
+    user_id: userId,
+    student: {
+      username,
+      avatar_url: avatarUrl,
+      role,
+      // The embed PostgREST returns for fk_user_title_definition: an object when the student wears
+      // a title, null when selected_title_definition_id is null.
+      selected_title: selectedTitle === null ? null : { title_name: selectedTitle },
+    },
+  };
 }
 
 function sessionRow(
@@ -93,7 +109,7 @@ describe('computeCourseLeaderboard', () => {
     const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
 
     expect(result).toEqual({
-      data: [{ rank: 1, studentId: 'stu-1', username: 'newcomer', avatarUrl: null, points: 0, streak: 0 }],
+      data: [{ rank: 1, studentId: 'stu-1', username: 'newcomer', avatarUrl: null, points: 0, streak: 0, title: null }],
       error: null,
     });
   });
@@ -113,7 +129,7 @@ describe('computeCourseLeaderboard', () => {
 
     const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
 
-    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, points: 150, streak: 0 }]);
+    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, points: 150, streak: 0, title: null }]);
   });
 
   // AC: completed, not passed — a finished attempt below the pass threshold still contributes.
@@ -123,7 +139,7 @@ describe('computeCourseLeaderboard', () => {
 
     const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
 
-    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, points: 25, streak: 0 }]);
+    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, points: 25, streak: 0, title: null }]);
   });
 
   // AC: streak reuses computeStreakFromSessions (lib/streakQueries.ts) over the passed=true
@@ -175,9 +191,9 @@ describe('computeCourseLeaderboard', () => {
     const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
 
     expect(result.data).toEqual([
-      { rank: 1, studentId: 'stu-2', username: 'anne', avatarUrl: null, points: 100, streak: 0 },
-      { rank: 1, studentId: 'stu-1', username: 'brockenbrough', avatarUrl: null, points: 100, streak: 0 },
-      { rank: 3, studentId: 'stu-3', username: 'zed', avatarUrl: null, points: 50, streak: 0 },
+      { rank: 1, studentId: 'stu-2', username: 'anne', avatarUrl: null, points: 100, streak: 0, title: null },
+      { rank: 1, studentId: 'stu-1', username: 'brockenbrough', avatarUrl: null, points: 100, streak: 0, title: null },
+      { rank: 3, studentId: 'stu-3', username: 'zed', avatarUrl: null, points: 50, streak: 0, title: null },
     ]);
   });
 
@@ -201,14 +217,27 @@ describe('computeCourseLeaderboard', () => {
     expect(result.data?.map((row) => row.studentId)).toEqual(['stu-2', 'stu-3', 'stu-1']);
   });
 
-  // AC: only username/avatar_url leave "user" — no first/last name, age or semester.
-  it('selects only username and avatar_url from the student embed', async () => {
+  // AC: only username/avatar_url and the worn title leave "user" — no first/last name, age or
+  // semester. The title is deliberately public: it is chosen to be displayed next to the name.
+  it('selects only username, avatar_url and the worn title from the student embed', async () => {
     queue('student_course', { data: [rosterRow('stu-1', 'ada', 'https://example.com/a.png')], error: null });
     queue('session_log', { data: [], error: null });
 
     const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
 
-    expect(result.data?.[0]).toEqual({ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: 'https://example.com/a.png', points: 0, streak: 0 });
+    expect(result.data?.[0]).toEqual({ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: 'https://example.com/a.png', points: 0, streak: 0, title: null });
+  });
+
+  it("carries through the title a student chose to wear", async () => {
+    queue('student_course', {
+      data: [rosterRow('stu-1', 'ada', null, 'student', 'Story Analyst')],
+      error: null,
+    });
+    queue('session_log', { data: [], error: null });
+
+    const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
+
+    expect(result.data?.[0].title).toBe('Story Analyst');
   });
 
   // AC: roster and session queries are both scoped to the given course/roster.

--- a/__tests__/lib/masteryTitles.test.ts
+++ b/__tests__/lib/masteryTitles.test.ts
@@ -9,9 +9,9 @@ const STORIES: AvailableActivityTitles = {
   courseId: 'course-1',
   courseName: 'Software Requirements',
   titles: [
-    { difficultyLevel: 1, title: 'Story Apprentice' },
-    { difficultyLevel: 2, title: 'Story Analyst' },
-    { difficultyLevel: 3, title: 'Story Expert' },
+    { difficultyLevel: 1, titleDefinitionId: 'title-story-1', title: 'Story Apprentice' },
+    { difficultyLevel: 2, titleDefinitionId: 'title-story-2', title: 'Story Analyst' },
+    { difficultyLevel: 3, titleDefinitionId: 'title-story-3', title: 'Story Expert' },
   ],
 };
 
@@ -21,9 +21,9 @@ const CRITERIA: AvailableActivityTitles = {
   courseId: 'course-1',
   courseName: 'Software Requirements',
   titles: [
-    { difficultyLevel: 1, title: 'Criteria Apprentice' },
-    { difficultyLevel: 2, title: 'Criteria Analyst' },
-    { difficultyLevel: 3, title: 'Criteria Expert' },
+    { difficultyLevel: 1, titleDefinitionId: 'title-criteria-1', title: 'Criteria Apprentice' },
+    { difficultyLevel: 2, titleDefinitionId: 'title-criteria-2', title: 'Criteria Analyst' },
+    { difficultyLevel: 3, titleDefinitionId: 'title-criteria-3', title: 'Criteria Expert' },
   ],
 };
 
@@ -96,25 +96,53 @@ describe('buildMasteryTitleEntries', () => {
     const entries = buildMasteryTitleEntries(AVAILABLE, []);
 
     const stories = entries.find((e) => e.activityType === 'IDENTIFY_WEAK_USER_STORIES')!;
-    expect(stories.progression).toEqual(['Story Apprentice', 'Story Analyst', 'Story Expert']);
+    expect(stories.progression.map((rung) => rung.title)).toEqual([
+      'Story Apprentice',
+      'Story Analyst',
+      'Story Expert',
+    ]);
   });
 
-  it('falls back to a generic "Level N" label for a difficulty level with no title_definition row', () => {
+  // The generic "Level N" substitution that used to happen here is gone on purpose: it made an
+  // untitled ladder render "Level 1" twice per rung (see components/TitleProgressionTrack.tsx) and
+  // it made a rung with no title_definition row indistinguishable from one actually named "Level 1",
+  // which the title dropdown has to be able to tell apart — only a real title can be worn.
+  it('keeps a difficulty level with no title_definition row as a null title, not a "Level N" label', () => {
     const untitled: AvailableActivityTitles = {
       activityType: 'WRITE_ACCEPTANCE_CRITERIA',
       activityName: 'Write Acceptance Criteria',
       courseId: 'course-1',
       courseName: 'Software Requirements',
       titles: [
-        { difficultyLevel: 1, title: null },
-        { difficultyLevel: 2, title: null },
-        { difficultyLevel: 3, title: null },
+        { difficultyLevel: 1, titleDefinitionId: null, title: null },
+        { difficultyLevel: 2, titleDefinitionId: null, title: null },
+        { difficultyLevel: 3, titleDefinitionId: null, title: null },
       ],
     };
 
     const entries = buildMasteryTitleEntries([untitled], []);
 
-    expect(entries[0].progression).toEqual(['Level 1', 'Level 2', 'Level 3']);
+    expect(entries[0].progression).toEqual([
+      { difficultyLevel: 1, titleDefinitionId: null, title: null },
+      { difficultyLevel: 2, titleDefinitionId: null, title: null },
+      { difficultyLevel: 3, titleDefinitionId: null, title: null },
+    ]);
+  });
+
+  it('keeps titled and untitled rungs apart within one ladder', () => {
+    const partiallyTitled: AvailableActivityTitles = {
+      ...STORIES,
+      titles: [
+        { difficultyLevel: 1, titleDefinitionId: 'title-story-1', title: 'Story Apprentice' },
+        { difficultyLevel: 2, titleDefinitionId: null, title: null },
+        { difficultyLevel: 3, titleDefinitionId: null, title: null },
+      ],
+    };
+
+    const entries = buildMasteryTitleEntries([partiallyTitled], []);
+
+    expect(entries[0].progression.map((rung) => rung.title)).toEqual(['Story Apprentice', null, null]);
+    expect(entries[0].progression.map((rung) => rung.titleDefinitionId)).toEqual(['title-story-1', null, null]);
   });
 
   it('sorts the progression by difficulty level regardless of input order', () => {
@@ -125,7 +153,11 @@ describe('buildMasteryTitleEntries', () => {
 
     const entries = buildMasteryTitleEntries([outOfOrder], []);
 
-    expect(entries[0].progression).toEqual(['Story Apprentice', 'Story Analyst', 'Story Expert']);
+    expect(entries[0].progression.map((rung) => rung.title)).toEqual([
+      'Story Apprentice',
+      'Story Analyst',
+      'Story Expert',
+    ]);
   });
 });
 

--- a/__tests__/lib/titleQueries.test.ts
+++ b/__tests__/lib/titleQueries.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { canWearTitle } from '../../lib/titleQueries';
+
+type Result = { data?: unknown; error?: unknown };
+
+// Same locally-built fake client as __tests__/lib/leaderboardQueries.test.ts and
+// instructorAuth.test.ts: canWearTitle takes `supabase` as a plain argument, so there is nothing to
+// vi.mock('../../lib/supabase') for.
+const state = {
+  queues: {} as Record<string, Result[]>,
+  filters: [] as { table: string; column: string; value: unknown }[],
+};
+
+function queue(table: string, result: Result) {
+  (state.queues[table] ??= []).push(result);
+}
+
+function makeBuilder(table: string, result: Result) {
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: (column: string, value: unknown) => {
+      state.filters.push({ table, column, value });
+      return builder;
+    },
+    maybeSingle: async () => result,
+    then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+      Promise.resolve(result).then(onOk, onErr),
+  };
+  return builder;
+}
+
+function makeSupabase() {
+  return {
+    from: (table: string) => makeBuilder(table, state.queues[table]?.shift() ?? { data: null, error: null }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+function sessionRow(activityType: string, difficultyLevel: number, passed: boolean) {
+  return { activity_type: activityType, difficulty_level: difficultyLevel, passed };
+}
+
+const STORIES = 'IDENTIFY_WEAK_USER_STORIES';
+const CRITERIA = 'IDENTIFY_WEAK_ACCEPTANCE_CRITERIA';
+
+describe('canWearTitle', () => {
+  beforeEach(() => {
+    state.queues = {};
+    state.filters = [];
+  });
+
+  it('allows a title for a level the student has passed', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 2 }, error: null });
+    queue('session_log', { data: [sessionRow(STORIES, 2, true)], error: null });
+
+    expect(await canWearTitle(makeSupabase(), 'stu-1', 'title-2')).toEqual({ ok: true, reason: null, error: null });
+  });
+
+  // Sequential progression: passing level 3 implies 1 and 2 were passed too, so an earlier rung
+  // stays wearable — the dropdown offers every earned rung, not just the highest.
+  it('allows a lower title once a higher level in the same activity has been passed', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 1 }, error: null });
+    queue('session_log', { data: [sessionRow(STORIES, 3, true)], error: null });
+
+    expect((await canWearTitle(makeSupabase(), 'stu-1', 'title-1')).ok).toBe(true);
+  });
+
+  it('refuses a level the student has attempted but not passed', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 2 }, error: null });
+    queue('session_log', { data: [sessionRow(STORIES, 2, false)], error: null });
+
+    const verdict = await canWearTitle(makeSupabase(), 'stu-1', 'title-2');
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe('You have not earned that title yet.');
+  });
+
+  it('refuses a level the student has never reached', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 3 }, error: null });
+    queue('session_log', { data: [sessionRow(STORIES, 1, true)], error: null });
+
+    expect((await canWearTitle(makeSupabase(), 'stu-1', 'title-3')).ok).toBe(false);
+  });
+
+  // The passed level has to be in the title's OWN activity type — mastery in one quiz must not
+  // unlock another quiz's titles.
+  it('refuses when the passed level belongs to a different activity type', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 1 }, error: null });
+    queue('session_log', { data: [sessionRow(CRITERIA, 3, true)], error: null });
+
+    expect((await canWearTitle(makeSupabase(), 'stu-1', 'title-1')).ok).toBe(false);
+  });
+
+  it('refuses a student with no session history at all', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 1 }, error: null });
+    queue('session_log', { data: [], error: null });
+
+    expect((await canWearTitle(makeSupabase(), 'stu-1', 'title-1')).ok).toBe(false);
+  });
+
+  it('refuses an unknown title_definition_id without reading session_log', async () => {
+    queue('title_definition', { data: null, error: null });
+
+    const verdict = await canWearTitle(makeSupabase(), 'stu-1', 'no-such-title');
+
+    expect(verdict).toEqual({ ok: false, reason: 'That title does not exist.', error: null });
+    expect(state.filters.some((f) => f.table === 'session_log')).toBe(false);
+  });
+
+  it('scopes the session query to the caller, not to the id in the request', async () => {
+    queue('title_definition', { data: { activity_type: STORIES, difficulty_level: 1 }, error: null });
+    queue('session_log', { data: [sessionRow(STORIES, 1, true)], error: null });
+
+    await canWearTitle(makeSupabase(), 'stu-1', 'title-1');
+
+    expect(state.filters).toContainEqual({ table: 'session_log', column: 'user_id', value: 'stu-1' });
+  });
+
+  it('reports a database error rather than silently allowing the title', async () => {
+    queue('title_definition', { data: null, error: { message: 'db down' } });
+
+    const verdict = await canWearTitle(makeSupabase(), 'stu-1', 'title-1');
+
+    expect(verdict.ok).toBe(false);
+    expect(verdict.error).toEqual({ message: 'db down' });
+  });
+});

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,7 +1,12 @@
 import { getSupabaseClient } from '../../../lib/supabase';
+import { canWearTitle } from '../../../lib/titleQueries';
 
+// selected_title is an embed, not a column: the row stores a title_definition_id, and every
+// consumer (the profile page's dropdown, the sidebar under the avatar) needs the name too. Joining
+// it here means neither has to make a second call, and a title renamed by its instructor shows up
+// renamed everywhere without a backfill.
 const PROFILE_COLUMNS =
-  'user_id, username, biography, avatar_url, role, first_name, last_name, age, semester, has_seen_onboarding_tour';
+  'user_id, username, biography, avatar_url, role, first_name, last_name, age, semester, has_seen_onboarding_tour, selected_title_definition_id, selected_title:title_definition(title_name)';
 
 const MIN_AGE = 1;
 const MAX_AGE = 129;
@@ -115,13 +120,22 @@ export async function PATCH(request: Request) {
   if (!user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
   const body = await request.json();
-  const { biography, first_name, last_name, age, semester, has_seen_onboarding_tour } = body as {
+  const {
+    biography,
+    first_name,
+    last_name,
+    age,
+    semester,
+    has_seen_onboarding_tour,
+    selected_title_definition_id,
+  } = body as {
     biography?: string;
     first_name?: string;
     last_name?: string;
     age?: number | null;
     semester?: number | null;
     has_seen_onboarding_tour?: boolean;
+    selected_title_definition_id?: string | null;
   };
 
   const updates: Record<string, unknown> = {};
@@ -152,6 +166,21 @@ export async function PATCH(request: Request) {
   // re-finished) — never unset by this route, but not rejected either; there's no harm in it,
   // and it keeps this route's validation from having to know about the tour's own state machine.
   if (has_seen_onboarding_tour !== undefined) updates.has_seen_onboarding_tour = has_seen_onboarding_tour;
+
+  // The title a student wears. Clearing it is always allowed; setting one is checked against their
+  // own session history, never taken on the client's word — this route derives user_id from the
+  // token, so canWearTitle is asking "did *this* caller pass that level", not "does the body say
+  // so". Without the check any title in the database could be worn by anyone.
+  if (selected_title_definition_id !== undefined) {
+    if (selected_title_definition_id === null) {
+      updates.selected_title_definition_id = null;
+    } else {
+      const verdict = await canWearTitle(supabase!, user.id, selected_title_definition_id);
+      if (verdict.error) return Response.json({ error: verdict.error.message }, { status: 500 });
+      if (!verdict.ok) return Response.json({ error: verdict.reason }, { status: 400 });
+      updates.selected_title_definition_id = selected_title_definition_id;
+    }
+  }
 
   if (Object.keys(updates).length === 0) {
     return Response.json({ error: 'No fields to update.' }, { status: 400 });

--- a/app/api/students/[studentId]/public-profile/route.ts
+++ b/app/api/students/[studentId]/public-profile/route.ts
@@ -55,7 +55,10 @@ export async function GET(request: Request, { params }: { params: { studentId: s
 
   const { data: target, error: targetError } = await supabase
     .from('user')
-    .select('username, avatar_url, biography, role')
+    // selected_title is embedded through fk_user_title_definition, same as GET /api/profile and the
+    // course leaderboard do — one join instead of a second query, and the same "what they chose to
+    // wear", not "what they've earned".
+    .select('username, avatar_url, biography, role, selected_title:title_definition(title_name)')
     .eq('user_id', params.studentId)
     .maybeSingle();
 
@@ -92,13 +95,22 @@ export async function GET(request: Request, { params }: { params: { studentId: s
     return Response.json({ error: computeError?.message ?? 'Could not load profile.' }, { status: 500 });
   }
 
-  const profile = target as { username: string; avatar_url: string | null; biography: string };
+  // `as unknown as` because supabase-js types an embed as an array without generated schema types,
+  // while PostgREST returns a single object (or null) for a many-to-one like this one — the same
+  // cast lib/activityCourseQueries.ts makes for its own embeds.
+  const profile = target as unknown as {
+    username: string;
+    avatar_url: string | null;
+    biography: string;
+    selected_title: { title_name: string } | null;
+  };
 
   return Response.json(
     {
       username: profile.username,
       avatarUrl: profile.avatar_url,
       biography: profile.biography,
+      selectedTitle: profile.selected_title?.title_name ?? null,
       score,
       titles,
       availableTitles,

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 import { AppShell } from '../../components/AppShell';
 import { ChangePasswordForm } from '../../components/ChangePasswordForm';
+import { EarnedTitleSelect } from '../../components/EarnedTitleSelect';
 import { EditableField } from '../../components/EditableField';
 import { ImageCropModal } from '../../components/ImageCropModal';
 import { MasteryProgressSection } from '../../components/MasteryProgressSection';
@@ -17,6 +18,7 @@ import {
   avatarSizeError,
 } from '../../lib/imageRules';
 import { getInitials } from '../../lib/initials';
+import { useMasteryProgress } from '../../lib/useMasteryProgress';
 
 type ProfileDraft = {
   first_name: string;
@@ -102,6 +104,25 @@ export default function ProfilePage() {
   const [uploading, setUploading] = useState(false);
   const [pendingImage, setPendingImage] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // One load for two consumers: the title dropdown next to the name and the mastery section in the
+  // right column. Empty strings mean "don't load" — see the hook's own note on why the caller does
+  // that instead of skipping the call (hooks can't be conditional), and why an instructor, who has
+  // no mastery at all, passes them too.
+  const mastery = useMasteryProgress(
+    !isInstructor && token ? token : '',
+    !isInstructor && profile ? profile.user_id : '',
+  );
+  const [savingTitle, setSavingTitle] = useState(false);
+
+  async function handleSelectTitle(titleDefinitionId: string | null) {
+    setSavingTitle(true);
+    // Same PATCH as every other profile field, so the fresh profile (with the joined title name)
+    // lands in UserContext and the sidebar under the avatar updates without its own fetch.
+    const failure = await patchProfile({ selected_title_definition_id: titleDefinitionId });
+    setSavingTitle(false);
+    setError(failure ?? '');
+  }
 
   /** Shared by profile creation and handleSaveAll below — both need the same age/semester validation. */
   function parseOptionalNumber(raw: string, min: number, max: number): { value: number | null; error?: string } {
@@ -294,15 +315,19 @@ export default function ProfilePage() {
   return (
     <>
       <AppShell active="profile">
-      <section className="mx-auto w-full max-w-md rounded-2xl border border-gray-100 bg-gray-50 p-8">
-        <p className="text-sm font-extrabold uppercase tracking-wide text-[#7C4DFF]">Profile</p>
-
-        {error ? (
-          <p className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600">{error}</p>
-        ) : null}
-
+      {/* The whole page used to sit in a single max-w-md column with no breakpoints at all, so a
+          1440px screen showed a 448px strip with the mastery cards stacked single-file down it.
+          The card keeps a narrow measure (it's a form), the mastery grid gets the room it needs,
+          and below lg the two stack back into one column. */}
+      <section className="mx-auto w-full max-w-5xl">
         {profile === null ? (
-          <>
+          <div className="mx-auto w-full max-w-md rounded-2xl border border-gray-100 bg-gray-50 p-8">
+            <p className="text-sm font-extrabold uppercase tracking-wide text-[#7C4DFF]">Profile</p>
+
+            {error ? (
+              <p className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600">{error}</p>
+            ) : null}
+
             <h1 className="mt-4 text-3xl font-extrabold text-[#1B1642]">Create your profile</h1>
             <form onSubmit={handleCreate} className="mt-6 space-y-4">
               <label className="block text-sm font-bold text-gray-600">
@@ -382,9 +407,16 @@ export default function ProfilePage() {
                 {creating ? 'Creating…' : 'Create profile'}
               </button>
             </form>
-          </>
+          </div>
         ) : (
-          <>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-6 sm:p-8 lg:col-span-1">
+            <p className="text-sm font-extrabold uppercase tracking-wide text-[#7C4DFF]">Profile</p>
+
+            {error ? (
+              <p className="mt-4 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-600">{error}</p>
+            ) : null}
+
             <div className="mt-6 flex flex-col items-center gap-3">
               <button
                 onClick={() => fileInputRef.current?.click()}
@@ -411,7 +443,33 @@ export default function ProfilePage() {
                 onChange={handleAvatarChange}
               />
               <h1 className="text-3xl font-extrabold text-[#1B1642]">{profile.username}</h1>
+              {/* The worn title sits directly above the name fields, in the brand accent rather
+                  than the username's near-black, so the two read as different things at a glance
+                  instead of as one two-line heading. */}
+              {profile.selected_title ? (
+                <p className="text-base font-extrabold text-brand-purple">{profile.selected_title.title_name}</p>
+              ) : null}
             </div>
+
+            {/* Instructors have no sessions and therefore no titles, same reasoning as the mastery
+                section and the sidebar's score pill being student-only. */}
+            {!isInstructor ? (
+              <div className="mt-5">
+                {/* Held back until the ladder has loaded: with entries still null the select would
+                    render its "pass a level to earn a title" empty state for a beat, which reads as
+                    a fact about the student rather than a loading state. */}
+                {mastery.loading ? (
+                  <div className="h-9 w-full animate-pulse rounded-brand-md bg-gray-100" />
+                ) : (
+                  <EarnedTitleSelect
+                    entries={mastery.entries ?? []}
+                    value={profile.selected_title_definition_id}
+                    onChange={handleSelectTitle}
+                    disabled={savingTitle}
+                  />
+                )}
+              </div>
+            ) : null}
 
             {!isEditing ? (
               <div className="mt-6 flex justify-center">
@@ -426,20 +484,26 @@ export default function ProfilePage() {
               </div>
             ) : null}
 
-            <EditableField
-              label="First name"
-              editing={isEditing}
-              value={isEditing ? (draft?.first_name ?? '') : (profile.first_name ?? '')}
-              onChange={(v) => updateDraft('first_name', v)}
-              placeholder="Enter your first name"
-            />
-            <EditableField
-              label="Last name"
-              editing={isEditing}
-              value={isEditing ? (draft?.last_name ?? '') : (profile.last_name ?? '')}
-              onChange={(v) => updateDraft('last_name', v)}
-              placeholder="Enter your last name"
-            />
+            {/* First and last name are one piece of information split across two fields, so they
+                share a row instead of stacking — the same grid-cols-2 pairing the create form
+                already uses for Age/Semester. Single column below sm, where two inputs side by side
+                would each be too narrow to read. */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <EditableField
+                label="First name"
+                editing={isEditing}
+                value={isEditing ? (draft?.first_name ?? '') : (profile.first_name ?? '')}
+                onChange={(v) => updateDraft('first_name', v)}
+                placeholder="Enter your first name"
+              />
+              <EditableField
+                label="Last name"
+                editing={isEditing}
+                value={isEditing ? (draft?.last_name ?? '') : (profile.last_name ?? '')}
+                onChange={(v) => updateDraft('last_name', v)}
+                placeholder="Enter your last name"
+              />
+            </div>
             <EditableField
               label="Age"
               editing={isEditing}
@@ -525,11 +589,26 @@ export default function ProfilePage() {
               </button>
             </div>
 
+            </div>
+
             {/* GitHub #39: cumulative score and mastery titles are a student concept, same as
                 the sidebar's score pill (AppShell.tsx) already being instructor-only — an
-                instructor has no sessions of their own to have a score or title from. */}
-            {!isInstructor ? <MasteryProgressSection token={token} studentId={profile.user_id} /> : null}
-          </>
+                instructor has no sessions of their own to have a score or title from. Its data
+                comes from the page's single useMasteryProgress call, shared with the title
+                dropdown above, rather than a fetch of its own. */}
+            {!isInstructor ? (
+              <div className="rounded-2xl border border-gray-100 bg-gray-50 p-6 sm:p-8 lg:col-span-2">
+                <MasteryProgressSection
+                  entries={mastery.entries}
+                  cumulativeScore={mastery.cumulativeScore}
+                  sessionsCompleted={mastery.sessionsCompleted}
+                  error={mastery.error}
+                  loading={mastery.loading}
+                  onRetry={mastery.retry}
+                />
+              </div>
+            ) : null}
+          </div>
         )}
       </section>
       </AppShell>

--- a/app/students/[id]/page.tsx
+++ b/app/students/[id]/page.tsx
@@ -137,6 +137,7 @@ function StudentProfileContent({ studentId }: { studentId: string }) {
             username: ownProfile.username,
             avatarUrl: ownProfile.avatar_url,
             biography: ownProfile.biography,
+            selectedTitle: ownProfile.selected_title?.title_name ?? null,
             score: ownScore,
             titles: ownTitles,
             availableTitles: ownAvailableTitles,
@@ -178,6 +179,9 @@ function StudentProfileContent({ studentId }: { studentId: string }) {
               <Avatar avatarUrl={profile.avatarUrl} fallbackName={profile.username} size="xl" />
               <div className="min-w-0">
                 <h1 className="break-words text-2xl font-extrabold text-brand-navy">{profile.username}</h1>
+                {profile.selectedTitle ? (
+                  <p className="mt-0.5 text-sm font-bold text-brand-purple">{profile.selectedTitle}</p>
+                ) : null}
                 {isSelf ? (
                   <p className="mt-1 text-sm font-semibold text-gray-500">
                     This is you —{' '}

--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import { getHighestTitleOverall } from '../lib/activityStore';
 import { Avatar } from './Avatar';
 import { LLMProviderSettingsModal } from './LLMProviderSettingsModal';
 import { OnboardingTour } from './OnboardingTour';
@@ -209,7 +208,6 @@ export function AppShell({
   const router = useRouter();
   const { token, profile, signOut, score } = useUser();
   const { active: tourActive, startTour } = useOnboardingTour();
-  const [levelLine, setLevelLine] = useState('Getting started');
   const [drawerOpen, setDrawerOpen] = useState(false);
 
   // GitHub #318: the tour highlights sidebar nav items, which are translated off-screen behind
@@ -227,12 +225,14 @@ export function AppShell({
   const visibleNavItems = navItems.filter((item) => item.key !== 'instructor-settings');
 
   // Score and mastery titles are a student concept — an instructor has neither, so there is
-  // nothing to fetch or show under their avatar.
-  useEffect(() => {
-    if (isInstructor) return;
-    const best = getHighestTitleOverall();
-    setLevelLine(best ? best.title : 'Getting started');
-  }, [isInstructor]);
+  // nothing to show under their avatar.
+  //
+  // The line under the username used to come from lib/activityStore.ts's getHighestTitleOverall(),
+  // which has had no writer since the play flow moved to the API and therefore always returned
+  // null — every student saw a permanent "Getting started". It now shows the title the student
+  // actually chose to wear, which arrives on the profile itself (GET /api/profile joins the name),
+  // so there is nothing to fetch here and nothing that can go stale independently of the profile.
+  const levelLine = profile?.selected_title?.title_name ?? 'Getting started';
 
   // GitHub #392: score itself now lives in UserContext (loaded once there, kept fresh by
   // refreshScore) rather than being fetched again here on every AppShell mount — AppShell just

--- a/components/CompletedSessionsSummary.tsx
+++ b/components/CompletedSessionsSummary.tsx
@@ -17,7 +17,10 @@ export function CompletedSessionsSummary({
   levelsPassed: number;
 }) {
   return (
-    <div className="grid grid-cols-3 gap-3">
+    // grid-cols-1 below sm so three tiles don't squeeze to ~100px on a phone — this matches
+    // components/MasteryProgressSkeleton.tsx, which was already responsive while this wasn't, so
+    // the layout no longer reflows the moment real data replaces the skeleton.
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
       <StatTile value={cumulativeScore} label="Cumulative score" />
       <StatTile value={sessionsCompleted} label="Sessions completed" />
       <StatTile value={levelsPassed} label="Levels passed" />

--- a/components/EarnedTitleSelect.tsx
+++ b/components/EarnedTitleSelect.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import type { MasteryTitleEntry } from '../lib/masteryTitles';
+
+/**
+ * Picks which mastery title the student wears next to their name.
+ *
+ * Every rung they have actually passed is offered, not just the highest one per quiz — having
+ * reached "Story Analyst" doesn't mean they'd rather not display "Story Apprentice". Options are
+ * grouped by quiz through native <optgroup>, which is also what makes the quiz titles themselves
+ * visible here: the group label is the instructor's own quiz name (assembled_quiz.quiz_name, via
+ * GET /api/students/{id}/available-titles), so a student can tell which quiz a title came from.
+ *
+ * A native <select> rather than a hand-built listbox, same call as
+ * components/LeaderboardCourseSwitcher.tsx: keyboard handling, mobile pickers and grouping all come
+ * for free, and the repo has no listbox primitive to reuse.
+ */
+export function EarnedTitleSelect({
+  entries,
+  value,
+  onChange,
+  disabled = false,
+}: {
+  entries: MasteryTitleEntry[];
+  /** title_definition_id of the worn title, or null for none. */
+  value: string | null;
+  onChange: (titleDefinitionId: string | null) => void;
+  disabled?: boolean;
+}) {
+  // A rung is offered only if it was passed AND has a title_definition row behind it. Without that
+  // row there is no id to store and nothing to show — lib/masteryTitles.ts deliberately leaves such
+  // a rung's title null rather than inventing a "Level N" placeholder.
+  const groups = entries
+    .map((entry) => ({
+      activityType: entry.activityType,
+      activityName: entry.activityName,
+      rungs:
+        entry.currentLevel === null
+          ? []
+          : entry.progression.filter(
+              (rung) =>
+                rung.difficultyLevel <= entry.currentLevel! && rung.title !== null && rung.titleDefinitionId !== null,
+            ),
+    }))
+    .filter((group) => group.rungs.length > 0);
+
+  if (groups.length === 0) {
+    return (
+      <p className="text-xs font-semibold text-gray-500">
+        Pass a level to earn a title you can display here.
+      </p>
+    );
+  }
+
+  return (
+    <label className="block">
+      <span className="mb-1.5 block text-xs font-bold uppercase tracking-wide text-gray-500">Displayed title</span>
+      <select
+        value={value ?? ''}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value === '' ? null : event.target.value)}
+        className="w-full rounded-brand-md border border-gray-300 bg-white px-3 py-2 text-sm font-bold text-brand-navy transition focus:border-brand-purple focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-purple disabled:opacity-70"
+      >
+        <option value="">No title</option>
+        {groups.map((group) => (
+          <optgroup key={group.activityType} label={group.activityName}>
+            {group.rungs.map((rung) => (
+              <option key={rung.titleDefinitionId!} value={rung.titleDefinitionId!}>
+                {rung.title} · Level {rung.difficultyLevel}
+              </option>
+            ))}
+          </optgroup>
+        ))}
+      </select>
+    </label>
+  );
+}

--- a/components/LeaderboardTable.tsx
+++ b/components/LeaderboardTable.tsx
@@ -42,6 +42,11 @@ export function LeaderboardRow({
           {entry.username}
         </Link>
         {isCurrentUser ? <span className="ml-2 text-xs font-extrabold text-brand-purple">You</span> : null}
+        {/* The mastery title this student chose to wear, under their name rather than beside it —
+            titles are long enough ("Acceptance Criteria Apprentice") to wreck the column width. */}
+        {entry.title ? (
+          <span className="mt-0.5 block text-xs font-bold text-brand-ink-muted">{entry.title}</span>
+        ) : null}
       </td>
       <td className="whitespace-nowrap px-4 py-3.5">
         <StreakBadge streak={entry.streak} />

--- a/components/MasteryProgressSection.tsx
+++ b/components/MasteryProgressSection.tsx
@@ -1,87 +1,41 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { buildMasteryTitleEntries, totalLevelsPassed, type MasteryTitleEntry } from '../lib/masteryTitles';
-import { loadAvailableTitles, loadStudentScore, loadStudentTitles } from '../lib/sessionClient';
+import { totalLevelsPassed, type MasteryTitleEntry } from '../lib/masteryTitles';
 import { CompletedSessionsSummary } from './CompletedSessionsSummary';
 import { MasteryProgressSkeleton } from './MasteryProgressSkeleton';
 import { MasteryTitleCard } from './MasteryTitleCard';
 
 /**
- * GitHub #39: the profile page's cumulative score + mastery titles section — self-contained (owns
- * its own fetch, loading, and error state), so app/profile/page.tsx just renders it for a student
- * and doesn't otherwise know how it works.
+ * GitHub #39: the profile page's cumulative score + mastery titles section.
  *
- * Loads GET /api/students/{id}/score, GET /api/students/{id}/titles, and
- * GET /api/students/{id}/available-titles in parallel, then reconciles the latter two via
- * lib/masteryTitles.ts: /titles only returns entries for activity types the student has actually
- * attempted, and /available-titles is the course-scoped list of every activity (and its full
- * title ladder) the student could attempt at all.
+ * It used to own its own fetch. That moved to lib/useMasteryProgress.ts once the profile page's
+ * title dropdown needed the same entries — see that hook's header for why one shared call beats
+ * two components fetching the same uncached endpoints. This component is now purely presentational
+ * and the page decides where its data comes from.
  */
-export function MasteryProgressSection({ token, studentId }: { token: string; studentId: string }) {
-  const [cumulativeScore, setCumulativeScore] = useState<number | null>(null);
-  const [sessionsCompleted, setSessionsCompleted] = useState<number | null>(null);
-  const [entries, setEntries] = useState<MasteryTitleEntry[] | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loadAttempt, setLoadAttempt] = useState(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    setError(null);
-
-    Promise.all([
-      // onRevalidate (GitHub #392 follow-up, same as UserProvider's own score load): corrects a
-      // stale cached score in the background if the server disagrees, rather than leaving this
-      // section stuck on a wrong number until the student finishes another session or logs out.
-      loadStudentScore(token, studentId, {
-        onRevalidate: (fresh) => {
-          if (cancelled) return;
-          setCumulativeScore(fresh.score);
-          setSessionsCompleted(fresh.sessionsCompleted);
-        },
-      }),
-      loadStudentTitles(token, studentId),
-      loadAvailableTitles(token, studentId),
-    ]).then(([scoreResult, titlesResult, availableResult]) => {
-      if (cancelled) return;
-
-      if (!scoreResult.ok) {
-        setError(scoreResult.error);
-        return;
-      }
-      if (!titlesResult.ok) {
-        setError(titlesResult.error);
-        return;
-      }
-      if (!availableResult.ok) {
-        setError(availableResult.error);
-        return;
-      }
-
-      setCumulativeScore(scoreResult.data.score);
-      setSessionsCompleted(scoreResult.data.sessionsCompleted);
-      setEntries(buildMasteryTitleEntries(availableResult.data.activities, titlesResult.data.titles));
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [token, studentId, loadAttempt]);
-
-  const loading = !error && entries === null;
-
+export function MasteryProgressSection({
+  entries,
+  cumulativeScore,
+  sessionsCompleted,
+  error,
+  loading,
+  onRetry,
+}: {
+  entries: MasteryTitleEntry[] | null;
+  cumulativeScore: number | null;
+  sessionsCompleted: number | null;
+  error: string | null;
+  loading: boolean;
+  onRetry: () => void;
+}) {
   return (
-    <div className="mt-8 border-t border-gray-100 pt-6">
+    <div>
       <p className="text-xs font-bold uppercase tracking-widest text-gray-400">Mastery &amp; Progress</p>
 
       {error ? (
         <div className="mt-3 rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-600">
           {error}
-          <button
-            type="button"
-            onClick={() => setLoadAttempt((count) => count + 1)}
-            className="ml-2 font-bold underline hover:text-red-700"
-          >
+          <button type="button" onClick={onRetry} className="ml-2 font-bold underline hover:text-red-700">
             Retry
           </button>
         </div>
@@ -96,18 +50,20 @@ export function MasteryProgressSection({ token, studentId }: { token: string; st
             sessionsCompleted={sessionsCompleted ?? 0}
             levelsPassed={totalLevelsPassed(entries ?? [])}
           />
-          <div className="space-y-4">
-            {entries && entries.length === 0 ? (
-              // Genuinely possible now that this is course-scoped (GET /api/students/{id}/
-              // available-titles), not a fixed set of three: a student enrolled in no course, or
-              // in courses with nothing linked yet, sees this instead of an empty list.
-              <p className="text-sm font-semibold text-gray-500">
-                No mastery titles yet — join a course to see what you can earn.
-              </p>
-            ) : (
-              (entries ?? []).map((entry) => <MasteryTitleCard key={entry.activityType} entry={entry} />)
-            )}
-          </div>
+          {entries && entries.length === 0 ? (
+            // Genuinely possible now that this is course-scoped (GET /api/students/{id}/
+            // available-titles), not a fixed set of three: a student enrolled in no course, or
+            // in courses with nothing linked yet, sees this instead of an empty list.
+            <p className="text-sm font-semibold text-gray-500">
+              No mastery titles yet — join a course to see what you can earn.
+            </p>
+          ) : (
+            <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+              {(entries ?? []).map((entry) => (
+                <MasteryTitleCard key={entry.activityType} entry={entry} />
+              ))}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/components/TitleProgressionTrack.tsx
+++ b/components/TitleProgressionTrack.tsx
@@ -1,3 +1,5 @@
+import type { TitleLadderRung } from '../lib/leaderboardTypes';
+
 function LockIcon() {
   return (
     <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
@@ -29,13 +31,13 @@ export function TitleProgressionTrack({
   progression,
   currentLevel,
 }: {
-  progression: string[];
+  progression: TitleLadderRung[];
   currentLevel: number | null;
 }) {
   return (
     <div className="mt-3 space-y-2">
-      {progression.map((title, index) => {
-        const level = index + 1;
+      {progression.map((rung) => {
+        const { difficultyLevel: level, title } = rung;
         const reached = currentLevel !== null && level <= currentLevel;
         const isCurrent = level === currentLevel;
         const isNext = currentLevel === null ? level === 1 : level === currentLevel + 1;
@@ -58,9 +60,21 @@ export function TitleProgressionTrack({
             >
               {reached ? <CheckIcon /> : <LockIcon />}
             </span>
+            {/* An activity whose title_definition rows don't exist yet (any freshly created quiz)
+                has no name for this rung. Showing the level alone is the whole row then — the
+                previous version substituted a "Level N" *title* and still rendered the level
+                sub-label underneath, so every such ladder read "Level 1 / Level 1 / Level 2 / …". */}
             <div className="min-w-0 flex-1">
-              <p className={`truncate text-sm font-extrabold ${reached ? 'text-brand-navy' : 'text-gray-400'}`}>{title}</p>
-              <p className="text-xs font-semibold text-gray-400">Level {level}</p>
+              {title === null ? (
+                <p className={`truncate text-sm font-extrabold ${reached ? 'text-brand-navy' : 'text-gray-400'}`}>
+                  Level {level}
+                </p>
+              ) : (
+                <>
+                  <p className={`truncate text-sm font-extrabold ${reached ? 'text-brand-navy' : 'text-gray-400'}`}>{title}</p>
+                  <p className="text-xs font-semibold text-gray-400">Level {level}</p>
+                </>
+              )}
             </div>
             {isCurrent ? (
               <span className="flex-none whitespace-nowrap rounded-full bg-brand-purple px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-wide text-white">

--- a/components/UserProvider.tsx
+++ b/components/UserProvider.tsx
@@ -18,6 +18,13 @@ export type Profile = {
   semester: number | null;
   /** GitHub #318: has the first-login guided tour been finished or skipped yet. */
   has_seen_onboarding_tour: boolean;
+  /** title_definition_id of the mastery title the student chose to wear, or null for none. */
+  selected_title_definition_id: string | null;
+  /**
+   * The worn title's name, joined by GET /api/profile rather than stored — so a title renamed by
+   * its instructor updates everywhere at once. Null whenever selected_title_definition_id is.
+   */
+  selected_title: { title_name: string } | null;
 };
 
 type UserContextValue = {

--- a/lib/leaderboardQueries.ts
+++ b/lib/leaderboardQueries.ts
@@ -13,11 +13,23 @@ import { computeStreakFromSessions, type StreakSessionRow } from './streakQuerie
 // without it, .eq('student.role', 'student') would null the embed instead of dropping the row,
 // and an instructor who was somehow enrolled would still show up ranked among their own
 // students. Backed by ix_user_role, the same index that embed relies on.
-const ROSTER_STUDENT_EMBED = 'student:user!inner(username, avatar_url, role)';
+//
+// selected_title rides along on this same embed rather than costing a query of its own: the worn
+// title is stored as a title_definition_id on "user", and PostgREST resolves the name through the
+// existing fk_user_title_definition foreign key. Note it is the title the student *chose*, not a
+// re-derivation of their highest earned one — showing a title nobody picked would put a name on a
+// leaderboard row its owner never opted into.
+const ROSTER_STUDENT_EMBED =
+  'student:user!inner(username, avatar_url, role, selected_title:title_definition(title_name))';
 
 type RosterRow = {
   user_id: string;
-  student: { username: string; avatar_url: string | null; role: string };
+  student: {
+    username: string;
+    avatar_url: string | null;
+    role: string;
+    selected_title: { title_name: string } | null;
+  };
 };
 
 /** One ranked row. No rankChange here — that's derived client-side, see LeaderboardEntry's own doc. */
@@ -29,6 +41,8 @@ export type LeaderboardRow = {
   points: number;
   /** Same definition as computeStudentStreak (lib/streakQueries.ts, GitHub #307). */
   streak: number;
+  /** The mastery title this student chose to wear, or null if they haven't picked one. */
+  title: string | null;
 };
 
 /**
@@ -97,6 +111,7 @@ export async function computeCourseLeaderboard(
         studentId: row.user_id,
         username: row.student.username,
         avatarUrl: row.student.avatar_url,
+        title: row.student.selected_title?.title_name ?? null,
         points: sumBestScores(sessions),
         streak: computeStreakFromSessions(sessions.filter((session) => session.passed)),
       };
@@ -116,6 +131,7 @@ export async function computeCourseLeaderboard(
       avatarUrl: entry.avatarUrl,
       points: entry.points,
       streak: entry.streak,
+      title: entry.title,
     });
     previousPoints = entry.points;
     previousRank = rank;

--- a/lib/leaderboardTypes.ts
+++ b/lib/leaderboardTypes.ts
@@ -37,6 +37,13 @@ export type LeaderboardEntry = {
    * device", not "since yesterday". See that store's header for the limits.
    */
   rankChange: number | null;
+  /**
+   * The mastery title this student chose to wear ("user".selected_title_definition_id, resolved to
+   * title_definition.title_name), or null if they haven't picked one. Read straight off the "user"
+   * embed this query already joins for username/avatar — no extra round trip, and no re-derivation
+   * of "highest earned", which would show a title the student never chose to display.
+   */
+  title: string | null;
 };
 
 /** A course the signed-in student can view a leaderboard for. */
@@ -69,7 +76,21 @@ export type AvailableActivityTitles = {
   activityName: string;
   courseId: string;
   courseName: string;
-  titles: { difficultyLevel: number; title: string | null }[];
+  titles: TitleLadderRung[];
+};
+
+/**
+ * One rung of an earnable title ladder, same shape as lib/titleQueries.ts's TitleLadderRung —
+ * re-declared here for the same reason PublicStudentTitle above is: this file imports nothing, so
+ * a client component can use it without dragging a server query module into the bundle.
+ *
+ * titleDefinitionId is null exactly when title is. It's what a student's chosen title is stored
+ * as ("user".selected_title_definition_id), so a rung without one is not wearable.
+ */
+export type TitleLadderRung = {
+  difficultyLevel: number;
+  titleDefinitionId: string | null;
+  title: string | null;
 };
 
 /**
@@ -80,6 +101,10 @@ export type AvailableActivityTitles = {
  * and deliberately so, are first_name/last_name, age, semester, email, the student's courses,
  * and anything about individual answers or attempts — all of which exist on the "user" row or a
  * join away from it, and none of which a peer has a reason to see.
+ *
+ * selectedTitle is a deliberate addition to that list rather than an oversight: a worn title is
+ * chosen by the student precisely to be seen next to their name, and it is already visible to
+ * every classmate on the course leaderboard.
  *
  * titles and availableTitles both stay in the raw API shape rather than a pre-built
  * MasteryTitleEntry[] so that lib/masteryTitles.ts remains the single place that reconciles the
@@ -93,6 +118,8 @@ export type PublicStudentProfile = {
   biography: string;
   /** Cumulative score, same definition as computeStudentScore (lib/scoreQueries.ts). */
   score: number;
+  /** The mastery title this student chose to wear, or null — same field as LeaderboardEntry.title. */
+  selectedTitle: string | null;
   titles: PublicStudentTitle[];
   /** The target's full earnable title ladder — lib/titleQueries.ts's loadAvailableTitleLadders. */
   availableTitles: AvailableActivityTitles[];

--- a/lib/masteryTitles.ts
+++ b/lib/masteryTitles.ts
@@ -9,7 +9,7 @@
 // in behavior, not just a data-source swap: this reconciliation used to always show all three
 // built-in activity types, even ones with no course link at all.
 
-import type { AvailableActivityTitles } from './leaderboardTypes';
+import type { AvailableActivityTitles, TitleLadderRung } from './leaderboardTypes';
 import type { StudentTitle } from './sessionClient';
 
 /**
@@ -25,8 +25,12 @@ import type { StudentTitle } from './sessionClient';
 export type MasteryTitleEntry = {
   activityType: string;
   activityName: string;
-  /** Every level's title in order, e.g. ["Story Apprentice", "Story Analyst", "Story Expert"]. */
-  progression: string[];
+  /**
+   * Every level's rung in order — e.g. "Story Apprentice", "Story Analyst", "Story Expert", each
+   * with the title_definition id a student would wear. A rung whose title is null has no
+   * title_definition row yet; see progressionOf below for why that stays null here.
+   */
+  progression: TitleLadderRung[];
   /** Highest level passed, or null if none has been. */
   currentLevel: number | null;
   /** progression[currentLevel - 1], or null alongside currentLevel === null. */
@@ -34,16 +38,18 @@ export type MasteryTitleEntry = {
 };
 
 /**
- * A level with no title_definition row yet (a freshly created custom quiz, or
- * WRITE_ACCEPTANCE_CRITERIA today, per lib/titleQueries.ts's own note) falls back to a generic
- * "Level N" label — the same placeholder lib/activityContent.ts's buildCustomActivityDefinition
- * used to hardcode, kept here instead now that the ladder itself comes from title_definition.
+ * The ladder's rungs in level order, kept as rungs rather than flattened to display strings.
+ *
+ * This used to substitute a generic "Level N" string for a level with no title_definition row (a
+ * freshly created custom quiz, or WRITE_ACCEPTANCE_CRITERIA today, per lib/titleQueries.ts's own
+ * note). That lost the distinction between "the title is called Level 2" and "there is no title
+ * here", and components/TitleProgressionTrack.tsx renders a "Level N" sub-label under every rung's
+ * name — so an untitled ladder came out as "Level 1 / Level 1 / Level 2 / Level 2 / …". Keeping
+ * title null lets the track render the level line exactly once, and lets the title dropdown skip
+ * rungs that aren't real, wearable titles.
  */
-function progressionOf(activity: AvailableActivityTitles): string[] {
-  return activity.titles
-    .slice()
-    .sort((a, b) => a.difficultyLevel - b.difficultyLevel)
-    .map((rung) => rung.title ?? `Level ${rung.difficultyLevel}`);
+function progressionOf(activity: AvailableActivityTitles): TitleLadderRung[] {
+  return activity.titles.slice().sort((a, b) => a.difficultyLevel - b.difficultyLevel);
 }
 
 /**

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -654,6 +654,7 @@ type PublicProfileResponse = {
   username: string;
   avatarUrl: string | null;
   biography: string;
+  selectedTitle: string | null;
   score: number;
   titles: PublicStudentTitle[];
   availableTitles: AvailableActivityTitles[];

--- a/lib/studentCourseClient.ts
+++ b/lib/studentCourseClient.ts
@@ -135,6 +135,8 @@ type LeaderboardRow = {
   avatarUrl: string | null;
   points: number;
   streak: number;
+  /** The mastery title this student chose to wear, or null — see LeaderboardEntry.title. */
+  title: string | null;
 };
 
 /**

--- a/lib/titleQueries.ts
+++ b/lib/titleQueries.ts
@@ -14,6 +14,7 @@ export type StudentTitle = {
 
 type SessionRow = PassedSessionRow;
 type TitleDefinitionRow = { activity_type: string; difficulty_level: number; title_name: string };
+type IdentifiedTitleDefinitionRow = TitleDefinitionRow & { title_definition_id: string };
 
 const NOT_STARTED = 'Not yet started';
 
@@ -58,8 +59,18 @@ export async function computeStudentTitles(supabase: SupabaseClient, userId: str
   return { titles, error: null };
 }
 
-/** One difficulty level's earnable title within an activity type's ladder — null if no title_definition row exists for it yet. */
-export type TitleLadderRung = { difficultyLevel: number; title: string | null };
+/**
+ * One difficulty level's earnable title within an activity type's ladder — title is null if no
+ * title_definition row exists for it yet, and titleDefinitionId is null in exactly the same case.
+ *
+ * The id travels with the name because a student can choose one of these as the title shown next
+ * to their name ("user".selected_title_definition_id), and that choice is stored by id, not text.
+ * A rung with a null title is therefore not selectable: there is nothing to wear and no row to
+ * point at. Consumers must not substitute a generic "Level N" string for a missing title — that
+ * placeholder is a rendering decision, and baking it in here is what made the ladder display
+ * "Level 1" twice per rung (see components/TitleProgressionTrack.tsx).
+ */
+export type TitleLadderRung = { difficultyLevel: number; titleDefinitionId: string | null; title: string | null };
 
 /**
  * One activity type's full earnable title ladder (every difficulty level, not just the one a
@@ -99,13 +110,16 @@ export async function loadAvailableTitleLadders(supabase: SupabaseClient, course
   const activityTypes = courseActivities.map((activity) => activity.activityType);
   const { data: titleRows, error: titleError } = await supabase
     .from('title_definition')
-    .select('activity_type, difficulty_level, title_name')
+    .select('title_definition_id, activity_type, difficulty_level, title_name')
     .in('activity_type', activityTypes);
 
   if (titleError) return { activities: null, error: titleError };
 
-  const titleByKey = new Map(
-    ((titleRows ?? []) as TitleDefinitionRow[]).map((row) => [`${row.activity_type}:${row.difficulty_level}`, row.title_name]),
+  const rungByKey = new Map(
+    ((titleRows ?? []) as IdentifiedTitleDefinitionRow[]).map((row) => [
+      `${row.activity_type}:${row.difficulty_level}`,
+      { id: row.title_definition_id, name: row.title_name },
+    ]),
   );
 
   const activities: AvailableActivityTitles[] = courseActivities.map((activity) => ({
@@ -115,9 +129,58 @@ export async function loadAvailableTitleLadders(supabase: SupabaseClient, course
     courseName: activity.courseName,
     titles: Array.from({ length: MAX_DIFFICULTY_LEVEL }, (_, index) => {
       const difficultyLevel = index + 1;
-      return { difficultyLevel, title: titleByKey.get(`${activity.activityType}:${difficultyLevel}`) ?? null };
+      const rung = rungByKey.get(`${activity.activityType}:${difficultyLevel}`);
+      return { difficultyLevel, titleDefinitionId: rung?.id ?? null, title: rung?.name ?? null };
     }),
   }));
 
   return { activities, error: null };
+}
+
+/**
+ * May this student wear this title? Answered against session_log, never against the request —
+ * the id arrives in a PATCH /api/profile body, so the client saying "this is mine" proves
+ * nothing. A title is wearable when the student has passed the difficulty level its
+ * title_definition row is defined for, in that row's activity type.
+ *
+ * The check reduces the student's sessions with highestPassedLevelByType (lib/sessionRules.ts) —
+ * the same reducer computeStudentTitles above and findStartDifficultyLevel already use — so
+ * "earned" cannot come to mean one thing on the profile page's dropdown and another here.
+ *
+ * Course enrollment is deliberately NOT re-checked: a title is earned by passing a level, and
+ * leaving the course afterwards doesn't unearn it. The dropdown is course-scoped only because
+ * it's built from available-titles, which is a discovery list, not a permission list.
+ */
+export async function canWearTitle(
+  supabase: SupabaseClient,
+  userId: string,
+  titleDefinitionId: string,
+): Promise<{ ok: boolean; reason: string | null; error: { message: string } | null }> {
+  const { data: titleRow, error: titleError } = await supabase
+    .from('title_definition')
+    .select('activity_type, difficulty_level')
+    .eq('title_definition_id', titleDefinitionId)
+    .maybeSingle();
+
+  if (titleError) return { ok: false, reason: null, error: titleError };
+  if (!titleRow) return { ok: false, reason: 'That title does not exist.', error: null };
+
+  const { activity_type: activityType, difficulty_level: difficultyLevel } = titleRow as {
+    activity_type: string;
+    difficulty_level: number;
+  };
+
+  const { data: sessionRows, error: sessionError } = await supabase
+    .from('session_log')
+    .select('activity_type, difficulty_level, passed')
+    .eq('user_id', userId);
+
+  if (sessionError) return { ok: false, reason: null, error: sessionError };
+
+  const highestPassed = highestPassedLevelByType((sessionRows ?? []) as SessionRow[]).get(activityType) ?? 0;
+  if (difficultyLevel > highestPassed) {
+    return { ok: false, reason: 'You have not earned that title yet.', error: null };
+  }
+
+  return { ok: true, reason: null, error: null };
 }

--- a/lib/useMasteryProgress.ts
+++ b/lib/useMasteryProgress.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { buildMasteryTitleEntries, type MasteryTitleEntry } from './masteryTitles';
+import { loadAvailableTitles, loadStudentScore, loadStudentTitles } from './sessionClient';
+
+/**
+ * The student's score plus their reconciled mastery ladder — lifted out of
+ * components/MasteryProgressSection.tsx, which used to own this fetch privately.
+ *
+ * It had to move because two things on the profile page now need the same entries: the title
+ * dropdown next to the student's name, and the mastery section further down. Both endpoints are
+ * deliberately uncached (a just-earned title has to show immediately, see loadStudentTitles' own
+ * comment), so letting each component fetch for itself would mean two of every request on every
+ * mount. The page calls this once and passes the result to both.
+ */
+export function useMasteryProgress(token: string, studentId: string) {
+  const [cumulativeScore, setCumulativeScore] = useState<number | null>(null);
+  const [sessionsCompleted, setSessionsCompleted] = useState<number | null>(null);
+  const [entries, setEntries] = useState<MasteryTitleEntry[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loadAttempt, setLoadAttempt] = useState(0);
+
+  const retry = useCallback(() => setLoadAttempt((count) => count + 1), []);
+
+  // Hooks can't be called conditionally, so the caller passes empty strings for "nothing to load
+  // yet" (profile still loading) or "not applicable" (an instructor, who has no mastery at all)
+  // rather than skipping the call. Reporting loading: false for that case matters — otherwise the
+  // profile page would render a mastery skeleton forever for an instructor.
+  const enabled = token !== '' && studentId !== '';
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+    setError(null);
+
+    Promise.all([
+      // onRevalidate (GitHub #392 follow-up, same as UserProvider's own score load): corrects a
+      // stale cached score in the background if the server disagrees, rather than leaving this
+      // section stuck on a wrong number until the student finishes another session or logs out.
+      loadStudentScore(token, studentId, {
+        onRevalidate: (fresh) => {
+          if (cancelled) return;
+          setCumulativeScore(fresh.score);
+          setSessionsCompleted(fresh.sessionsCompleted);
+        },
+      }),
+      loadStudentTitles(token, studentId),
+      loadAvailableTitles(token, studentId),
+    ]).then(([scoreResult, titlesResult, availableResult]) => {
+      if (cancelled) return;
+
+      if (!scoreResult.ok) {
+        setError(scoreResult.error);
+        return;
+      }
+      if (!titlesResult.ok) {
+        setError(titlesResult.error);
+        return;
+      }
+      if (!availableResult.ok) {
+        setError(availableResult.error);
+        return;
+      }
+
+      setCumulativeScore(scoreResult.data.score);
+      setSessionsCompleted(scoreResult.data.sessionsCompleted);
+      setEntries(buildMasteryTitleEntries(availableResult.data.activities, titlesResult.data.titles));
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, token, studentId, loadAttempt]);
+
+  return {
+    entries,
+    cumulativeScore,
+    sessionsCompleted,
+    error,
+    loading: enabled && !error && entries === null,
+    retry,
+  };
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -41,6 +41,13 @@ CREATE TABLE "user" (
     -- account backfilled by the ALTER TABLE below is treated the same as a brand new one: they
     -- get the tour once, same as everybody else.
     has_seen_onboarding_tour bool NOT NULL DEFAULT false,
+    -- The mastery title this student has chosen to wear next to their name. NULL means none,
+    -- which is every account's starting state — nothing is auto-selected on the student's behalf.
+    -- A title_definition_id rather than the title text: an instructor renaming a title carries
+    -- straight through to every display, and ON DELETE SET NULL (below) cleans up after a deleted
+    -- one instead of leaving a dangling name. Which titles are *earnable* stays derived from
+    -- session_log as it always was — only the student's pick is stored here.
+    selected_title_definition_id uuid,
     PRIMARY KEY (user_id));
 
 -- ---------------------------------------------------------------------
@@ -483,6 +490,13 @@ ALTER TABLE assembled_quiz_extra_question ADD CONSTRAINT fk_assembled_quiz_extra
 ALTER TABLE assembled_quiz_extra_question ADD CONSTRAINT fk_assembled_quiz_extra_question_question FOREIGN KEY (question_id) REFERENCES question (question_id) ON DELETE CASCADE;
 
 ALTER TABLE title_definition ADD CONSTRAINT fk_title_definition_activity_type FOREIGN KEY (activity_type) REFERENCES activity_type (activity_type);
+
+-- The title a student has chosen to wear. ON DELETE SET NULL rather than RESTRICT or CASCADE:
+-- deleting a title_definition row must not be blocked by whoever happens to be wearing it, and it
+-- certainly must not delete their profile — the wearer simply stops having a title, which is the
+-- same state every account starts in. This FK is also why the column stores an id instead of the
+-- title text: it is what keeps a stale name from surviving the row it came from.
+ALTER TABLE "user" ADD CONSTRAINT fk_user_title_definition FOREIGN KEY (selected_title_definition_id) REFERENCES title_definition (title_definition_id) ON DELETE SET NULL;
 -- Who authored the story, for attribution/moderation.
 ALTER TABLE user_story ADD CONSTRAINT fk_user_story_user FOREIGN KEY (creator_id) REFERENCES "user" (user_id);
 
@@ -961,6 +975,16 @@ CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
 -- tour once, exactly like a freshly registered one:
 --
 --   ALTER TABLE "user" ADD COLUMN IF NOT EXISTS has_seen_onboarding_tour bool NOT NULL DEFAULT false;
+
+-- Selectable mastery title (the profile page's title dropdown): if your "user" table predates
+-- this column, add it and its foreign key. Existing rows backfill to NULL — nobody is wearing a
+-- title until they pick one, which is deliberate: auto-selecting the highest earned title would
+-- put a name on accounts that never asked for one.
+--
+--   ALTER TABLE "user" ADD COLUMN IF NOT EXISTS selected_title_definition_id uuid;
+--   ALTER TABLE "user" ADD CONSTRAINT fk_user_title_definition
+--     FOREIGN KEY (selected_title_definition_id)
+--     REFERENCES title_definition (title_definition_id) ON DELETE SET NULL;
 
 -- GitHub #347 (create and browse quizzes): if your activity_type table predates quiz_name/
 -- description/creator_id, add them without touching the three existing rows' keys — every


### PR DESCRIPTION
 resolve #430

Profile page is responsive instead of a fixed 448px column: two columns
on desktop, one below lg, first and last name side by side.

Remove the duplicated "Level N" rows in the mastery ladder — the generic
label was rendered as the title and as the sub-label whenever a level had
no title_definition row.

Add a dropdown to pick which earned title to wear, grouped by quiz. Stored
as "user".selected_title_definition_id (new column + FK), validated
server-side against session_log, and displayed on the profile, in the
sidebar, on the leaderboard and on a peer's profile.

Needs a schema migration — see the footer of supabase/schema.sql.