### PR TITLE
"Cannot change the profile twice"-bug fixed

### DIFF
--- a/app/api/profile/avatar/route.ts
+++ b/app/api/profile/avatar/route.ts
@@ -6,6 +6,7 @@ import {
   avatarSizeError,
   sniffAvatarMime,
 } from '../../../../lib/imageRules';
+import { PROFILE_COLUMNS } from '../../../../lib/profileQueries';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -68,7 +69,7 @@ export async function POST(request: Request) {
     .from('user')
     .update({ avatar_url: publicUrl })
     .eq('user_id', user.id)
-    .select('user_id, username, biography, avatar_url, role')
+    .select(PROFILE_COLUMNS)
     .single();
 
   if (updateError) return Response.json({ error: updateError.message }, { status: 400 });

--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -1,12 +1,6 @@
 import { getSupabaseClient } from '../../../lib/supabase';
+import { PROFILE_COLUMNS } from '../../../lib/profileQueries';
 import { canWearTitle } from '../../../lib/titleQueries';
-
-// selected_title is an embed, not a column: the row stores a title_definition_id, and every
-// consumer (the profile page's dropdown, the sidebar under the avatar) needs the name too. Joining
-// it here means neither has to make a second call, and a title renamed by its instructor shows up
-// renamed everywhere without a backfill.
-const PROFILE_COLUMNS =
-  'user_id, username, biography, avatar_url, role, first_name, last_name, age, semester, has_seen_onboarding_tour, selected_title_definition_id, selected_title:title_definition(title_name)';
 
 const MIN_AGE = 1;
 const MAX_AGE = 129;

--- a/lib/profileQueries.ts
+++ b/lib/profileQueries.ts
@@ -1,0 +1,11 @@
+// Shared by app/api/profile/route.ts and app/api/profile/avatar/route.ts (GitHub #428) — both
+// PATCH the "user" row and hand the result straight to the client's setProfile, which replaces
+// the whole cached profile rather than merging fields. A select() missing a column here doesn't
+// just omit it from one response; it wipes that field from client state until the next login.
+//
+// selected_title is an embed, not a column: the row stores a title_definition_id, and every
+// consumer (the profile page's dropdown, the sidebar under the avatar) needs the name too. Joining
+// it here means neither has to make a second call, and a title renamed by its instructor shows up
+// renamed everywhere without a backfill.
+export const PROFILE_COLUMNS =
+  'user_id, username, biography, avatar_url, role, first_name, last_name, age, semester, has_seen_onboarding_tour, selected_title_definition_id, selected_title:title_definition(title_name)';


### PR DESCRIPTION
-Resolve #428 
Steps: 1. login, 2. click profile, 3. click on image to load new image, 4. click on new image and save, 5. the image is not saved and page now shows: Not set for first, last, age, semester, bio. (BUG), 5. any time you return to the profile page in this session the fields will be empty. 6. log out 7. log in, 8. the missing fields are there and you still cannot change the profile image.