### PR TITLE
Fix question-modal and title-ladder bugs; move title editing to the quiz page

### DIFF
--- a/__tests__/api/activity-types.test.ts
+++ b/__tests__/api/activity-types.test.ts
@@ -6,24 +6,26 @@ const h = vi.hoisted(() => {
   const state = {
     queues: {} as Record<string, Result[]>,
     tables: [] as string[],
+    // Title authoring writes through saveTitleLadder's select-then-insert-or-update, and a failed
+    // ladder insert rolls the catalog back with a delete — none of this existed on this builder
+    // before.
     inserts: [] as { table: string; payload: unknown }[],
-    // Title authoring writes through an upsert, and a failed ladder insert rolls the catalog back
-    // with a delete — neither existed on this builder before.
-    upserts: [] as { table: string; payload: unknown }[],
+    updates: [] as { table: string; payload: unknown; filters: { column: string; value: unknown }[] }[],
     deletes: [] as { table: string; filters: { column: string; value: unknown }[] }[],
     user: { id: 'instructor-1' } as { id: string } | null,
   };
 
   function makeBuilder(table: string, result: Result) {
     const filters: { column: string; value: unknown }[] = [];
+    let pendingUpdatePayload: unknown = null;
 
     const builder: Record<string, unknown> = {
       insert: (payload: unknown) => {
         state.inserts.push({ table, payload });
         return builder;
       },
-      upsert: (payload: unknown) => {
-        state.upserts.push({ table, payload });
+      update: (payload: unknown) => {
+        pendingUpdatePayload = payload;
         return builder;
       },
       delete: () => {
@@ -33,6 +35,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: (column: string, value: unknown) => {
         filters.push({ column, value });
+        if (pendingUpdatePayload !== null) state.updates.push({ table, payload: pendingUpdatePayload, filters: [...filters] });
         return builder;
       },
       in: (column: string, value: unknown) => {
@@ -103,7 +106,7 @@ beforeEach(() => {
   h.state.queues = {};
   h.state.tables = [];
   h.state.inserts = [];
-  h.state.upserts = [];
+  h.state.updates = [];
   h.state.deletes = [];
   h.state.user = { id: 'instructor-1' };
 });
@@ -347,7 +350,8 @@ describe('POST /api/activities/types — mastery titles', () => {
   it('writes the ladder alongside the catalog', async () => {
     queueRole('instructor');
     queue('activity_type', { data: activityTypeRow(), error: null });
-    queue('title_definition', { data: null, error: null });
+    queue('title_definition', { data: [], error: null }); // saveTitleLadder's existing-rows lookup: a brand-new catalog has none
+    queue('title_definition', { data: null, error: null }); // the insert
 
     const res = await POST(
       makeRequest(
@@ -361,11 +365,12 @@ describe('POST /api/activities/types — mastery titles', () => {
     );
 
     expect(res.status).toBe(201);
-    const upsert = h.state.upserts.find((entry) => entry.table === 'title_definition');
-    expect(upsert?.payload).toEqual([
+    const insert = h.state.inserts.find((entry) => entry.table === 'title_definition');
+    expect(insert?.payload).toEqual([
       expect.objectContaining({ activity_type: 'MY_CUSTOM_QUIZ', difficulty_level: 1, title_name: 'Story Apprentice' }),
       expect.objectContaining({ activity_type: 'MY_CUSTOM_QUIZ', difficulty_level: 2, title_name: 'Story Analyst' }),
     ]);
+    expect(h.state.updates).toHaveLength(0);
   });
 
   it('creates the catalog without touching title_definition when no titles are given', async () => {
@@ -396,7 +401,8 @@ describe('POST /api/activities/types — mastery titles', () => {
     expect(res.status).toBe(201);
     // Only clears were requested and there is nothing to clear on a catalog created a moment ago,
     // so the ladder write is a no-op rather than a delete.
-    expect(h.state.upserts).toHaveLength(0);
+    expect(h.state.inserts.filter((entry) => entry.table === 'title_definition')).toHaveLength(0);
+    expect(h.state.updates).toHaveLength(0);
   });
 
   // Rollback by hand — there is no transaction. Leaving the catalog behind would be worse than
@@ -404,7 +410,8 @@ describe('POST /api/activities/types — mastery titles', () => {
   it('deletes the just-created catalog when the ladder insert fails', async () => {
     queueRole('instructor');
     queue('activity_type', { data: activityTypeRow(), error: null });
-    queue('title_definition', { data: null, error: { message: 'ladder exploded' } });
+    queue('title_definition', { data: [], error: null }); // saveTitleLadder's existing-rows lookup
+    queue('title_definition', { data: null, error: { message: 'ladder exploded' } }); // the insert
 
     const res = await POST(
       makeRequest(validBody({ titles: [{ difficultyLevel: 1, titleName: 'Story Apprentice' }] })),

--- a/__tests__/api/instructor-quiz-titles.test.ts
+++ b/__tests__/api/instructor-quiz-titles.test.ts
@@ -2,23 +2,30 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 type Result = { data?: unknown; error?: unknown };
 
-// Same harness as __tests__/api/instructor-quiz-detail.test.ts, extended with upsert/delete —
-// PUT writes the ladder through both.
+// Same harness as __tests__/api/instructor-quiz-detail.test.ts, extended with insert/update/delete
+// — PUT writes the ladder through saveTitleLadder's select-then-insert-or-update-then-delete
+// sequence (lib/titleAuthoringQueries.ts).
 const h = vi.hoisted(() => {
   const state = {
     queues: {} as Record<string, Result[]>,
     tables: [] as string[],
-    upserts: [] as { table: string; payload: unknown; options: unknown }[],
+    inserts: [] as { table: string; payload: unknown }[],
+    updates: [] as { table: string; payload: unknown; filters: { column: string; value: unknown }[] }[],
     deletes: [] as { table: string; filters: { column: string; value: unknown }[] }[],
   };
 
   function makeBuilder(table: string, result: Result) {
     const filters: { column: string; value: unknown }[] = [];
+    let pendingUpdatePayload: unknown = null;
 
     const builder: Record<string, unknown> = {
       select: () => builder,
-      upsert: (payload: unknown, options: unknown) => {
-        state.upserts.push({ table, payload, options });
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      update: (payload: unknown) => {
+        pendingUpdatePayload = payload;
         return builder;
       },
       delete: () => {
@@ -27,6 +34,7 @@ const h = vi.hoisted(() => {
       },
       eq: (column: string, value: unknown) => {
         filters.push({ column, value });
+        if (pendingUpdatePayload !== null) state.updates.push({ table, payload: pendingUpdatePayload, filters: [...filters] });
         return builder;
       },
       in: (column: string, value: unknown) => {
@@ -101,7 +109,8 @@ function req(body: unknown, token: string | null = 'valid-token') {
 beforeEach(() => {
   h.state.queues = {};
   h.state.tables = [];
-  h.state.upserts = [];
+  h.state.inserts = [];
+  h.state.updates = [];
   h.state.deletes = [];
 });
 
@@ -125,7 +134,7 @@ describe('PUT /api/instructor/quizzes/{activityType}/titles', () => {
     const res = await req({ titles: [{ difficultyLevel: 1, titleName: 'Story Apprentice' }] });
 
     expect(res.status).toBe(404);
-    expect(h.state.upserts).toHaveLength(0);
+    expect(h.state.inserts).toHaveLength(0);
   });
 
   // 404-then-403, the ordering findOwnedCourse established: existence first, then ownership.
@@ -137,7 +146,7 @@ describe('PUT /api/instructor/quizzes/{activityType}/titles', () => {
 
     expect(res.status).toBe(403);
     expect(await res.text()).toBe('');
-    expect(h.state.upserts).toHaveLength(0);
+    expect(h.state.inserts).toHaveLength(0);
   });
 
   // A built-in catalog has creator_id NULL, so nobody owns it and nobody can rename its ladder.
@@ -159,10 +168,11 @@ describe('PUT /api/instructor/quizzes/{activityType}/titles', () => {
     expect(h.state.tables).not.toContain('activity_type');
   });
 
-  it('saves the ladder and returns it as stored', async () => {
+  it('saves a new rung and returns it as stored', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow(), error: null });
-    queue('title_definition', { data: null, error: null }); // the upsert
+    queue('title_definition', { data: [], error: null }); // saveTitleLadder's existing-rows lookup: none yet
+    queue('title_definition', { data: null, error: null }); // the insert
     queue('title_definition', {
       data: [{ difficulty_level: 1, title_name: 'Story Apprentice' }],
       error: null,
@@ -172,7 +182,37 @@ describe('PUT /api/instructor/quizzes/{activityType}/titles', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ titles: [{ difficultyLevel: 1, titleName: 'Story Apprentice' }] });
-    expect(h.state.upserts[0].options).toEqual({ onConflict: 'activity_type,difficulty_level' });
+    expect(h.state.inserts).toHaveLength(1);
+    expect(h.state.updates).toHaveLength(0);
+  });
+
+  // GitHub #464 follow-up regression: renaming an already-selected title must UPDATE the existing
+  // row in place, never touch its id — that's what used to violate fk_user_title_definition.
+  it('renames an existing rung by updating it in place, without touching its id', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null });
+    queue('title_definition', {
+      data: [{ title_definition_id: 'existing-id', difficulty_level: 1 }],
+      error: null,
+    }); // saveTitleLadder's existing-rows lookup: already has a row at level 1
+    queue('title_definition', { data: null, error: null }); // the update
+    queue('title_definition', {
+      data: [{ difficulty_level: 1, title_name: 'Renamed Title' }],
+      error: null,
+    }); // the re-read
+
+    const res = await req({ titles: [{ difficultyLevel: 1, titleName: 'Renamed Title' }] });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ titles: [{ difficultyLevel: 1, titleName: 'Renamed Title' }] });
+    expect(h.state.inserts).toHaveLength(0);
+    expect(h.state.updates).toEqual([
+      {
+        table: 'title_definition',
+        payload: { title_name: 'Renamed Title' },
+        filters: [{ column: 'title_definition_id', value: 'existing-id' }],
+      },
+    ]);
   });
 
   it('clears a rung sent as an empty string', async () => {
@@ -184,7 +224,8 @@ describe('PUT /api/instructor/quizzes/{activityType}/titles', () => {
     const res = await req({ titles: [{ difficultyLevel: 2, titleName: '' }] });
 
     expect(res.status).toBe(200);
-    expect(h.state.upserts).toHaveLength(0);
+    expect(h.state.inserts).toHaveLength(0);
+    expect(h.state.updates).toHaveLength(0);
     expect(h.state.deletes[0].filters).toEqual([
       { column: 'activity_type', value: ACTIVITY_TYPE },
       { column: 'difficulty_level', value: [2] },

--- a/__tests__/lib/titleAuthoringQueries.test.ts
+++ b/__tests__/lib/titleAuthoringQueries.test.ts
@@ -12,10 +12,19 @@ type Result = { data?: unknown; error?: unknown };
 // functions take `supabase` as a plain argument, so there is nothing to vi.mock.
 const state = {
   queues: {} as Record<string, Result[]>,
-  upserts: [] as { table: string; payload: unknown; options: unknown }[],
+  inserts: [] as { table: string; payload: unknown }[],
+  updates: [] as { table: string; payload: unknown; filters: { column: string; value: unknown }[] }[],
   deletes: [] as { table: string; filters: { column: string; value: unknown }[] }[],
   orders: [] as { table: string; column: string }[],
 };
+
+function resetState() {
+  state.queues = {};
+  state.inserts = [];
+  state.updates = [];
+  state.deletes = [];
+  state.orders = [];
+}
 
 function queue(table: string, result: Result) {
   (state.queues[table] ??= []).push(result);
@@ -23,11 +32,16 @@ function queue(table: string, result: Result) {
 
 function makeBuilder(table: string, result: Result) {
   const filters: { column: string; value: unknown }[] = [];
+  let pendingUpdatePayload: unknown = null;
 
   const builder: Record<string, unknown> = {
     select: () => builder,
-    upsert: (payload: unknown, options: unknown) => {
-      state.upserts.push({ table, payload, options });
+    insert: (payload: unknown) => {
+      state.inserts.push({ table, payload });
+      return builder;
+    },
+    update: (payload: unknown) => {
+      pendingUpdatePayload = payload;
       return builder;
     },
     delete: () => {
@@ -36,6 +50,7 @@ function makeBuilder(table: string, result: Result) {
     },
     eq: (column: string, value: unknown) => {
       filters.push({ column, value });
+      if (pendingUpdatePayload !== null) state.updates.push({ table, payload: pendingUpdatePayload, filters: [...filters] });
       return builder;
     },
     in: (column: string, value: unknown) => {
@@ -61,12 +76,7 @@ function makeSupabase() {
 }
 
 describe('loadTitleLadder', () => {
-  beforeEach(() => {
-    state.queues = {};
-    state.upserts = [];
-    state.deletes = [];
-    state.orders = [];
-  });
+  beforeEach(resetState);
 
   it('maps rows to the level/name shape, in level order', async () => {
     queue('title_definition', {
@@ -104,31 +114,74 @@ describe('loadTitleLadder', () => {
 });
 
 describe('saveTitleLadder', () => {
-  beforeEach(() => {
-    state.queues = {};
-    state.upserts = [];
-    state.deletes = [];
-    state.orders = [];
-  });
+  beforeEach(resetState);
 
-  it('upserts filled rungs on the (activity_type, difficulty_level) unique key', async () => {
-    queue('title_definition', { data: null, error: null });
+  // GitHub #464 follow-up: a plain upsert used to generate a fresh title_definition_id for every
+  // row, including ones that already exist — Postgres's ON CONFLICT DO UPDATE puts every payload
+  // column except the conflict target into the SET clause, so that was a real UPDATE to an
+  // existing row's primary key. fk_user_title_definition (ON DELETE SET NULL, no ON UPDATE clause)
+  // rejects that the moment a student has already selected the title. These tests assert the
+  // insert/update split that avoids ever touching an existing row's id.
+
+  it('inserts a genuinely new rung with a fresh id', async () => {
+    queue('title_definition', { data: [], error: null }); // no existing row at this level
 
     const { error } = await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
       { difficultyLevel: 1, titleName: 'Story Apprentice' },
     ]);
 
     expect(error).toBeNull();
-    const upsert = state.upserts[0];
-    expect(upsert.table).toBe('title_definition');
-    expect(upsert.options).toEqual({ onConflict: 'activity_type,difficulty_level' });
-    expect(upsert.payload).toEqual([
-      expect.objectContaining({
-        activity_type: 'TEST_CATALOG',
-        difficulty_level: 1,
-        title_name: 'Story Apprentice',
-      }),
+    expect(state.updates).toHaveLength(0);
+    expect(state.inserts).toEqual([
+      {
+        table: 'title_definition',
+        payload: [
+          expect.objectContaining({
+            activity_type: 'TEST_CATALOG',
+            difficulty_level: 1,
+            title_name: 'Story Apprentice',
+          }),
+        ],
+      },
     ]);
+  });
+
+  it("updates an existing rung by its own id, never touching title_definition_id", async () => {
+    queue('title_definition', {
+      data: [{ title_definition_id: 'existing-id-1', difficulty_level: 1 }],
+      error: null,
+    });
+
+    const { error } = await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
+      { difficultyLevel: 1, titleName: 'Renamed Title' },
+    ]);
+
+    expect(error).toBeNull();
+    expect(state.inserts).toHaveLength(0);
+    expect(state.updates).toEqual([
+      {
+        table: 'title_definition',
+        payload: { title_name: 'Renamed Title' },
+        filters: [{ column: 'title_definition_id', value: 'existing-id-1' }],
+      },
+    ]);
+  });
+
+  it('inserts and updates in the same call when rungs are a mix of new and existing', async () => {
+    queue('title_definition', {
+      data: [{ title_definition_id: 'existing-id-2', difficulty_level: 2 }],
+      error: null,
+    });
+
+    await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
+      { difficultyLevel: 1, titleName: 'New Rung' },
+      { difficultyLevel: 2, titleName: 'Updated Rung' },
+    ]);
+
+    expect(state.inserts).toHaveLength(1);
+    expect(state.updates).toHaveLength(1);
+    expect((state.inserts[0].payload as { difficulty_level: number }[])[0].difficulty_level).toBe(1);
+    expect(state.updates[0].filters).toEqual([{ column: 'title_definition_id', value: 'existing-id-2' }]);
   });
 
   it('deletes rungs that were cleared', async () => {
@@ -139,7 +192,8 @@ describe('saveTitleLadder', () => {
       { difficultyLevel: 3, titleName: null },
     ]);
 
-    expect(state.upserts).toHaveLength(0);
+    expect(state.inserts).toHaveLength(0);
+    expect(state.updates).toHaveLength(0);
     expect(state.deletes[0].filters).toEqual([
       { column: 'activity_type', value: 'TEST_CATALOG' },
       { column: 'difficulty_level', value: [2, 3] },
@@ -147,15 +201,15 @@ describe('saveTitleLadder', () => {
   });
 
   it('does both in one call when some rungs are set and others cleared', async () => {
-    queue('title_definition', { data: null, error: null });
-    queue('title_definition', { data: null, error: null });
+    queue('title_definition', { data: [], error: null }); // existing-rows lookup for the filled rung
+    queue('title_definition', { data: null, error: null }); // the delete
 
     await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
       { difficultyLevel: 1, titleName: 'Story Apprentice' },
       { difficultyLevel: 2, titleName: null },
     ]);
 
-    expect(state.upserts).toHaveLength(1);
+    expect(state.inserts).toHaveLength(1);
     expect(state.deletes).toHaveLength(1);
   });
 
@@ -163,30 +217,53 @@ describe('saveTitleLadder', () => {
     const { error } = await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', []);
 
     expect(error).toBeNull();
-    expect(state.upserts).toHaveLength(0);
+    expect(state.inserts).toHaveLength(0);
+    expect(state.updates).toHaveLength(0);
     expect(state.deletes).toHaveLength(0);
   });
 
-  it('stops and reports when the upsert fails, without running the delete', async () => {
-    queue('title_definition', { data: null, error: { message: 'upsert failed' } });
+  it('stops and reports when the existing-rows lookup fails, without inserting, updating or deleting', async () => {
+    queue('title_definition', { data: null, error: { message: 'select failed' } });
 
     const { error } = await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
       { difficultyLevel: 1, titleName: 'Story Apprentice' },
       { difficultyLevel: 2, titleName: null },
     ]);
 
-    expect(error).toEqual({ message: 'upsert failed' });
+    expect(error).toEqual({ message: 'select failed' });
+    expect(state.inserts).toHaveLength(0);
+    expect(state.deletes).toHaveLength(0);
+  });
+
+  it('stops and reports when the insert fails, without running the delete', async () => {
+    queue('title_definition', { data: [], error: null });
+    queue('title_definition', { data: null, error: { message: 'insert failed' } });
+
+    const { error } = await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
+      { difficultyLevel: 1, titleName: 'Story Apprentice' },
+      { difficultyLevel: 2, titleName: null },
+    ]);
+
+    expect(error).toEqual({ message: 'insert failed' });
+    expect(state.deletes).toHaveLength(0);
+  });
+
+  it('stops and reports when the update fails, without running the delete', async () => {
+    queue('title_definition', { data: [{ title_definition_id: 'existing-id-1', difficulty_level: 1 }], error: null });
+    queue('title_definition', { data: null, error: { message: 'update failed' } });
+
+    const { error } = await saveTitleLadder(makeSupabase(), 'TEST_CATALOG', [
+      { difficultyLevel: 1, titleName: 'Renamed' },
+      { difficultyLevel: 2, titleName: null },
+    ]);
+
+    expect(error).toEqual({ message: 'update failed' });
     expect(state.deletes).toHaveLength(0);
   });
 });
 
 describe('listTitleNames', () => {
-  beforeEach(() => {
-    state.queues = {};
-    state.upserts = [];
-    state.deletes = [];
-    state.orders = [];
-  });
+  beforeEach(resetState);
 
   it('de-duplicates names used by more than one catalog', async () => {
     queue('title_definition', {

--- a/app/instructor/assembled-quizzes/[quizId]/page.tsx
+++ b/app/instructor/assembled-quizzes/[quizId]/page.tsx
@@ -9,6 +9,7 @@ import { ConfirmModal } from '../../../../components/ConfirmModal';
 import { QuestionFormModal } from '../../../../components/QuestionFormModal';
 import { PromptFormModal } from '../../../../components/PromptFormModal';
 import { RatingPromptModal } from '../../../../components/RatingPromptModal';
+import { TitleLadderModal } from '../../../../components/TitleLadderModal';
 import {
   createAndPickQuestionForQuiz,
   createAndPickUserStoryForQuiz,
@@ -54,6 +55,14 @@ const LEVEL_LABEL: Record<1 | 2 | 3, string> = { 1: 'Easy', 2: 'Medium', 3: 'Har
  * /api/instructor/quizzes/{activityType}). Per catalog, not per quiz — the rubric is a property of
  * the catalog itself, not of any one quiz that composes it, since more than one quiz can compose
  * the same catalog (see activity_type.rating_prompt's own comment in supabase/schema.sql).
+ *
+ * "Mastery Titles" (below "From catalogs", for either grading kind) is the same per-catalog-row
+ * shape, moved here from app/instructor/quizzes/[activityType]/page.tsx's own inline section — a
+ * title ladder is still a property of the catalog (title_definition keys on activity_type), not of
+ * the quiz, so PUT /api/instructor/quizzes/{activityType}/titles is unchanged; only where the
+ * instructor opens the editor from moved. See components/TitleLadderModal.tsx for why it fetches
+ * its own initial ladder on open rather than reading a value already loaded here, unlike the
+ * rubric's initialValue.
  */
 export default function AssembledQuizDetailPage({ params }: { params: { quizId: string } }) {
   const { token, loading, authorized } = useRequireRole('instructor');
@@ -76,6 +85,7 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
   const [addError, setAddError] = useState('');
   const [catalogToRemove, setCatalogToRemove] = useState<QuizCatalogComposition | null>(null);
   const [ratingPromptTarget, setRatingPromptTarget] = useState<QuizCatalogComposition | null>(null);
+  const [titleLadderTarget, setTitleLadderTarget] = useState<QuizCatalogComposition | null>(null);
   const [showDeleteQuiz, setShowDeleteQuiz] = useState(false);
   const [showAddQuestionsModal, setShowAddQuestionsModal] = useState(false);
   const [showCreateItemModal, setShowCreateItemModal] = useState(false);
@@ -394,6 +404,33 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
               )}
             </div>
 
+            {catalogs.length > 0 ? (
+              <>
+                <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">Mastery Titles</p>
+                <p className="mb-4 text-xs font-semibold text-gray-500">
+                  What a student is called once they pass each level of a catalog. Set per catalog — more than
+                  one quiz can compose the same catalog, so its ladder isn&apos;t specific to this quiz alone.
+                </p>
+                <div className="mb-6 space-y-3">
+                  {catalogs.map((catalog) => (
+                    <div
+                      key={catalog.activityType}
+                      className="flex flex-wrap items-center justify-between gap-3 rounded-brand-lg border border-gray-100 bg-gray-50 p-4"
+                    >
+                      <p className="min-w-0 flex-1 font-semibold text-brand-navy">{catalog.name}</p>
+                      <button
+                        type="button"
+                        onClick={() => setTitleLadderTarget(catalog)}
+                        className="flex-none rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-extrabold text-gray-600 transition hover:border-brand-purple hover:text-brand-purple"
+                      >
+                        Edit titles
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </>
+            ) : null}
+
             {quiz.gradingKind === 'llm-graded' && catalogs.length > 0 ? (
               <>
                 <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">Grading Rubrics</p>
@@ -621,6 +658,19 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
           initialValue={ratingPromptTarget.ratingPrompt ?? ''}
           onCancel={() => setRatingPromptTarget(null)}
           onSave={handleSaveCatalogRatingPrompt}
+        />
+      ) : null}
+
+      {titleLadderTarget && token ? (
+        <TitleLadderModal
+          token={token}
+          activityType={titleLadderTarget.activityType}
+          catalogName={titleLadderTarget.name}
+          onClose={() => setTitleLadderTarget(null)}
+          onSaved={() => {
+            setTitleLadderTarget(null);
+            showToast('Mastery titles saved.');
+          }}
         />
       ) : null}
 

--- a/app/instructor/quizzes/[activityType]/page.tsx
+++ b/app/instructor/quizzes/[activityType]/page.tsx
@@ -13,18 +13,9 @@ import { RatingPromptModal } from '../../../../components/RatingPromptModal';
 import {
   deleteCatalog,
   loadQuizDetail,
-  loadTitleNames,
-  saveTitleLadder,
   updateRatingPrompt,
   type QuizMeta,
 } from '../../../../lib/quizClient';
-import type { StoredTitleRung } from '../../../../lib/titleAuthoringQueries';
-import {
-  emptyTitleLadderDraft,
-  TitleLadderFields,
-  titleLadderDraftToRungs,
-  type TitleLadderDraft,
-} from '../../../../components/TitleLadderFields';
 import { createQuestion, updateQuestion } from '../../../../lib/sessionClient';
 import {
   createUserStory,
@@ -40,12 +31,6 @@ import { useRequireRole } from '../../../../lib/useRequireRole';
 
 const LEVEL_OPTIONS = ['all', 1, 2, 3] as const;
 
-/** The stored ladder (only levels that have a title) widened into a full per-level form draft. */
-function titleLadderToDraft(titles: StoredTitleRung[]): TitleLadderDraft {
-  const draft = emptyTitleLadderDraft();
-  for (const rung of titles) draft[rung.difficultyLevel] = rung.titleName;
-  return draft;
-}
 const HIGHLIGHT_MS = 4000;
 const TOAST_MS = 3200;
 
@@ -121,11 +106,6 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
   const [showDeleteCatalog, setShowDeleteCatalog] = useState(false);
   const [ratingPromptModalOpen, setRatingPromptModalOpen] = useState(false);
 
-  const [titleDraft, setTitleDraft] = useState<TitleLadderDraft>(emptyTitleLadderDraft);
-  const [titleSuggestions, setTitleSuggestions] = useState<string[]>([]);
-  const [savingTitles, setSavingTitles] = useState(false);
-  const [titleError, setTitleError] = useState('');
-
   useEffect(() => {
     if (!token) return;
     let cancelled = false;
@@ -140,7 +120,6 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
         setQuiz(result.data.quiz);
         setQuestions(result.data.questions);
         setPrompts(result.data.userStories);
-        setTitleDraft(titleLadderToDraft(result.data.titles));
       } else if (result.status === 404) {
         setNotFound(true);
       } else if (result.status === 403) {
@@ -154,38 +133,6 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
       cancelled = true;
     };
   }, [token, params.activityType, retryCount]);
-
-  // Suggestions only — a failure leaves the title fields working as plain text inputs, so it is
-  // deliberately not surfaced as a page error.
-  useEffect(() => {
-    if (!token) return;
-    let cancelled = false;
-    loadTitleNames(token).then((result) => {
-      if (!cancelled && result.ok) setTitleSuggestions(result.data.titleNames);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [token]);
-
-  async function handleSaveTitles() {
-    if (!token) return;
-    setSavingTitles(true);
-    setTitleError('');
-
-    const result = await saveTitleLadder(token, params.activityType, titleLadderDraftToRungs(titleDraft));
-    setSavingTitles(false);
-
-    if (!result.ok) {
-      setTitleError(result.error);
-      return;
-    }
-
-    // Re-seed from what the server actually stored rather than keeping the local draft — the two
-    // can differ (trimming, a rung cleared to null), and the stored version is the truth.
-    setTitleDraft(titleLadderToDraft(result.data.titles));
-    setToastMessage('Mastery titles saved.');
-  }
 
   if (loading || !authorized) return null;
   if (!token || !profile) return null;
@@ -451,54 +398,6 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
                 </button>
               </div>
             ) : null}
-
-            {/* Catalog-level metadata, so it sits above the level filter rather than inside the
-                filtered list — the ladder describes all three levels at once and filtering to one
-                level must not hide the other two rungs. Read-only until the same Edit toggle that
-                governs questions and prompts is on. */}
-            <div className="mb-6 mt-6 rounded-brand-lg border border-gray-100 bg-gray-50 p-5">
-              <p className="text-xs font-bold uppercase tracking-widest text-gray-400">Mastery titles</p>
-
-              {editMode ? (
-                <>
-                  <p className="mb-3 mt-1.5 text-xs font-semibold text-gray-500">
-                    What a student is called once they pass each level. Start typing to reuse a title
-                    that already exists. Students who already passed a level get its title as soon as
-                    you save.
-                  </p>
-                  <TitleLadderFields
-                    draft={titleDraft}
-                    onChange={(lvl, value) => setTitleDraft((current) => ({ ...current, [lvl]: value }))}
-                    suggestions={titleSuggestions}
-                    disabled={savingTitles}
-                  />
-                  {titleError ? <p className="mt-3 text-xs font-bold text-brand-danger">{titleError}</p> : null}
-                  <button
-                    type="button"
-                    onClick={handleSaveTitles}
-                    disabled={savingTitles}
-                    className="mt-4 rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:opacity-60"
-                  >
-                    {savingTitles ? 'Saving…' : 'Save titles'}
-                  </button>
-                </>
-              ) : (
-                <div className="mt-3 grid gap-2 sm:grid-cols-3">
-                  {LEVEL_OPTIONS.filter((lvl): lvl is 1 | 2 | 3 => lvl !== 'all').map((lvl) => (
-                    <div key={lvl} className="rounded-brand-md border border-gray-200 bg-white px-3.5 py-2.5">
-                      <p className="text-xs font-bold uppercase tracking-wide text-gray-400">{LEVEL_LABEL[lvl]}</p>
-                      <p
-                        className={`mt-0.5 text-sm font-extrabold ${
-                          titleDraft[lvl] ? 'text-brand-navy' : 'text-gray-400'
-                        }`}
-                      >
-                        {titleDraft[lvl] || 'No title yet'}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
 
             <div className="mb-6 mt-6 flex flex-wrap gap-1.5">
               {LEVEL_OPTIONS.map((lvl) => (

--- a/components/QuestionFormModal.tsx
+++ b/components/QuestionFormModal.tsx
@@ -32,6 +32,13 @@ const FOCUSABLE_SELECTOR = 'button, [href], input, select, textarea, [tabindex]:
  * (the triggering Edit/New Question button) on close; Escape closes; Tab is trapped inside the
  * panel while it's open, since this is a true modal — nothing behind it should be reachable by
  * keyboard.
+ *
+ * GitHub #464: a successful save only auto-closes in 'edit' mode. In 'add' mode the modal stays
+ * open — each save is already a real, persisted write via onSave, so there is nothing to lose by
+ * letting the instructor add another right away — and the form resets to a blank question (quiz/
+ * level selection stays as-is, since a batch of questions usually shares both). addedQuestions
+ * tracks this session's own saves so the instructor can see them without the catalog's real list
+ * behind this modal's full-screen overlay.
  */
 export function QuestionFormModal({
   mode,
@@ -77,9 +84,17 @@ export function QuestionFormModal({
   const [errors, setErrors] = useState<FormErrors>({});
   const [isSaving, setIsSaving] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  // GitHub #464: in 'add' mode, a successful save no longer closes the modal — an instructor
+  // adding a batch of questions to a catalog shouldn't have to reopen it after every single one.
+  // addedQuestions is this modal instance's own running list (cleared on close, not persisted —
+  // the parent's `questions` state, updated via onSave below, is what actually persists each one)
+  // so the instructor can see what they've already added without the list being hidden behind
+  // this modal's own full-screen overlay.
+  const [addedQuestions, setAddedQuestions] = useState<{ id: string; questionText: string; level: 1 | 2 | 3 }[]>([]);
 
   const panelRef = useRef<HTMLDivElement>(null);
   const firstFieldRef = useRef<HTMLSelectElement>(null);
+  const questionTextRef = useRef<HTMLTextAreaElement>(null);
   const previouslyFocusedRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
@@ -166,11 +181,26 @@ export function QuestionFormModal({
     const result = await onSave(question);
     setIsSaving(false);
 
-    if (result.ok) {
-      close();
-    } else {
+    if (!result.ok) {
       setSubmitError(result.error);
+      return;
     }
+
+    // Editing is a single, targeted action on one existing question — closing afterward is the
+    // unsurprising behavior an edit form usually has. Adding is the repeated, batch-y flow #464
+    // is about, so it stays open instead; see addedQuestions' own comment above.
+    if (mode === 'edit') {
+      close();
+      return;
+    }
+
+    setAddedQuestions((current) => [...current, { id: questionId, questionText: question.questionText, level }]);
+    setQuestionText('');
+    setOptionTexts(EMPTY_OPTIONS);
+    setCorrectIndex(null);
+    setExplanation('');
+    setErrors({});
+    questionTextRef.current?.focus();
   }
 
   const isEdit = mode === 'edit';
@@ -247,9 +277,33 @@ export function QuestionFormModal({
             </div>
           </div>
 
+          {mode === 'add' && addedQuestions.length > 0 ? (
+            <div
+              role="status"
+              className="mb-4 rounded-brand-md border border-brand-teal/40 bg-brand-teal/10 p-3"
+            >
+              <p className="flex items-center gap-2 text-xs font-bold text-brand-teal-dark">
+                <span className="flex h-4 w-4 flex-none items-center justify-center rounded-full bg-brand-teal text-brand-teal-ink">
+                  <svg viewBox="0 0 24 24" className="h-2.5 w-2.5" fill="none" stroke="currentColor" strokeWidth={3} strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M20 6 9 17l-5-5" />
+                  </svg>
+                </span>
+                {addedQuestions.length} question{addedQuestions.length === 1 ? '' : 's'} added this session — keep going, or press Done below.
+              </p>
+              <ul className="mt-2 max-h-24 space-y-1 overflow-y-auto text-xs font-semibold text-brand-ink-muted">
+                {addedQuestions.map((added) => (
+                  <li key={added.id} className="truncate">
+                    · {added.questionText}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+
           <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
             Question Prompt
             <textarea
+              ref={questionTextRef}
               value={questionText}
               onChange={(event) => setQuestionText(event.target.value)}
               rows={3}
@@ -299,7 +353,9 @@ export function QuestionFormModal({
               disabled={isSaving}
               className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white disabled:opacity-60"
             >
-              Cancel
+              {/* Once at least one question has been saved this session, "Cancel" would wrongly
+                  imply it could be undone — every save so far is already a real, persisted write. */}
+              {addedQuestions.length > 0 ? 'Done' : 'Cancel'}
             </button>
             <button
               type="submit"

--- a/components/TitleLadderModal.tsx
+++ b/components/TitleLadderModal.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { loadQuizDetail, loadTitleNames, saveTitleLadder } from '../lib/quizClient';
+import type { StoredTitleRung } from '../lib/titleAuthoringQueries';
+import { emptyTitleLadderDraft, TitleLadderFields, titleLadderDraftToRungs, type TitleLadderDraft } from './TitleLadderFields';
+import { useModalDismiss } from './useModalDismiss';
+
+/** The stored ladder (only levels that have a title) widened into a full per-level form draft. */
+function titleLadderToDraft(titles: StoredTitleRung[]): TitleLadderDraft {
+  const draft = emptyTitleLadderDraft();
+  for (const rung of titles) draft[rung.difficultyLevel] = rung.titleName;
+  return draft;
+}
+
+/**
+ * One catalog's mastery-title ladder, editable from wherever a catalog is reached — moved here
+ * from app/instructor/quizzes/[activityType]/page.tsx's own inline section onto
+ * app/instructor/assembled-quizzes/[quizId]/page.tsx instead, so titles are set from the quiz the
+ * instructor is actually assembling for a course, one modal per linked catalog. Titles still
+ * belong to the catalog (activity_type), not the quiz — PUT /api/instructor/quizzes/{activityType}/
+ * titles is unchanged — this only relocates where the instructor opens that editor from.
+ *
+ * Unlike RatingPromptModal, which receives its initialValue from data the parent already loaded
+ * (catalog.ratingPrompt lives on QuizCatalogComposition), there is no per-catalog title preview
+ * loaded on the quiz page — fetching every linked catalog's ladder up front would mean one
+ * GET /api/instructor/quizzes/{activityType} round trip per catalog before the page could render
+ * anything. So this modal fetches its own initial ladder (plus the cross-catalog title-name
+ * suggestion list) the moment it opens, the same "fetch once you actually need it" reasoning
+ * QuestionFormModal and PromptFormModal already follow for their own option/level pickers.
+ */
+export function TitleLadderModal({
+  token,
+  activityType,
+  catalogName,
+  onClose,
+  onSaved,
+}: {
+  token: string;
+  activityType: string;
+  catalogName: string;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [draft, setDraft] = useState<TitleLadderDraft | null>(null);
+  const [suggestions, setSuggestions] = useState<string[]>([]);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+
+  // No firstFieldRef target: the form's fields don't exist until the ladder finishes loading, so
+  // there is nothing stable to focus at mount time the way every other modal here focuses an
+  // always-present first field.
+  const { panelRef, requestClose } = useModalDismiss<HTMLDivElement>({
+    onClose,
+    isBlocked: saving,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([loadQuizDetail(token, activityType), loadTitleNames(token)]).then(([detailResult, namesResult]) => {
+      if (cancelled) return;
+      if (!detailResult.ok) {
+        setLoadFailed(true);
+        return;
+      }
+      setDraft(titleLadderToDraft(detailResult.data.titles));
+      if (namesResult.ok) setSuggestions(namesResult.data.titleNames);
+      // A failed suggestions fetch leaves the fields working as plain text inputs — same
+      // "suggestions only" tolerance the catalog page's own version of this had.
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [token, activityType]);
+
+  async function handleSave() {
+    if (!draft || saving) return;
+
+    setSaving(true);
+    setError('');
+
+    const result = await saveTitleLadder(token, activityType, titleLadderDraftToRungs(draft));
+    setSaving(false);
+
+    if (!result.ok) {
+      setError(result.error);
+      return;
+    }
+
+    onSaved();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-4 py-8"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) requestClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="title-ladder-modal-title"
+        className="max-h-[90vh] w-full max-w-md overflow-y-auto rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
+      >
+        <div className="mb-5 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wide text-brand-gold">{catalogName}</p>
+            <h2 id="title-ladder-modal-title" className="mt-1 text-xl font-extrabold text-white">
+              Mastery Titles
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={requestClose}
+            disabled={saving}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-full border border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted transition hover:text-white disabled:opacity-60"
+          >
+            <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        {loadFailed ? (
+          <p className="text-sm font-semibold text-brand-danger-light">Could not load this catalog&apos;s titles.</p>
+        ) : !draft ? (
+          <p className="text-sm font-semibold text-brand-ink-muted">Loading…</p>
+        ) : (
+          <>
+            <p className="mb-4 text-xs font-semibold text-brand-ink-muted">
+              What a student is called once they pass each level. Start typing to reuse a title that already
+              exists. Students who already passed a level get its title as soon as you save.
+            </p>
+            <TitleLadderFields
+              draft={draft}
+              onChange={(lvl, value) => setDraft((current) => (current ? { ...current, [lvl]: value } : current))}
+              suggestions={suggestions}
+              disabled={saving}
+              tone="dark"
+            />
+            {error ? <p className="mt-3 text-xs font-bold text-brand-danger">{error}</p> : null}
+
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                type="button"
+                onClick={requestClose}
+                disabled={saving}
+                className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSave}
+                disabled={saving}
+                className="rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving ? 'Saving…' : 'Save titles'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/titleAuthoringQueries.ts
+++ b/lib/titleAuthoringQueries.ts
@@ -44,18 +44,25 @@ export async function loadTitleLadder(
 }
 
 /**
- * Writes one catalog's ladder: rungs with a name are upserted, rungs explicitly cleared (titleName
- * null) are deleted. Levels absent from `rungs` are left exactly as they are, so a caller can send
- * a single rung without wiping the other two.
+ * Writes one catalog's ladder: rungs with a name are inserted or updated (see below), rungs
+ * explicitly cleared (titleName null) are deleted. Levels absent from `rungs` are left exactly as
+ * they are, so a caller can send a single rung without wiping the other two.
  *
- * The upsert keys on uq_title_definition_activity_level rather than on title_definition_id, which
- * is what makes "save the form again" idempotent: editing a title updates the existing row instead
- * of inserting a second one for the same level. That identity is load-bearing beyond tidiness —
- * "user".selected_title_definition_id points at these rows, so replacing a row on every save would
- * silently un-wear the title for every student wearing it (the FK is ON DELETE SET NULL).
+ * Editing an existing rung must preserve its title_definition_id rather than replace the row,
+ * because "user".selected_title_definition_id points at it — a student already wearing the title
+ * would silently lose it (or, worse, the save itself would fail) otherwise.
  *
- * A title_definition_id is generated per inserted row and ignored on conflict; Postgres keeps the
- * existing id, which is exactly the behaviour the paragraph above depends on.
+ * This used to be a single upsert keyed on uq_title_definition_activity_level, generating a fresh
+ * title_definition_id for every row and relying on Postgres to "ignore it on conflict" — that
+ * belief was wrong. `ON CONFLICT (activity_type, difficulty_level) DO UPDATE SET ...` puts every
+ * column present in the payload into the SET clause except the conflict target itself, and
+ * title_definition_id isn't part of that target, so it WAS being overwritten with the freshly
+ * generated id on every save. That's an UPDATE to the primary key of a row "user" may already
+ * reference, which fk_user_title_definition (ON DELETE SET NULL, but no ON UPDATE clause)
+ * correctly rejects — "update or delete on table title_definition violates foreign key constraint
+ * fk_user_title_definition" the moment any student had already selected that title. Splitting into
+ * an explicit update (existing rows, id untouched) and insert (new rows, fresh id) avoids the
+ * primary key ever moving for a row that already exists.
  */
 export async function saveTitleLadder(
   supabase: SupabaseClient,
@@ -66,19 +73,52 @@ export async function saveTitleLadder(
   const cleared = rungs.filter((rung) => rung.titleName === null).map((rung) => rung.difficultyLevel);
 
   if (filled.length > 0) {
-    const { error } = await supabase
+    const { data: existingData, error: existingError } = await supabase
       .from('title_definition')
-      .upsert(
-        filled.map((rung) => ({
+      .select('title_definition_id, difficulty_level')
+      .eq('activity_type', activityType)
+      .in(
+        'difficulty_level',
+        filled.map((rung) => rung.difficultyLevel),
+      );
+
+    if (existingError) return { error: existingError };
+
+    const existingIdByLevel = new Map(
+      ((existingData ?? []) as { title_definition_id: string; difficulty_level: number }[]).map((row) => [
+        row.difficulty_level,
+        row.title_definition_id,
+      ]),
+    );
+
+    const toInsert = filled.filter((rung) => !existingIdByLevel.has(rung.difficultyLevel));
+    const toUpdate = filled.filter((rung) => existingIdByLevel.has(rung.difficultyLevel));
+
+    if (toInsert.length > 0) {
+      const { error } = await supabase.from('title_definition').insert(
+        toInsert.map((rung) => ({
           title_definition_id: crypto.randomUUID(),
           activity_type: activityType,
           difficulty_level: rung.difficultyLevel,
           title_name: rung.titleName as string,
         })),
-        { onConflict: 'activity_type,difficulty_level' },
       );
 
-    if (error) return { error };
+      if (error) return { error };
+    }
+
+    // One statement per row rather than a batched call: supabase-js/PostgREST has no bulk-update-
+    // by-differing-values primitive (that's what upsert is for, and upsert is exactly the thing
+    // this function stopped using) — a handful of rows at most (MAX_DIFFICULTY_LEVEL is 3), so the
+    // extra round trips are not a real cost.
+    for (const rung of toUpdate) {
+      const { error } = await supabase
+        .from('title_definition')
+        .update({ title_name: rung.titleName as string })
+        .eq('title_definition_id', existingIdByLevel.get(rung.difficultyLevel));
+
+      if (error) return { error };
+    }
   }
 
   if (cleared.length > 0) {


### PR DESCRIPTION

- QuestionFormModal no longer closes after adding a question — the form resets and stays open so an instructor can add several in a row, with a running "added this session" list and the close button relabeling to "Done" once at least one has been saved.
- saveTitleLadder no longer regenerates title_definition_id on every save. The old single upsert put every payload column (including the id) into the ON CONFLICT DO UPDATE SET clause, so re-saving an existing title tried to change its primary key — which fk_user_title_definition correctly rejected the moment a student had already selected that title. Now split into an explicit insert (new rungs) and update (existing rungs, id untouched).
- Mastery-title editing moved from the Question Catalog detail page to the Quiz detail page (one "Edit titles" button per linked catalog, via new components/TitleLadderModal.tsx) — titles are still stored per catalog, only where the editor opens from changed.