### PR TITLE
Add an "All" scope to the full leaderboard and make it genuinely global

### DIFF
--- a/__tests__/api/leaderboard.test.ts
+++ b/__tests__/api/leaderboard.test.ts
@@ -70,10 +70,10 @@ describe('GET /api/leaderboard', () => {
     expect(response.status).toBe(401);
   });
 
-  // No courseId anywhere in this route — the caller's own enrolled courses (derived from their
-  // token) decide the roster, unlike GET /api/courses/{courseId}/leaderboard.
-  it('returns 200 with an empty list for a caller enrolled in nothing', async () => {
-    queue('student_course', { data: [], error: null }); // getEnrolledCourseIds
+  // The roster doesn't depend on the caller at all — every student account is ranked regardless
+  // of who's asking, unlike GET /api/courses/{courseId}/leaderboard.
+  it('returns 200 with an empty list when there are no student accounts at all', async () => {
+    queue('user', { data: [], error: null });
 
     const response = await GET(req());
     const body = await response.json();
@@ -82,12 +82,11 @@ describe('GET /api/leaderboard', () => {
     expect(body.entries).toEqual([]);
   });
 
-  it('returns the ranked, cross-course roster for an enrolled caller', async () => {
-    queue('student_course', { data: [{ course_id: 'course-a' }], error: null }); // getEnrolledCourseIds
-    queue('student_course', {
-      data: [{ user_id: 'student-1', student: { username: 'ada', avatar_url: null, role: 'student' } }],
+  it('returns every student account ranked, not just ones who share a course with the caller', async () => {
+    queue('user', {
+      data: [{ user_id: 'student-1', username: 'ada', avatar_url: null, selected_title: null }],
       error: null,
-    }); // roster
+    });
     queue('session_log', {
       data: [
         {
@@ -109,8 +108,8 @@ describe('GET /api/leaderboard', () => {
     expect(body.entries).toEqual([{ rank: 1, studentId: 'student-1', username: 'ada', avatarUrl: null, title: null, points: 100, streak: 1 }]);
   });
 
-  it('returns 500 when the enrolled-courses lookup fails', async () => {
-    queue('student_course', { data: null, error: { message: 'db down' } });
+  it('returns 500 when the roster query fails', async () => {
+    queue('user', { data: null, error: { message: 'db down' } });
 
     const response = await GET(req());
     expect(response.status).toBe(500);

--- a/__tests__/lib/leaderboardQueries.test.ts
+++ b/__tests__/lib/leaderboardQueries.test.ts
@@ -341,10 +341,13 @@ describe('computeCourseLeaderboard', () => {
   });
 });
 
-const VIEWER_ID = 'viewer-1';
-
-function enrolledCourseRow(courseId: string) {
-  return { course_id: courseId };
+function globalUserRow(userId: string, username: string, avatarUrl: string | null = null, selectedTitle: string | null = null) {
+  return {
+    user_id: userId,
+    username,
+    avatar_url: avatarUrl,
+    selected_title: selectedTitle ? { title_name: selectedTitle } : null,
+  };
 }
 
 describe('computeGlobalLeaderboard', () => {
@@ -354,105 +357,77 @@ describe('computeGlobalLeaderboard', () => {
     state.filters = [];
   });
 
-  it('returns an empty list, without touching the roster or session tables, when the viewer is enrolled nowhere', async () => {
-    queue('student_course', { data: [], error: null }); // getEnrolledCourseIds
-
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
-
-    expect(result).toEqual({ data: [], error: null });
-    expect(state.tables).toEqual(['student_course']);
-  });
-
-  // GitHub #432 follow-up: the whole point of this function — sums a student's score across
-  // every course they're in, not just one, unlike computeCourseLeaderboard's course-scoped sum.
-  it("sums a student's score across every course they're enrolled in, not just one", async () => {
-    queue('student_course', { data: [enrolledCourseRow('course-a'), enrolledCourseRow('course-b')], error: null }); // getEnrolledCourseIds
-    queue('student_course', { data: [rosterRow(VIEWER_ID, 'ada')], error: null }); // roster across course-a/course-b
+  // Confirmed deliberately (not a privacy oversight): a global leaderboard ranks every student
+  // account, not just ones who share a course with the caller — see the function's own doc for
+  // why an earlier, shared-course-scoped version was replaced.
+  it('returns every student account, regardless of whether they share a course with anyone', async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada'), globalUserRow('stu-2', 'bea')], error: null });
     queue('session_log', {
-      data: [
-        sessionRow(VIEWER_ID, 'CATALOG_IN_COURSE_A', 1, 50),
-        sessionRow(VIEWER_ID, 'CATALOG_IN_COURSE_B', 1, 20),
-      ],
+      data: [sessionRow('stu-1', 'SOME_CATALOG', 1, 50), sessionRow('stu-2', 'UNRELATED_CATALOG', 1, 20)],
       error: null,
     });
 
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
+    const result = await computeGlobalLeaderboard(makeSupabase());
 
-    expect(result.data).toEqual([{ rank: 1, studentId: VIEWER_ID, username: 'ada', avatarUrl: null, title: null, points: 70, streak: 0 }]);
-  });
-
-  // The roster query spans every one of the viewer's courses via .in(), so the same classmate
-  // enrolled in two of them must be counted (and ranked) once, not twice.
-  it('deduplicates a classmate enrolled in more than one of the viewer\'s courses', async () => {
-    queue('student_course', { data: [enrolledCourseRow('course-a'), enrolledCourseRow('course-b')], error: null });
-    queue('student_course', {
-      data: [rosterRow('stu-1', 'ada'), rosterRow('stu-1', 'ada')], // same student surfaced by both courses' rows
-      error: null,
-    });
-    queue('session_log', { data: [sessionRow('stu-1', 'SOME_CATALOG', 1, 30)], error: null });
-
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
-
-    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, title: null, points: 30, streak: 0 }]);
-  });
-
-  // The defining difference from computeCourseLeaderboard: no activity_type filter at all, so a
-  // classmate who shares only one of several courses with the viewer still shows their FULL
-  // cross-course total here, not just what they earned in the shared course.
-  it("does not filter a classmate's points to only the course they share with the viewer", async () => {
-    queue('student_course', { data: [enrolledCourseRow('course-a')], error: null });
-    queue('student_course', { data: [rosterRow('stu-1', 'ada')], error: null });
-    queue('session_log', {
-      data: [
-        sessionRow('stu-1', 'SHARED_COURSE_CATALOG', 1, 10),
-        // Earned in some other course the viewer isn't part of at all.
-        sessionRow('stu-1', 'UNRELATED_COURSE_CATALOG', 1, 500),
-      ],
-      error: null,
-    });
-
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
-
-    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, title: null, points: 510, streak: 0 }]);
-  });
-
-  it('scopes the roster query to every one of the viewer\'s enrolled courses', async () => {
-    queue('student_course', { data: [enrolledCourseRow('course-a'), enrolledCourseRow('course-b')], error: null });
-    queue('student_course', { data: [], error: null });
-
-    await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
-
-    expect(state.filters).toEqual([
-      { table: 'student_course', column: 'user_id', value: VIEWER_ID },
-      { table: 'student_course', column: 'course_id', value: ['course-a', 'course-b'] },
-      { table: 'student_course', column: 'student.role', value: 'student' },
+    expect(result.data).toEqual([
+      { rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, title: null, points: 50, streak: 0 },
+      { rank: 2, studentId: 'stu-2', username: 'bea', avatarUrl: null, title: null, points: 20, streak: 0 },
     ]);
   });
 
-  it('returns the error and no data when the enrolled-courses lookup fails', async () => {
-    queue('student_course', { data: null, error: { message: 'db down' } });
+  it("sums a student's score across every course they're in, not just one", async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada')], error: null });
+    queue('session_log', {
+      data: [sessionRow('stu-1', 'CATALOG_IN_COURSE_A', 1, 50), sessionRow('stu-1', 'CATALOG_IN_COURSE_B', 1, 20)],
+      error: null,
+    });
 
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
+    const result = await computeGlobalLeaderboard(makeSupabase());
 
-    expect(result).toEqual({ data: null, error: { message: 'db down' } });
-    expect(state.tables).toEqual(['student_course']);
+    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, title: null, points: 70, streak: 0 }]);
+  });
+
+  it('includes a student with zero completed sessions at 0 points, not omitted', async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'newcomer')], error: null });
+    queue('session_log', { data: [], error: null });
+
+    const result = await computeGlobalLeaderboard(makeSupabase());
+
+    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'newcomer', avatarUrl: null, title: null, points: 0, streak: 0 }]);
+  });
+
+  it('scopes the roster query to student accounts only', async () => {
+    queue('user', { data: [], error: null });
+
+    await computeGlobalLeaderboard(makeSupabase());
+
+    expect(state.filters).toEqual([{ table: 'user', column: 'role', value: 'student' }]);
+    expect(state.tables).toEqual(['user']);
+  });
+
+  it('returns an empty list, without touching session_log, when there are no student accounts at all', async () => {
+    queue('user', { data: [], error: null });
+
+    const result = await computeGlobalLeaderboard(makeSupabase());
+
+    expect(result).toEqual({ data: [], error: null });
+    expect(state.tables).toEqual(['user']);
   });
 
   it('returns the error and no data when the roster query fails', async () => {
-    queue('student_course', { data: [enrolledCourseRow('course-a')], error: null });
-    queue('student_course', { data: null, error: { message: 'db down' } });
+    queue('user', { data: null, error: { message: 'db down' } });
 
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
+    const result = await computeGlobalLeaderboard(makeSupabase());
 
     expect(result).toEqual({ data: null, error: { message: 'db down' } });
+    expect(state.tables).toEqual(['user']);
   });
 
   it('returns the error and no data when the session query fails', async () => {
-    queue('student_course', { data: [enrolledCourseRow('course-a')], error: null });
-    queue('student_course', { data: [rosterRow('stu-1', 'ada')], error: null });
+    queue('user', { data: [globalUserRow('stu-1', 'ada')], error: null });
     queue('session_log', { data: null, error: { message: 'db down' } });
 
-    const result = await computeGlobalLeaderboard(makeSupabase(), VIEWER_ID);
+    const result = await computeGlobalLeaderboard(makeSupabase());
 
     expect(result).toEqual({ data: null, error: { message: 'db down' } });
   });

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -7,19 +7,15 @@ function getToken(request: Request): string | null {
 }
 
 /**
- * GET /api/leaderboard — the dashboard's global leaderboard (GitHub #432 follow-up), the
- * counterpart to GET /api/courses/{courseId}/leaderboard that ranks by total score across every
- * course the caller shares with the ranked students, not one course's own points. See
- * computeGlobalLeaderboard (lib/leaderboardQueries.ts) for why "global" stops at "shares a course
- * with the caller" rather than every user in the app — the same enrollment-based disclosure
- * boundary GET /api/courses/{courseId}/leaderboard and GET /api/students/{id}/public-profile use.
+ * GET /api/leaderboard — the global leaderboard: every student account in the app, ranked by
+ * total score across every course they're in. See computeGlobalLeaderboard's own doc
+ * (lib/leaderboardQueries.ts) for why this is a deliberate exception to the shared-course
+ * disclosure boundary GET /api/courses/{courseId}/leaderboard and
+ * GET /api/students/{id}/public-profile otherwise enforce — a specific course's own leaderboard
+ * is still the shared-roster-only view; this route is the intentionally different one.
  *
- * No courseId in this route at all — that absence is the point: the caller's own enrolled
- * courses (derived from their token, never a request param) decide the roster.
- *
- * A caller enrolled in nothing gets a normal 200 with an empty list, not a 403/404 — same
- * reasoning as computeCourseLeaderboard's "course exists but has nobody enrolled" case: there is
- * no error here, just nothing to rank yet.
+ * Any authenticated user gets the same ranking back — the roster doesn't depend on the caller at
+ * all, only a valid token is required to call this at all, same as every other protected route.
  */
 export async function GET(request: Request) {
   const token = getToken(request);
@@ -34,7 +30,7 @@ export async function GET(request: Request) {
   } = await supabase.auth.getUser(token);
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
-  const { data, error } = await computeGlobalLeaderboard(supabase, user.id);
+  const { data, error } = await computeGlobalLeaderboard(supabase);
   if (error || !data) {
     return Response.json({ error: error?.message ?? 'Could not load leaderboard.' }, { status: 500 });
   }

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -4,7 +4,10 @@ import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
 import { AppShell } from "../../components/AppShell";
-import { LeaderboardCourseSwitcher } from "../../components/LeaderboardCourseSwitcher";
+import {
+  ALL_COURSES_SCOPE,
+  LeaderboardCourseSwitcher,
+} from "../../components/LeaderboardCourseSwitcher";
 import { LeaderboardSkeleton } from "../../components/LeaderboardSkeleton";
 import {
   LeaderboardTable,
@@ -12,7 +15,9 @@ import {
 } from "../../components/LeaderboardTable";
 import { Pagination } from "../../components/Pagination";
 import {
+  GLOBAL_LEADERBOARD_KEY,
   loadCourseLeaderboard,
+  loadGlobalLeaderboard,
   loadMyLeaderboardCourses,
 } from "../../lib/studentCourseClient";
 import { getCachedLeaderboard } from "../../lib/leaderboardStore";
@@ -26,13 +31,21 @@ import { useRequireRole } from "../../lib/useRequireRole";
 const PAGE_SIZE = 10; // keep in sync with ROW_COUNT in components/LeaderboardSkeleton.tsx
 
 /**
- * The course leaderboard: where a student stands against their classmates.
+ * The full leaderboard: where a student stands, either against every student in the app ("All",
+ * the default) or against one course's roster at a time.
  *
- * Reads GET /api/courses/{courseId}/leaderboard via lib/studentCourseClient.ts's
- * loadCourseLeaderboard. rankChange is attached by that client call from
- * lib/previousRankStore.ts's last-recorded snapshot; this page
- * is what records the NEW snapshot, once per fresh fetch, after the entries carrying the old
- * snapshot's deltas have rendered — see the effect below and recordLeaderboardRanks's own doc.
+ * "All" reads GET /api/leaderboard via loadGlobalLeaderboard; a specific course reads
+ * GET /api/courses/{courseId}/leaderboard via loadCourseLeaderboard — genuinely different
+ * endpoints/queries (computeGlobalLeaderboard vs. computeCourseLeaderboard, lib/leaderboardQueries.ts),
+ * not the same one with/without a filter tacked on. Both share the same courseId-keyed cache
+ * (lib/leaderboardStore.ts) and rank-snapshot store (lib/previousRankStore.ts) as the dashboard's
+ * always-global LeaderboardPreview, under the reserved GLOBAL_LEADERBOARD_KEY when the scope is
+ * "All" — the two views can't disagree about the global ranking's cache or "since last visit" delta.
+ *
+ * rankChange is attached by the client call from lib/previousRankStore.ts's last-recorded
+ * snapshot; this page is what records the NEW snapshot, once per fresh fetch, after the entries
+ * carrying the old snapshot's deltas have rendered — see the effect below and
+ * recordLeaderboardRanks's own doc.
  *
  * Split into an inner component because useSearchParams() forces the nearest Suspense boundary
  * to render client-side — without one, `npm run build` fails prerendering this route.
@@ -78,31 +91,42 @@ function LeaderboardContent() {
   }, [token]);
 
   const courseIdParam = searchParams.get("courseId");
-  // An unknown ?courseId= falls back to the first course rather than showing an empty page for
-  // a course the student isn't in — the switcher then re-syncs the URL below.
-  const selectedCourseId = courses
-    ? (courses.find((course) => course.courseId === courseIdParam)?.courseId ??
-      courses[0]?.courseId ??
-      null)
-    : null;
+  // Anything that isn't one of the student's own courses — no param, "all" itself, or an unknown
+  // id — resolves to "All" (the default cross-course view) rather than an empty page for a course
+  // the student isn't in. The switcher then re-syncs the URL below.
+  const selectedScope: string = courses
+    ? (courses.find((course) => course.courseId === courseIdParam)?.courseId ?? ALL_COURSES_SCOPE)
+    : ALL_COURSES_SCOPE;
+
+  // The cache/rank-snapshot key for the current scope — the reserved GLOBAL_LEADERBOARD_KEY for
+  // "All", sharing the same entry the dashboard's LeaderboardPreview reads/writes, or the real
+  // course_id otherwise.
+  const scopeCacheKey = selectedScope === ALL_COURSES_SCOPE ? GLOBAL_LEADERBOARD_KEY : selectedScope;
 
   useEffect(() => {
-    if (!token || !selectedCourseId) {
-      setEntries(courses && courses.length === 0 ? [] : null);
+    if (!token || !courses) {
+      setEntries(null);
+      return;
+    }
+    if (courses.length === 0) {
+      setEntries([]);
       return;
     }
 
     let cancelled = false;
-    // Skip the null reset (and the resulting skeleton) when this course's leaderboard is
-    // already cached this session — loadCourseLeaderboard below will resolve it from cache
-    // essentially instantly, so there is nothing to show a loading state for (GitHub #328).
-    if (getCachedLeaderboard(selectedCourseId) === null) {
+    // Skip the null reset (and the resulting skeleton) when this scope's leaderboard is already
+    // cached this session — the loader below will resolve it from cache essentially instantly, so
+    // there is nothing to show a loading state for (GitHub #328).
+    if (getCachedLeaderboard(scopeCacheKey) === null) {
       setEntries(null);
     }
     setEntriesFailed(false);
     setPage(1);
 
-    loadCourseLeaderboard(token, selectedCourseId).then((result) => {
+    const loader =
+      selectedScope === ALL_COURSES_SCOPE ? loadGlobalLeaderboard(token) : loadCourseLeaderboard(token, selectedScope);
+
+    loader.then((result) => {
       if (cancelled) return;
       if (!result.ok) {
         setEntriesFailed(true);
@@ -114,33 +138,42 @@ function LeaderboardContent() {
     return () => {
       cancelled = true;
     };
+    // courses !== null (not `courses` itself) is the third dep deliberately: selectedScope
+    // resolves to ALL_COURSES_SCOPE both before courses has loaded and after (whenever no
+    // ?courseId= is in the URL), so without some signal that loading finished, this effect would
+    // never re-fire the moment courses arrives and entries would stay stuck on the skeleton
+    // forever. The boolean (not the array reference) is what keeps this from refiring every time
+    // handleRefresh gives `courses` a new array identity without selectedScope changing.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token, selectedCourseId]);
+  }, [token, selectedScope, courses !== null]);
 
   // Records THIS render's ranks as the new "previous" snapshot, once per fresh, non-empty fetch —
   // never during the fetch that produced the rankChange values just shown. Deliberately not
   // inside the fetch effect above: that effect's job is "get the data", this one's is "the data
   // has now been shown to the student", and folding them together would record before render.
   useEffect(() => {
-    if (!selectedCourseId || !entries || entries.length === 0) return;
-    recordLeaderboardRanks(selectedCourseId, entries);
-  }, [selectedCourseId, entries]);
+    if (!entries || entries.length === 0) return;
+    recordLeaderboardRanks(scopeCacheKey, entries);
+  }, [scopeCacheKey, entries]);
 
-  function handleSelectCourse(courseId: string) {
-    router.replace(`/leaderboard?courseId=${encodeURIComponent(courseId)}`, {
-      scroll: false,
-    });
+  function handleSelectScope(scope: string) {
+    router.replace(
+      scope === ALL_COURSES_SCOPE ? "/leaderboard" : `/leaderboard?courseId=${encodeURIComponent(scope)}`,
+      { scroll: false },
+    );
   }
 
   function handleRefresh() {
-    if (!token || !selectedCourseId || refreshing) return;
+    if (!token || refreshing) return;
     setRefreshing(true);
     // Forces both caches this page reads: the course list (membership can have changed since
-    // this session started) and the selected course's entries — the one on-demand escape hatch
+    // this session started) and the selected scope's entries — the one on-demand escape hatch
     // for both of the session caches GitHub #328 introduced.
     Promise.all([
       loadMyLeaderboardCourses(token, { forceRefresh: true }),
-      loadCourseLeaderboard(token, selectedCourseId, { forceRefresh: true }),
+      selectedScope === ALL_COURSES_SCOPE
+        ? loadGlobalLeaderboard(token, { forceRefresh: true })
+        : loadCourseLeaderboard(token, selectedScope, { forceRefresh: true }),
     ]).then(([coursesResult, entriesResult]) => {
       setRefreshing(false);
       if (coursesResult.ok) setCourses(coursesResult.data.courses);
@@ -229,8 +262,8 @@ function LeaderboardContent() {
           <>
             <LeaderboardCourseSwitcher
               courses={courses}
-              selectedCourseId={selectedCourseId}
-              onSelect={handleSelectCourse}
+              selectedCourseId={selectedScope}
+              onSelect={handleSelectScope}
             />
 
             {entriesFailed ? (

--- a/components/LeaderboardCourseSwitcher.tsx
+++ b/components/LeaderboardCourseSwitcher.tsx
@@ -2,14 +2,21 @@
 
 import type { LeaderboardCourse } from '../lib/leaderboardTypes';
 
-// Above this many courses the pill row wraps into an unreadable block, so it becomes a select.
-// Same threshold reasoning as ActivityFilters' choice of control per filter.
+// Above this many choices (including "All") the pill row wraps into an unreadable block, so it
+// becomes a select. Same threshold reasoning as ActivityFilters' choice of control per filter.
 const MAX_PILLS = 4;
 
+/** The sentinel for "every student in the app" — never a real course_id (those are UUIDs). */
+export const ALL_COURSES_SCOPE = 'all';
+
 /**
- * Picks which course's ranking is shown. The selection lives in the URL (?courseId=), not in
- * component state — the page owns that, this component only reports the change — so a
- * leaderboard view stays linkable and survives a reload.
+ * Picks which ranking is shown: literally every student in the app ("All", the default) or one
+ * course's own roster at a time. The selection lives in the URL (?courseId=), not in component
+ * state — the page owns that, this component only reports the change — so a leaderboard view
+ * stays linkable and survives a reload.
+ *
+ * "All" is always offered, even with a single enrolled course — it isn't "this course, plus every
+ * other course I'm in" (a no-op with one course), it's every student, enrolled anywhere or not.
  */
 export function LeaderboardCourseSwitcher({
   courses,
@@ -17,21 +24,21 @@ export function LeaderboardCourseSwitcher({
   onSelect,
 }: {
   courses: LeaderboardCourse[];
-  selectedCourseId: string | null;
+  selectedCourseId: string;
   onSelect: (courseId: string) => void;
 }) {
-  // One course is not a choice — the heading already says which one it is.
-  if (courses.length <= 1) return null;
+  if (courses.length === 0) return null;
 
-  if (courses.length > MAX_PILLS) {
+  if (courses.length + 1 > MAX_PILLS) {
     return (
       <label className="mb-5 block">
         <span className="mb-1.5 block text-xs font-bold uppercase tracking-wide text-gray-500">Course</span>
         <select
-          value={selectedCourseId ?? ''}
+          value={selectedCourseId}
           onChange={(event) => onSelect(event.target.value)}
           className="w-full max-w-xs rounded-brand-md border border-gray-300 bg-white px-3 py-2 text-sm font-bold text-brand-navy focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-purple"
         >
+          <option value={ALL_COURSES_SCOPE}>All</option>
           {courses.map((course) => (
             <option key={course.courseId} value={course.courseId}>
               {course.courseName}
@@ -44,7 +51,7 @@ export function LeaderboardCourseSwitcher({
 
   return (
     <div className="mb-5 flex flex-wrap gap-2" role="group" aria-label="Course">
-      {courses.map((course) => {
+      {[{ courseId: ALL_COURSES_SCOPE, courseName: 'All' }, ...courses].map((course) => {
         const isSelected = course.courseId === selectedCourseId;
         return (
           <button

--- a/components/LeaderboardPreview.tsx
+++ b/components/LeaderboardPreview.tsx
@@ -6,9 +6,9 @@ import { Avatar } from './Avatar';
 import { LeaderboardRankBadge } from './LeaderboardRankBadge';
 import { RankChangeIndicator } from './RankChangeIndicator';
 import { StreakBadge } from './StreakBadge';
-import { GLOBAL_LEADERBOARD_KEY, loadGlobalLeaderboard } from '../lib/studentCourseClient';
+import { GLOBAL_LEADERBOARD_KEY, loadGlobalLeaderboard, loadMyLeaderboardCourses } from '../lib/studentCourseClient';
 import { recordLeaderboardRanks } from '../lib/previousRankStore';
-import type { LeaderboardEntry } from '../lib/leaderboardTypes';
+import type { LeaderboardCourse, LeaderboardEntry } from '../lib/leaderboardTypes';
 
 const TOP_COUNT = 5;
 
@@ -41,9 +41,10 @@ function PreviewRow({ entry, isCurrentUser }: { entry: LeaderboardEntry; isCurre
 
 /**
  * The dashboard's glance at the GLOBAL leaderboard (GitHub #432 follow-up): the top five, plus
- * the student's own row appended when they didn't make it, ranked by total score across every
- * course the student shares with the people shown — not one course's own points. The per-course
- * leaderboard lives elsewhere now: app/leaderboard/page.tsx (with its course switcher) and
+ * the student's own row appended when they didn't make it, ranked by every student's own total
+ * score across all of their courses — not one course's own points, and not limited to students
+ * who share a course with the viewer (see computeGlobalLeaderboard's own doc for why). The
+ * per-course leaderboard lives elsewhere now: app/leaderboard/page.tsx (with its course switcher) and
  * components/CourseLeaderboard.tsx (embedded on a course's own quiz-list page) are the two
  * course-scoped readers of GET /api/courses/{courseId}/leaderboard; this is the one reader of the
  * separate, global GET /api/leaderboard (lib/leaderboardQueries.ts's computeGlobalLeaderboard) —
@@ -58,25 +59,32 @@ function PreviewRow({ entry, isCurrentUser }: { entry: LeaderboardEntry; isCurre
  * Reads GET /api/leaderboard via lib/studentCourseClient.ts's loadGlobalLeaderboard, cached under
  * the reserved GLOBAL_LEADERBOARD_KEY in the same courseId-keyed stores real course leaderboards
  * use (lib/leaderboardStore.ts, lib/previousRankStore.ts) — a completed session's existing
- * cache-clear (the play flow's handleFinishSummary) already covers this entry too. An empty
- * result can only mean "not enrolled in any course at all" (see computeGlobalLeaderboard's own
- * doc: the viewer's own row would otherwise always appear, even at 0 points), so that's the one
- * case rendered as "join a course" rather than "be the first".
+ * cache-clear (the play flow's handleFinishSummary) already covers this entry too.
+ *
+ * computeGlobalLeaderboard now ranks literally every student account, enrolled anywhere or not —
+ * a deliberate exception to the shared-course disclosure boundary the rest of the app enforces
+ * (see that function's own doc). That means the entries list itself can no longer answer "has this
+ * student joined a course yet" the way an empty result used to: a never-enrolled student still
+ * gets ranked, just with 0 points, alongside everyone else. So "join a course" is decided from a
+ * second, independent read — loadMyLeaderboardCourses, the same enrolled-courses list
+ * app/leaderboard/page.tsx already reads — rather than from the leaderboard response.
  */
 export function LeaderboardPreview({ token, studentId }: { token: string; studentId?: string }) {
   const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
+  const [courses, setCourses] = useState<LeaderboardCourse[] | null>(null);
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
 
-    loadGlobalLeaderboard(token).then((result) => {
+    Promise.all([loadGlobalLeaderboard(token), loadMyLeaderboardCourses(token)]).then(([entriesResult, coursesResult]) => {
       if (cancelled) return;
-      if (!result.ok) {
+      if (!entriesResult.ok || !coursesResult.ok) {
         setFailed(true);
         return;
       }
-      setEntries(result.data.entries);
+      setEntries(entriesResult.data.entries);
+      setCourses(coursesResult.data.courses);
     });
 
     return () => {
@@ -89,7 +97,7 @@ export function LeaderboardPreview({ token, studentId }: { token: string; studen
     recordLeaderboardRanks(GLOBAL_LEADERBOARD_KEY, entries);
   }, [entries]);
 
-  if (entries === null && !failed) {
+  if ((entries === null || courses === null) && !failed) {
     return (
       <section className="mb-7 animate-pulse rounded-brand-lg bg-brand-navy p-6" aria-hidden="true">
         <div className="mb-4 h-6 w-32 rounded-full bg-white/10" />
@@ -106,10 +114,7 @@ export function LeaderboardPreview({ token, studentId }: { token: string; studen
   const top = rows.slice(0, TOP_COUNT);
   const me = rows.find((entry) => entry.studentId === studentId) ?? null;
   const meInTop = top.some((entry) => entry.studentId === studentId);
-  // An empty result here only ever means "not enrolled anywhere" — see computeGlobalLeaderboard's
-  // own doc: the viewer's own courses always include the viewer, so a real, non-empty enrollment
-  // would always produce at least the viewer's own row.
-  const notEnrolled = !failed && rows.length === 0;
+  const notEnrolled = !failed && (courses?.length ?? 0) === 0;
 
   return (
     <section className="mb-7 rounded-brand-lg bg-brand-navy p-6 text-brand-ink">

--- a/lib/leaderboardQueries.ts
+++ b/lib/leaderboardQueries.ts
@@ -8,7 +8,6 @@ import type { SupabaseClient } from './sessionQueries';
 import { sumBestScores, type SessionRow } from './scoreQueries';
 import { computeStreakFromSessions, type StreakSessionRow } from './streakQueries';
 import { listActivityTypesForCourses } from './activityCourseQueries';
-import { getEnrolledCourseIds } from './courseQueries';
 
 // Aliased to `student`, same convention as lib/sessionQueries.ts's STUDENT_EMBED, because the
 // table is called "user" (a reserved word). !inner matters here exactly the way it does there:
@@ -176,45 +175,64 @@ export async function computeCourseLeaderboard(
 }
 
 /**
- * The dashboard's global leaderboard (GitHub #432 follow-up): every student who shares at least
- * one course with the viewer, ranked by their TOTAL score across every course they're in — no
- * activity_type filter, the same "no course_id filter" definition computeStudentScore already
- * uses for a single student's own sidebar total. The one thing this deliberately does NOT do is
- * rank every student in the entire app: this codebase's one other cross-user disclosure rule,
- * GET /api/students/{id}/public-profile, only ever disclosed a student's identity/score to
- * someone who shares a course with them (lib/courseQueries.ts's isEnrolledInAnyCourse), and a
- * literal "every user, everywhere" leaderboard would be the first place in the app to break that
- * invariant. "Shares at least one course with the viewer" is the least-surprising way to stay
- * global (not capped to a single course, unlike computeCourseLeaderboard) without doing that —
- * the union of every course the viewer is in, rather than one course's own roster.
+ * A direct read off "user" rather than a student_course-scoped embed like ROSTER_STUDENT_EMBED —
+ * computeGlobalLeaderboard's roster is every student account, not one scoped to a shared course,
+ * so there's no join row to embed onto. Same fields, mapped into RosterRow's shape below so it can
+ * still go through the shared rankRoster tail unchanged.
+ */
+type GlobalUserRow = {
+  user_id: string;
+  username: string;
+  avatar_url: string | null;
+  selected_title: { title_name: string } | null;
+};
+
+/**
+ * The dashboard's (and the full leaderboard page's "All" scope) global leaderboard: literally
+ * every student account in the app, ranked by their TOTAL score across every course they're in —
+ * no activity_type filter, the same "no course_id filter" definition computeStudentScore already
+ * uses for a single student's own sidebar total.
  *
- * The viewer's own courses always include the viewer, so an empty result here can only mean "not
- * enrolled in any course at all" — never "enrolled, but nobody has scored yet" (their own 0-point
- * row would still appear). Callers can rely on that to choose which empty-state message to show,
- * the same way computeCourseLeaderboard's callers rely on data: [] meaning "a real, empty roster".
+ * This is a deliberate, explicit exception to the disclosure boundary every other cross-user read
+ * in this app enforces (GET /api/courses/{courseId}/leaderboard, GET /api/students/{id}/
+ * public-profile — both gated on isEnrolledInAnyCourse, "do the caller and the target share a
+ * course"). An earlier version of this function scoped the roster to "shares a course with the
+ * viewer" specifically to preserve that boundary; product direction confirmed a global leaderboard
+ * should mean literally every student, visible to every other student, with no shared-course
+ * requirement — so the roster query below intentionally has no relationship to the caller at all.
+ * A caller that wants the shared-course-only view should read GET /api/courses/{courseId}/leaderboard
+ * for a specific course instead.
+ *
+ * Because the roster no longer depends on the caller, this takes no viewerId — every caller sees
+ * the same ranking. An empty result now only means "no student accounts exist at all", not
+ * "nobody enrolled anywhere"; callers that used to treat [] as "you're not in a course yet" need
+ * a different signal for that (e.g. their own enrolled-courses list) now that this always returns
+ * every student, enrolled or not.
  *
  * Same roster-then-sessions shape as computeCourseLeaderboard, and the same rankRoster tail — the
- * two can't disagree about what "rank" or "tie" means, only about which points count.
+ * two can't disagree about what "rank" or "tie" means, only about which points count and who's
+ * ranked at all.
  */
 export async function computeGlobalLeaderboard(
   supabase: SupabaseClient,
-  viewerId: string,
 ): Promise<{ data: LeaderboardRow[] | null; error: { message: string } | null }> {
-  const { courseIds, error: courseIdsError } = await getEnrolledCourseIds(supabase, viewerId);
-  if (courseIdsError) return { data: null, error: courseIdsError };
+  const { data: userData, error: userError } = await supabase
+    .from('user')
+    .select('user_id, username, avatar_url, selected_title:title_definition(title_name)')
+    .eq('role', 'student');
 
-  if (!courseIds || courseIds.length === 0) return { data: [], error: null };
+  if (userError) return { data: null, error: userError };
 
-  const { data: rosterData, error: rosterError } = await supabase
-    .from('student_course')
-    .select(`user_id, ${ROSTER_STUDENT_EMBED}`)
-    .in('course_id', courseIds)
-    .eq('student.role', 'student');
+  const roster: RosterRow[] = ((userData ?? []) as unknown as GlobalUserRow[]).map((row) => ({
+    user_id: row.user_id,
+    student: {
+      username: row.username,
+      avatar_url: row.avatar_url,
+      role: 'student',
+      selected_title: row.selected_title,
+    },
+  }));
 
-  if (rosterError) return { data: null, error: rosterError };
-
-  const rosterRows = (rosterData ?? []) as unknown as RosterRow[];
-  const roster = [...new Map(rosterRows.map((row) => [row.user_id, row])).values()];
   if (roster.length === 0) return { data: [], error: null };
 
   const studentIds = roster.map((row) => row.user_id);

--- a/lib/studentCourseClient.ts
+++ b/lib/studentCourseClient.ts
@@ -221,10 +221,10 @@ export function loadCourseLeaderboard(
 export const GLOBAL_LEADERBOARD_KEY = '__global__';
 
 /**
- * The dashboard's global leaderboard (GET /api/leaderboard, GitHub #432 follow-up): every
- * student who shares at least one course with the caller, ranked by their total score across all
- * of their courses — see computeGlobalLeaderboard's own doc (lib/leaderboardQueries.ts) for why
- * "global" stops at "shares a course with me" rather than every user in the app.
+ * The global leaderboard (GET /api/leaderboard): literally every student account in the app,
+ * ranked by their total score across all of their courses — see computeGlobalLeaderboard's own
+ * doc (lib/leaderboardQueries.ts) for why this deliberately does not stop at "shares a course
+ * with the caller" the way GET /api/courses/{courseId}/leaderboard does.
  *
  * Same cache-first/forceRefresh shape as loadCourseLeaderboard above, and the same
  * cache/rank-change plumbing, just keyed by GLOBAL_LEADERBOARD_KEY instead of a courseId — so a


### PR DESCRIPTION
- app/leaderboard/page.tsx / components/LeaderboardCourseSwitcher.tsx: the full leaderboard page defaulted to the student's first course with no way back to a cross-course view. Added an "All" option (default, first in the switcher) that reads the global endpoint; picking a specific course still works as before.
- Fixed a real bug hit while verifying this: the entries-fetch effect depended on [token, selectedScope], but selectedScope resolves to "all" both before and after the course list finishes loading, so the effect never re-fired once data arrived and the default view got stuck on the skeleton forever. Now also depends on whether the course list has loaded.
- lib/leaderboardQueries.ts (computeGlobalLeaderboard) / app/api/leaderboard/route.ts: "All" now ranks every student account in the app, not just students who share a course with the viewer. This is a deliberate, confirmed exception to the shared-course disclosure boundary every other cross-user read in this app enforces (course leaderboard, public profiles) — product direction explicitly signed off on it after a student's points from another course were found missing from their "All" view.
- components/LeaderboardPreview.tsx: the dashboard widget's "join a course" empty state used to be inferred from an empty leaderboard result, which is no longer possible now that every student always appears (even at 0 points). Now checks the student's own enrolled- courses list directly instead.
- Updated unit and route tests for the new roster query shape.