### PR TITLE
Encrypt instructor LLM API keys before storing them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,14 @@ NEXT_PUBLIC_SUPABASE_URL="https://your-project-id.supabase.co"
 # "CHANGE-ME") makes instructor signup fail closed rather than fall back to a
 # built-in default.
 INSTRUCTOR_SIGNUP_CODE=
+
+# The key instructor_llm_config.api_key is encrypted with (lib/secretEncryption.ts) before it's
+# ever written to the database — an instructor's LLM provider API key is never stored in
+# plaintext. Must be a base64-encoded 32-byte value: generate one per deployment with
+# `openssl rand -base64 32` and set it only in that deployment's own environment — never commit a
+# real value here or anywhere else in the repo. Leaving this unset, set to a placeholder starting
+# with "CHANGE-ME", or set to a value that doesn't decode to exactly 32 bytes makes saving or
+# reading an LLM config fail closed (500) rather than fall back to writing/reading plaintext.
+# Rotating this value makes every previously-saved config unreadable — affected instructors will
+# need to re-save their LLM provider settings.
+LLM_CONFIG_ENCRYPTION_KEY=

--- a/__tests__/api/instructor-llm-config.test.ts
+++ b/__tests__/api/instructor-llm-config.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 type Result = { data?: unknown; error?: unknown };
 
@@ -67,6 +67,12 @@ vi.mock('../../lib/supabase', () => ({
 }));
 
 import { GET, POST } from '../../app/api/instructor/llm-config/route';
+import { decryptSecret } from '../../lib/secretEncryption';
+
+// A real 32-byte key so POST's encryptSecret call succeeds by default — same pattern
+// __tests__/api/auth.test.ts uses for INSTRUCTOR_SIGNUP_CODE, saved/restored around every test.
+const VALID_ENCRYPTION_KEY = Buffer.alloc(32, 3).toString('base64');
+const ORIGINAL_ENCRYPTION_KEY = process.env.LLM_CONFIG_ENCRYPTION_KEY;
 
 function req(body: unknown, token: string | null = 'valid-token') {
   return new Request('http://localhost/api/instructor/llm-config', {
@@ -103,6 +109,12 @@ beforeEach(() => {
   h.state.inserts = [];
   h.state.updates = [];
   h.state.filters = [];
+  process.env.LLM_CONFIG_ENCRYPTION_KEY = VALID_ENCRYPTION_KEY;
+});
+
+afterEach(() => {
+  if (ORIGINAL_ENCRYPTION_KEY === undefined) delete process.env.LLM_CONFIG_ENCRYPTION_KEY;
+  else process.env.LLM_CONFIG_ENCRYPTION_KEY = ORIGINAL_ENCRYPTION_KEY;
 });
 
 describe('POST /api/instructor/llm-config', () => {
@@ -118,13 +130,28 @@ describe('POST /api/instructor/llm-config', () => {
     expect(JSON.stringify(body)).not.toContain('sk-secret');
 
     expect(h.state.inserts).toHaveLength(1);
-    expect(h.state.inserts[0].payload).toMatchObject({
+    const insertedPayload = h.state.inserts[0].payload as { api_key: string; [key: string]: unknown };
+    expect(insertedPayload).toMatchObject({
       user_id: 'instructor-1',
       provider: 'CLAUDE',
       model: 'claude-opus-5',
-      api_key: 'sk-secret',
       is_active: false,
     });
+    // The stored api_key is never the raw plaintext — it's ciphertext that decrypts back to it.
+    expect(insertedPayload.api_key).not.toBe('sk-secret');
+    expect(decryptSecret(insertedPayload.api_key)).toBe('sk-secret');
+  });
+
+  it('answers 500 without writing anything when LLM_CONFIG_ENCRYPTION_KEY is not configured', async () => {
+    delete process.env.LLM_CONFIG_ENCRYPTION_KEY;
+    queueRole('instructor');
+
+    const res = await POST(req({ provider: 'CLAUDE', apiKey: 'sk-secret', model: 'claude-opus-5' }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe('LLM key storage is not configured.');
+    expect(h.state.inserts).toHaveLength(0);
   });
 
   it('deactivates any previously active row when setActive is true', async () => {

--- a/__tests__/api/llm-submissions.test.ts
+++ b/__tests__/api/llm-submissions.test.ts
@@ -63,7 +63,14 @@ vi.mock('../../lib/llm/factory', async (importOriginal) => {
   return { ...actual, getLLMProvider: vi.fn() };
 });
 
+// Mocked rather than exercised for real (that's __tests__/lib/secretEncryption.test.ts's job) —
+// this route test stays focused on routing/authorization. Defaults to an identity function so
+// CONFIG.api_key below still flows through to getLLMProvider unchanged; individual tests can
+// override it to simulate a decrypt failure.
+vi.mock('../../lib/secretEncryption', () => ({ decryptSecret: vi.fn((value: string) => value) }));
+
 import { getLLMProvider } from '../../lib/llm/factory';
+import { decryptSecret } from '../../lib/secretEncryption';
 import { POST } from '../../app/api/activities/[activityType]/llm/submissions/route';
 
 const ACTIVITY = 'WRITE_ACCEPTANCE_CRITERIA';
@@ -158,6 +165,8 @@ beforeEach(() => {
   rateAcceptanceCriteria.mockResolvedValue({ score: 8, feedback: 'Clear and testable.' });
   vi.mocked(getLLMProvider).mockReset();
   vi.mocked(getLLMProvider).mockReturnValue({ rateAcceptanceCriteria } as never);
+  vi.mocked(decryptSecret).mockReset();
+  vi.mocked(decryptSecret).mockImplementation((value: string) => value);
 });
 
 describe('POST /api/activities/[activityType]/llm/submissions', () => {
@@ -291,6 +300,18 @@ describe('POST /api/activities/[activityType]/llm/submissions', () => {
     const response = await POST(req({ userStoryId: 'story-1', submittedText: 'x', sessionId: SESSION_ID }), PARAMS());
 
     expect(response.status).toBe(500);
+  });
+
+  it('returns 500 without calling the provider when the stored api_key cannot be decrypted', async () => {
+    queueUpToLLM();
+    vi.mocked(decryptSecret).mockReturnValue(null);
+
+    const response = await POST(req({ userStoryId: 'story-1', submittedText: 'x', sessionId: SESSION_ID }), PARAMS());
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body.error).toBe('Configured LLM provider key could not be read.');
+    expect(getLLMProvider).not.toHaveBeenCalled();
   });
 
   it('returns 502 when the LLM provider request fails', async () => {

--- a/__tests__/lib/secretEncryption.test.ts
+++ b/__tests__/lib/secretEncryption.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { encryptSecret, decryptSecret } from '../../lib/secretEncryption';
+
+// A real 32-byte key, base64-encoded, matching the format LLM_CONFIG_ENCRYPTION_KEY documents in
+// .env.example (`openssl rand -base64 32`).
+const VALID_KEY = Buffer.alloc(32, 7).toString('base64');
+
+// Saved and restored around every test — same pattern __tests__/api/auth.test.ts uses for
+// INSTRUCTOR_SIGNUP_CODE — so one test's value can never leak into the next.
+const ORIGINAL_KEY = process.env.LLM_CONFIG_ENCRYPTION_KEY;
+
+describe('secretEncryption', () => {
+  afterEach(() => {
+    if (ORIGINAL_KEY === undefined) delete process.env.LLM_CONFIG_ENCRYPTION_KEY;
+    else process.env.LLM_CONFIG_ENCRYPTION_KEY = ORIGINAL_KEY;
+  });
+
+  describe('with a configured key', () => {
+    beforeEach(() => {
+      process.env.LLM_CONFIG_ENCRYPTION_KEY = VALID_KEY;
+    });
+
+    it('round-trips a plaintext string through encrypt then decrypt', () => {
+      const ciphertext = encryptSecret('sk-super-secret-key');
+      expect(ciphertext).not.toBeNull();
+      expect(ciphertext).not.toContain('sk-super-secret-key');
+      expect(decryptSecret(ciphertext!)).toBe('sk-super-secret-key');
+    });
+
+    it('produces a different ciphertext for the same plaintext on repeated calls (random IV)', () => {
+      const first = encryptSecret('sk-same-key');
+      const second = encryptSecret('sk-same-key');
+      expect(first).not.toBe(second);
+      expect(decryptSecret(first!)).toBe('sk-same-key');
+      expect(decryptSecret(second!)).toBe('sk-same-key');
+    });
+
+    it('returns null when decrypting a tampered ciphertext instead of throwing', () => {
+      const ciphertext = encryptSecret('sk-super-secret-key')!;
+      const tampered = ciphertext.slice(0, -4) + 'abcd';
+      expect(decryptSecret(tampered)).toBeNull();
+    });
+
+    it('returns null when decrypting a value that predates encryption (plain string, no delimiters)', () => {
+      expect(decryptSecret('sk-plaintext-legacy-value')).toBeNull();
+    });
+
+    it('returns null when decrypting under a different key than it was encrypted with', () => {
+      const ciphertext = encryptSecret('sk-super-secret-key')!;
+      process.env.LLM_CONFIG_ENCRYPTION_KEY = Buffer.alloc(32, 9).toString('base64');
+      expect(decryptSecret(ciphertext)).toBeNull();
+    });
+  });
+
+  describe('without a configured key', () => {
+    it('encryptSecret returns null when LLM_CONFIG_ENCRYPTION_KEY is unset', () => {
+      delete process.env.LLM_CONFIG_ENCRYPTION_KEY;
+      expect(encryptSecret('sk-super-secret-key')).toBeNull();
+    });
+
+    it('decryptSecret returns null when LLM_CONFIG_ENCRYPTION_KEY is unset', () => {
+      delete process.env.LLM_CONFIG_ENCRYPTION_KEY;
+      expect(decryptSecret('anything')).toBeNull();
+    });
+
+    it('rejects a CHANGE-ME-style placeholder the same way INSTRUCTOR_SIGNUP_CODE does', () => {
+      process.env.LLM_CONFIG_ENCRYPTION_KEY = 'CHANGE-ME-please-set-a-real-key';
+      expect(encryptSecret('sk-super-secret-key')).toBeNull();
+    });
+
+    it('rejects a key that does not decode to exactly 32 bytes', () => {
+      process.env.LLM_CONFIG_ENCRYPTION_KEY = Buffer.alloc(16, 1).toString('base64');
+      expect(encryptSecret('sk-super-secret-key')).toBeNull();
+    });
+  });
+});

--- a/app/api/activities/[activityType]/llm/submissions/route.ts
+++ b/app/api/activities/[activityType]/llm/submissions/route.ts
@@ -1,6 +1,7 @@
 import { getSupabaseClient } from "../../../../../../lib/supabase";
 import { getGradingKind } from "../../../../../../lib/activityTypes";
 import { getLLMProvider, isLLMProviderName } from "../../../../../../lib/llm/factory";
+import { decryptSecret } from "../../../../../../lib/secretEncryption";
 import { SESSION_COLUMNS, isPassing } from "../../../../../../lib/sessionRules";
 import { awardedScoreForRating } from "../../../../../../lib/llmActivityRules";
 import {
@@ -202,9 +203,16 @@ export async function POST(request: Request, { params }: { params: { activityTyp
       { status: 500 },
     );
 
-  const { provider: providerName, api_key: apiKey, model } = config as LLMConfigRow;
+  const { provider: providerName, api_key: storedApiKey, model } = config as LLMConfigRow;
   if (!isLLMProviderName(providerName))
     return Response.json({ error: "Configured LLM provider is invalid." }, { status: 500 });
+
+  // storedApiKey is ciphertext (lib/secretEncryption.ts) — decrypted only here, in memory, at the
+  // point it's handed to the provider SDK. null covers both a missing/misconfigured
+  // LLM_CONFIG_ENCRYPTION_KEY and a row saved before encryption existed (see
+  // supabase/schema.sql's migration note).
+  const apiKey = decryptSecret(storedApiKey);
+  if (!apiKey) return Response.json({ error: "Configured LLM provider key could not be read." }, { status: 500 });
 
   const provider = getLLMProvider(providerName, apiKey, model);
   if (!provider)

--- a/app/api/instructor/llm-config/route.ts
+++ b/app/api/instructor/llm-config/route.ts
@@ -1,12 +1,15 @@
 import { getSupabaseClient } from '../../../../lib/supabase';
 import { requireInstructor } from '../../../../lib/instructorAuth';
 import { isLLMProviderName } from '../../../../lib/llm/provider';
+import { encryptSecret } from '../../../../lib/secretEncryption';
 
 const UNIQUE_VIOLATION = '23505';
 
 // api_key is deliberately excluded — write-only from the client's perspective, matching the
 // schema comment on instructor_llm_config ("only a service-role route can read or write
-// api_key, and that route is responsible for masking it before it reaches the client").
+// api_key, and that route is responsible for masking it before it reaches the client"). The
+// column itself also never holds a plaintext key: POST encrypts it (lib/secretEncryption.ts)
+// before the insert, so even a direct database read only ever sees ciphertext.
 const CONFIG_COLUMNS = 'instructor_llm_config_id, provider, model, is_active, updated_at';
 
 function getToken(request: Request): string | null {
@@ -34,7 +37,7 @@ function getToken(request: Request): string | null {
  *  - 403 if the caller isn't an instructor (no body, matching requireInstructor's convention)
  *  - 400 if provider isn't one of CLAUDE/CHATGPT/GEMINI, or apiKey is empty
  *  - 200 with the saved row — api_key never included
- *  - 500 if Supabase isn't configured or a query fails
+ *  - 500 if Supabase isn't configured, LLM_CONFIG_ENCRYPTION_KEY isn't configured, or a query fails
  *
  * GET AC summary:
  *  - Same 401/403 as POST.
@@ -125,6 +128,14 @@ export async function POST(request: Request) {
     return Response.json({ error: 'apiKey is required.' }, { status: 400 });
   }
 
+  // Encrypted before it ever reaches the database — see lib/secretEncryption.ts. null means
+  // LLM_CONFIG_ENCRYPTION_KEY isn't configured for this deployment; fail closed rather than
+  // fall back to writing the plaintext key.
+  const encryptedApiKey = encryptSecret(apiKey);
+  if (!encryptedApiKey) {
+    return Response.json({ error: 'LLM key storage is not configured.' }, { status: 500 });
+  }
+
   const isActive = Boolean(setActive);
 
   const deactivateExisting = () =>
@@ -138,7 +149,7 @@ export async function POST(request: Request) {
         user_id: guard.user_id,
         provider,
         model,
-        api_key: apiKey,
+        api_key: encryptedApiKey,
         is_active: isActive,
       })
       .select(CONFIG_COLUMNS)

--- a/docs/manuals/administrator-manual.md
+++ b/docs/manuals/administrator-manual.md
@@ -64,9 +64,20 @@ enrollment-by-instructor only, by design.
 ## Setting up LLM grading (for "Write Acceptance Criteria"-style activities)
 
 Some activity catalogs are graded by an LLM instead of multiple-choice. For these to work, an
-instructor has to configure an LLM provider under **Instructor → Settings**. This is **not** an
-environment variable — the API key is entered through that in-app form and stored (encrypted at
-rest, masked in every API response) in the `instructor_llm_config` table.
+instructor has to configure an LLM provider under **Instructor → Settings**. The provider/model
+choice is not an environment variable — it's entered through that in-app form and stored (masked
+in every API response) in the `instructor_llm_config` table. The API key itself *is* backed by an
+environment variable, though: `LLM_CONFIG_ENCRYPTION_KEY` (see `.env.example`) is the secret the
+app encrypts that key with before writing it to the database, so it's never stored in plaintext —
+this variable must be set (a base64-encoded 32-byte value, `openssl rand -base64 32`) for saving
+or grading against an LLM config to work at all; if it's missing, saving a config or grading a
+submission fails with a 500 rather than silently falling back to plaintext.
+
+**If you're deploying this on top of an existing database** that already has rows in
+`instructor_llm_config` from before `LLM_CONFIG_ENCRYPTION_KEY` existed: those rows were saved as
+plaintext and cannot be decrypted after this change ships. Any instructor who already configured
+a provider needs to re-save it once from **Instructor → Settings** — grading will 500 with
+"Configured LLM provider key could not be read" until they do.
 
 Supported providers today (see `lib/llm/factory.ts`): Anthropic Claude, OpenAI ChatGPT, and
 Google Gemini. Whichever one is configured needs a valid API key from that provider, which the

--- a/lib/secretEncryption.ts
+++ b/lib/secretEncryption.ts
@@ -1,0 +1,76 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+
+// instructor_llm_config.api_key used to be written to the database exactly as submitted — plain
+// text, readable to anyone with database access (a backup leak, a SQL injection limited to that
+// one table, an over-shared read replica). This module is the fix: AES-256-GCM, keyed by a
+// per-deployment secret (LLM_CONFIG_ENCRYPTION_KEY) that never lives in the database, the same
+// "secret belongs in the environment, not a table" convention app/api/auth/register/route.ts
+// already uses for INSTRUCTOR_SIGNUP_CODE.
+//
+// Both functions return null on any failure (missing/misconfigured key, corrupt ciphertext)
+// rather than throwing — mirrors getSupabaseClient()'s null-on-missing-config pattern so callers
+// can respond 500 the same way every other route does on missing config, instead of needing a
+// try/catch around a crypto call.
+
+const ALGORITHM = "aes-256-gcm";
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+
+function loadKey(): Buffer | null {
+  const raw = process.env.LLM_CONFIG_ENCRYPTION_KEY;
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  // Rejects a leaked/placeholder default the same way isConfiguredInstructorCode does, even if
+  // someone pastes a CHANGE-ME-style value directly into the env var.
+  if (trimmed.length === 0 || trimmed.toUpperCase().startsWith("CHANGE-ME")) return null;
+
+  let key: Buffer;
+  try {
+    key = Buffer.from(trimmed, "base64");
+  } catch {
+    return null;
+  }
+  // A wrong-length key would silently produce ciphertext no correctly-configured deployment
+  // could ever decrypt — fail closed instead of guessing at padding/truncation.
+  if (key.length !== KEY_BYTES) return null;
+  return key;
+}
+
+/** iv:authTag:ciphertext, each base64 — a single string so the column can stay `text`. */
+export function encryptSecret(plaintext: string): string | null {
+  const key = loadKey();
+  if (!key) return null;
+
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ciphertext = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return `${iv.toString("base64")}:${authTag.toString("base64")}:${ciphertext.toString("base64")}`;
+}
+
+export function decryptSecret(stored: string): string | null {
+  const key = loadKey();
+  if (!key) return null;
+
+  const parts = stored.split(":");
+  if (parts.length !== 3) return null;
+  const [ivPart, authTagPart, ciphertextPart] = parts;
+
+  try {
+    const iv = Buffer.from(ivPart, "base64");
+    const authTag = Buffer.from(authTagPart, "base64");
+    const ciphertext = Buffer.from(ciphertextPart, "base64");
+
+    const decipher = createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    const plaintext = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+    return plaintext.toString("utf8");
+  } catch {
+    // Wrong key, corrupt/tampered ciphertext, or a pre-encryption plaintext row (see
+    // supabase/schema.sql's migration note) all land here — GCM's auth-tag check throws rather
+    // than returning garbage, which is exactly the failure mode we want surfaced as "can't read
+    // this," not silently misread.
+    return null;
+  }
+}

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1339,3 +1339,14 @@ CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
 --
 -- No backfill needed: DEFAULT 4 already matches QUESTIONS_PER_SESSION, so every existing quiz
 -- draws exactly as it did before this column existed.
+
+-- instructor_llm_config.api_key is now encrypted before it's written (lib/secretEncryption.ts,
+-- keyed by the LLM_CONFIG_ENCRYPTION_KEY env var — see .env.example) — no column/type change,
+-- it's still `text`, just no longer plaintext. Unlike the other notes in this footer, this one
+-- has NO safe backfill: any row saved before this change is plaintext, not the app's
+-- iv:authTag:ciphertext format, and cannot be decrypted after the fact — there is no key that
+-- would work, because none was ever used to encrypt it. If your deployment has pre-existing rows
+-- in this table, each affected instructor needs to re-save their LLM provider config once from
+-- Instructor → Settings after this deploys; grading against the old row 500s with "Configured
+-- LLM provider key could not be read" until they do. See docs/manuals/administrator-manual.md's
+-- "Setting up LLM grading" section for the operator-facing version of this note.


### PR DESCRIPTION
instructor_llm_config.api_key was stored as plaintext and read back unmodified to call the LLM provider SDK — the admin manual already (incorrectly) claimed it was encrypted at rest. Add lib/secretEncryption.ts (AES-256-GCM, keyed by the new LLM_CONFIG_ENCRYPTION_KEY env var, same fail-closed convention as INSTRUCTOR_SIGNUP_CODE) and wire it into the write path (POST /api/instructor/llm-config) and read path (POST /api/activities/{activityType}/llm/submissions).

Existing plaintext rows can't be decrypted after this ships; documented in supabase/schema.sql's footer and the administrator manual that affected instructors need to re-save their config once.

resolve #485 