### PR TITLE
added default question catalogs

### DIFF
--- a/__tests__/api/instructor-questions.test.ts
+++ b/__tests__/api/instructor-questions.test.ts
@@ -168,6 +168,20 @@ describe('POST /api/instructor/questions', () => {
     expect(res.status).toBe(400);
   });
 
+  // GitHub #478: a built-in example catalog (creator_id IS NULL) is strictly read-only — no new
+  // question may be filed under it, even though the activityType itself is valid.
+  it('rejects adding a question to a built-in example catalog with 403', async () => {
+    queueRole('instructor');
+    queueValidActivityType();
+    queue('activity_type', { data: { creator_id: null }, error: null }); // assertCatalogIsEditable
+
+    const res = await POST(postRequest(validBody()));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/built-in example catalog/);
+    expect(h.state.tables).not.toContain('question');
+  });
+
   it('rejects an invalid difficultyLevel with 400', async () => {
     queueRole('instructor');
     queueValidActivityType();

--- a/__tests__/api/instructor-quiz-detail.test.ts
+++ b/__tests__/api/instructor-quiz-detail.test.ts
@@ -191,6 +191,7 @@ describe('GET /api/instructor/quizzes/[activityType]', () => {
       authorName: 'Ada Brockenbrough',
       gradingKind: 'mcq',
       ratingPrompt: null,
+      isBuiltIn: false,
     });
 
     expect(body.questions).toHaveLength(2);
@@ -231,15 +232,18 @@ describe('GET /api/instructor/quizzes/[activityType]', () => {
     expect(h.state.tables).not.toContain('question');
   });
 
-  it('returns 403 with an empty body for a built-in catalog (creator_id is null)', async () => {
+  // GitHub #478: a built-in example catalog is visible (read-only) to every instructor, not just
+  // whoever created it — there is no creator to match anyway, since creator_id is NULL.
+  it('returns 200 with isBuiltIn: true for a built-in catalog (creator_id is null)', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow(), error: null }); // default creator_id: null
+    queue('question', { data: [questionRow({ user_id: null })], error: null });
 
     const res = await req();
-    expect(res.status).toBe(403);
-    expect(await res.text()).toBe('');
-    expect(h.state.tables).not.toContain('question');
-    expect(h.state.tables).not.toContain('user_story');
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.quiz.isBuiltIn).toBe(true);
+    expect(body.questions[0].ownerId).toBeNull();
   });
 
   it('returns 500 when the catalog lookup fails', async () => {

--- a/__tests__/api/instructor-quiz-duplicate.test.ts
+++ b/__tests__/api/instructor-quiz-duplicate.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Result = { data?: unknown; error?: unknown };
+
+const h = vi.hoisted(() => {
+  const state = {
+    queues: {} as Record<string, Result[]>,
+    tables: [] as string[],
+    inserts: [] as { table: string; payload: unknown }[],
+    deletes: [] as { table: string; column: string; value: unknown }[],
+  };
+
+  function makeBuilder(table: string, result: Result) {
+    let isDelete = false;
+
+    const builder: Record<string, unknown> = {
+      select: () => builder,
+      insert: (payload: unknown) => {
+        state.inserts.push({ table, payload });
+        return builder;
+      },
+      delete: () => {
+        isDelete = true;
+        return builder;
+      },
+      eq: (column: string, value: unknown) => {
+        if (isDelete) state.deletes.push({ table, column, value });
+        return builder;
+      },
+      in: (column: string, value: unknown) => {
+        if (isDelete) state.deletes.push({ table, column, value });
+        return builder;
+      },
+      maybeSingle: async () => result,
+      then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
+        Promise.resolve(result).then(onOk, onErr),
+    };
+    return builder;
+  }
+
+  return { state, makeBuilder };
+});
+
+function queue(table: string, result: Result) {
+  (h.state.queues[table] ??= []).push(result);
+}
+
+vi.mock('../../lib/supabase', () => ({
+  getSupabaseClient: () => ({
+    auth: {
+      getUser: async (token: string) =>
+        token === 'valid-token'
+          ? { data: { user: { id: 'instructor-1' } }, error: null }
+          : { data: { user: null }, error: { message: 'Invalid token' } },
+    },
+    from: (table: string) => {
+      h.state.tables.push(table);
+      const result = h.state.queues[table]?.shift() ?? { data: null, error: null };
+      return h.makeBuilder(table, result);
+    },
+  }),
+}));
+
+import { POST } from '../../app/api/instructor/quizzes/[activityType]/duplicate/route';
+
+function queueRole(role: string) {
+  queue('user', { data: { role }, error: null });
+}
+
+function quizRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+    quiz_name: 'Identify Weak User Stories',
+    description: null,
+    grading_kind: 'mcq',
+    rating_prompt: null,
+    creator_id: null,
+    creator: null,
+    ...overrides,
+  };
+}
+
+function sourceDetailRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    description: null,
+    grading_kind: 'mcq',
+    rating_prompt: null,
+    ...overrides,
+  };
+}
+
+function postRequest(body: unknown, activityType = 'IDENTIFY_WEAK_USER_STORIES', token: string | null = 'valid-token') {
+  return POST(
+    new Request(`http://localhost/api/instructor/quizzes/${activityType}/duplicate`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify(body),
+    }),
+    { params: { activityType } },
+  );
+}
+
+beforeEach(() => {
+  h.state.queues = {};
+  h.state.tables = [];
+  h.state.inserts = [];
+  h.state.deletes = [];
+});
+
+describe('POST /api/instructor/quizzes/[activityType]/duplicate', () => {
+  it('returns 401 without a token', async () => {
+    const res = await postRequest({ name: 'My Copy' }, 'IDENTIFY_WEAK_USER_STORIES', null);
+    expect(res.status).toBe(401);
+    expect(h.state.tables).toEqual([]);
+  });
+
+  it('returns 403 with an empty body when the caller is a student', async () => {
+    queueRole('student');
+    const res = await postRequest({ name: 'My Copy' });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it('returns 404 when the source catalog does not exist', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: null, error: null }); // getQuizByActivityType
+
+    const res = await postRequest({ name: 'My Copy' }, 'NOT_REAL');
+    expect(res.status).toBe(404);
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it("returns 403 with an empty body when the source catalog belongs to a different instructor (not built-in, not the caller's)", async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ activity_type: 'MY_CUSTOM_QUIZ', creator_id: 'instructor-2' }), error: null });
+
+    const res = await postRequest({ name: 'My Copy' }, 'MY_CUSTOM_QUIZ');
+    expect(res.status).toBe(403);
+    expect(await res.text()).toBe('');
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it('returns 400 for a blank name', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null }); // built-in, so visible
+
+    const res = await postRequest({ name: '   ' });
+    expect(res.status).toBe(400);
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it('returns 400 when the derived key is empty (a name with no letters or digits)', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null });
+
+    const res = await postRequest({ name: '!!!' });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/at least one letter or number/);
+    expect(h.state.inserts).toEqual([]);
+  });
+
+  it('duplicates a built-in mcq catalog: new activity_type row, questions, answers, and links, all owned by the caller', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null }); // getQuizByActivityType (route's own visibility check)
+    queue('activity_type', { data: sourceDetailRow(), error: null }); // duplicateCatalog's own read
+    queue('activity_type', { data: null, error: null }); // insert new activity_type row
+    queue('question', {
+      data: [
+        {
+          question_prompt: 'Which story is weakest?',
+          difficulty_level: 1,
+          order_number: 1,
+          max_score: 10,
+          question_to_answer: [
+            { answer: { option_text: 'Wrong', is_correct: false, explanation: null } },
+            { answer: { option_text: 'Right', is_correct: true, explanation: 'Because.' } },
+          ],
+        },
+      ],
+      error: null,
+    }); // source questions
+    queue('question', { data: null, error: null }); // question insert
+    queue('answer', { data: null, error: null }); // answer insert
+    queue('question_to_answer', { data: null, error: null }); // link insert
+
+    const res = await postRequest({ name: 'My Copy of Weak Stories' });
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.quiz).toEqual({
+      activityType: 'MY_COPY_OF_WEAK_STORIES',
+      name: 'My Copy of Weak Stories',
+      description: null,
+      gradingKind: 'mcq',
+      ratingPrompt: null,
+      questionCount: 1,
+    });
+
+    const catalogInsert = h.state.inserts.find((i) => i.table === 'activity_type');
+    expect(catalogInsert?.payload).toMatchObject({
+      activity_type: 'MY_COPY_OF_WEAK_STORIES',
+      quiz_name: 'My Copy of Weak Stories',
+      grading_kind: 'mcq',
+      creator_id: 'instructor-1',
+    });
+
+    const questionInsert = h.state.inserts.find((i) => i.table === 'question');
+    expect(questionInsert?.payload).toEqual([
+      expect.objectContaining({
+        question_prompt: 'Which story is weakest?',
+        activity_type: 'MY_COPY_OF_WEAK_STORIES',
+        difficulty_level: 1,
+        order_number: 1,
+        max_score: 10,
+        user_id: 'instructor-1',
+      }),
+    ]);
+
+    const answerInsert = h.state.inserts.find((i) => i.table === 'answer');
+    expect(answerInsert?.payload).toEqual([
+      expect.objectContaining({ option_text: 'Wrong', is_correct: false, explanation: null }),
+      expect.objectContaining({ option_text: 'Right', is_correct: true, explanation: 'Because.' }),
+    ]);
+
+    const linkInsert = h.state.inserts.find((i) => i.table === 'question_to_answer');
+    expect(linkInsert?.payload).toEqual([
+      { question_id: expect.any(String), answer_id: expect.any(String) },
+      { question_id: expect.any(String), answer_id: expect.any(String) },
+    ]);
+  });
+
+  it('duplicates a built-in llm-graded catalog: new activity_type row plus every user_story, owned by the caller', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ activity_type: 'WRITE_ACCEPTANCE_CRITERIA', grading_kind: 'llm-graded' }), error: null });
+    queue('activity_type', { data: sourceDetailRow({ grading_kind: 'llm-graded' }), error: null });
+    queue('activity_type', { data: null, error: null }); // insert
+    queue('user_story', {
+      data: [{ story_text: 'As a shopper, I want a cart.', difficulty_level: 1 }],
+      error: null,
+    });
+    queue('user_story', { data: null, error: null }); // insert
+
+    const res = await postRequest({ name: 'My AC Copy' }, 'WRITE_ACCEPTANCE_CRITERIA');
+    expect(res.status).toBe(201);
+
+    const body = await res.json();
+    expect(body.quiz).toMatchObject({ gradingKind: 'llm-graded', questionCount: 1 });
+
+    const storyInsert = h.state.inserts.find((i) => i.table === 'user_story');
+    expect(storyInsert?.payload).toEqual([
+      expect.objectContaining({
+        story_text: 'As a shopper, I want a cart.',
+        difficulty_level: 1,
+        activity_type: 'MY_AC_COPY',
+        creator_id: 'instructor-1',
+      }),
+    ]);
+
+    expect(h.state.tables).not.toContain('question');
+  });
+
+  it('lets an instructor duplicate their own (non-built-in) catalog too', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ activity_type: 'MY_CUSTOM_QUIZ', creator_id: 'instructor-1' }), error: null });
+    queue('activity_type', { data: sourceDetailRow(), error: null });
+    queue('activity_type', { data: null, error: null });
+    queue('question', { data: [], error: null });
+
+    const res = await postRequest({ name: 'Second Copy' }, 'MY_CUSTOM_QUIZ');
+    expect(res.status).toBe(201);
+  });
+
+  it('returns 409 when the derived key collides with an existing catalog', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null });
+    queue('activity_type', { data: sourceDetailRow(), error: null });
+    queue('activity_type', { data: null, error: { code: '23505', message: 'duplicate key' } }); // insert collides
+
+    const res = await postRequest({ name: 'Identify Weak User Stories' });
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toMatch(/already exists/);
+  });
+
+  it('rolls back the new catalog when copying its questions fails', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow(), error: null });
+    queue('activity_type', { data: sourceDetailRow(), error: null });
+    queue('activity_type', { data: null, error: null }); // insert succeeds
+    queue('question', { data: null, error: { message: 'DB failure' } }); // source read fails
+
+    const res = await postRequest({ name: 'My Copy' });
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toBe('DB failure');
+
+    expect(h.state.deletes).toContainEqual({ table: 'activity_type', column: 'activity_type', value: 'MY_COPY' });
+  });
+});

--- a/__tests__/api/instructor-quizzes.test.ts
+++ b/__tests__/api/instructor-quizzes.test.ts
@@ -17,6 +17,10 @@ const h = vi.hoisted(() => {
         state.filters.push({ table, column, value });
         return builder;
       },
+      is: (column: string, value: unknown) => {
+        state.filters.push({ table, column, value });
+        return builder;
+      },
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });
         return builder;
@@ -161,6 +165,7 @@ describe('GET /api/instructor/quizzes', () => {
         gradingKind: 'mcq',
         questionCount: 0,
         quizCount: 0,
+        isBuiltIn: false,
       },
     ]);
   });
@@ -243,5 +248,63 @@ describe('GET /api/instructor/quizzes', () => {
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('DB down');
+  });
+
+  // GitHub #478: every instructor also sees the built-in example catalogs, separate from their own.
+  describe('exampleCatalogs (GitHub #478)', () => {
+    it('returns the built-in catalogs (creator_id IS NULL), flagged isBuiltIn, alongside the caller\'s own', async () => {
+      queueRole('instructor');
+      queue('activity_type', { data: [], error: null }); // mine
+      queue('activity_type', { data: [quizRow()], error: null }); // examples
+
+      const res = await GET(req());
+      expect(res.status).toBe(200);
+      const body = await res.json();
+
+      expect(body.exampleCatalogs).toEqual([
+        {
+          activityType: 'IDENTIFY_WEAK_USER_STORIES',
+          name: 'Identify Weak User Stories',
+          description: null,
+          authorName: 'Built-in',
+          gradingKind: 'mcq',
+          questionCount: 36,
+          quizCount: 0,
+          isBuiltIn: true,
+        },
+      ]);
+    });
+
+    it('queries the example catalogs with .is(creator_id, null), independent of the "mine" filter', async () => {
+      queueRole('instructor');
+      queue('activity_type', { data: [], error: null });
+      queue('activity_type', { data: [], error: null });
+
+      await GET(req());
+
+      expect(h.state.filters).toContainEqual({ table: 'activity_type', column: 'creator_id', value: null });
+    });
+
+    it('flags a quiz the caller created as isBuiltIn: false', async () => {
+      queueRole('instructor');
+      queue('activity_type', { data: [quizRow({ creator_id: 'instructor-1', creator: null })], error: null });
+      queue('activity_type', { data: [], error: null });
+
+      const res = await GET(req());
+      const body = await res.json();
+
+      expect(body.quizzes[0].isBuiltIn).toBe(false);
+    });
+
+    it('returns 500 when the example-catalogs query fails, after the "mine" query already succeeded', async () => {
+      queueRole('instructor');
+      queue('activity_type', { data: [], error: null }); // mine
+      queue('activity_type', { data: null, error: { message: 'DB down' } }); // examples
+
+      const res = await GET(req());
+      expect(res.status).toBe(500);
+      const body = await res.json();
+      expect(body.error).toBe('DB down');
+    });
   });
 });

--- a/__tests__/api/instructor-user-stories.test.ts
+++ b/__tests__/api/instructor-user-stories.test.ts
@@ -230,6 +230,20 @@ describe('POST /api/instructor/user-stories', () => {
     expect(h.state.inserts).toEqual([]);
   });
 
+  // GitHub #478: a built-in example catalog (creator_id IS NULL) is strictly read-only — no new
+  // prompt may be filed under it, even though the activityType itself is a valid llm-graded key.
+  it('rejects adding a prompt to a built-in example catalog with 403', async () => {
+    queueRole('instructor');
+    queueGradingKind('llm-graded');
+    queue('activity_type', { data: { creator_id: null }, error: null }); // assertCatalogIsEditable
+
+    const res = await POST(postRequest(validBody()));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toMatch(/built-in example catalog/);
+    expect(h.state.inserts).toEqual([]);
+  });
+
   it('returns 400 for a difficulty level outside 1-3', async () => {
     for (const difficultyLevel of [0, 4, '2', null, undefined]) {
       queueRole('instructor');

--- a/app/api/instructor/questions/route.ts
+++ b/app/api/instructor/questions/route.ts
@@ -1,6 +1,7 @@
 import { getSupabaseClient } from '../../../../lib/supabase';
 import { requireInstructor } from '../../../../lib/instructorAuth';
 import { createQuestionWithAnswers, validateQuestionInput, type QuestionInputBody } from '../../../../lib/questionAuthoringQueries';
+import { assertCatalogIsEditable } from '../../../../lib/activityTypeQueries';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -15,6 +16,8 @@ function getToken(request: Request): string | null {
  * - answers must have at least 2 items, exactly one with isCorrect: true
  * - order_number is auto-assigned as MAX(order_number) + 1 for the activity type
  * - user_id is taken from the authenticated instructor, not from the request body
+ * - activityType must not be a built-in example catalog (creator_id IS NULL) — 403s otherwise
+ *   (GitHub #478, assertCatalogIsEditable in lib/activityTypeQueries.ts)
  *
  * Returns 201 with { questionId, answerIds }.
  *
@@ -45,6 +48,11 @@ export async function POST(request: Request) {
 
   const validation = await validateQuestionInput(supabase, (body ?? {}) as QuestionInputBody);
   if (!validation.ok) return Response.json({ error: validation.error }, { status: validation.status });
+
+  // GitHub #478: a built-in example catalog is strictly read-only — no new question may be filed
+  // under it, even by an instructor who owns none of its existing questions.
+  const editable = await assertCatalogIsEditable(supabase, validation.data.activityType);
+  if (!editable.ok) return editable.response;
 
   // Resolve the instructor's user_id from the token so the question is attributed to them.
   const { data: { user }, error: authError } = await supabase.auth.getUser(token!);

--- a/app/api/instructor/quizzes/[activityType]/duplicate/route.ts
+++ b/app/api/instructor/quizzes/[activityType]/duplicate/route.ts
@@ -1,0 +1,85 @@
+import { getSupabaseClient } from '../../../../../../lib/supabase';
+import { requireInstructor } from '../../../../../../lib/instructorAuth';
+import { deriveActivityTypeKey } from '../../../../../../lib/activityTypes';
+import { duplicateCatalog, getQuizByActivityType } from '../../../../../../lib/activityTypeQueries';
+
+function getToken(request: Request): string | null {
+  const auth = request.headers.get('Authorization');
+  return auth?.startsWith('Bearer ') ? auth.slice(7) : null;
+}
+
+/**
+ * POST /api/instructor/quizzes/:activityType/duplicate — copies a catalog the caller can view
+ * (GitHub #478) into a brand-new catalog they own. The main use is an example catalog's
+ * "Duplicate" action (creator_id IS NULL), but the same visibility rule GET on the sibling route
+ * uses also lets an instructor duplicate one of their own catalogs — the source is only ever read,
+ * see duplicateCatalog (lib/activityTypeQueries.ts) for the copy mechanics and its own
+ * rollback-by-hand discipline.
+ *
+ * Body: { name: string } — the copy's display name; the stored key is derived from it the same way
+ * POST /api/activities/types derives one at creation (deriveActivityTypeKey).
+ *
+ * Same visibility rule as GET on the sibling route: a catalog that's neither built-in nor the
+ * caller's own 403s here too, so this route can't be used to read a colleague's catalog contents
+ * out by guessing its activityType and duplicating it.
+ *
+ * - 401 missing/invalid bearer token
+ * - 403 caller isn't an instructor, or the source catalog belongs to a different instructor (no
+ *   body either way)
+ * - 404 source activityType matches no catalog
+ * - 400 invalid JSON, missing/blank name, or a name whose derived key is empty/too long
+ * - 409 the derived key collides with an existing catalog — pick a different name
+ * - 201 { quiz: { activityType, name, description, gradingKind, ratingPrompt, questionCount } }
+ * - 500 Supabase not configured, or a query fails
+ */
+export async function POST(request: Request, { params }: { params: { activityType: string } }) {
+  const supabase = getSupabaseClient();
+  if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
+
+  const guard = await requireInstructor(supabase, getToken(request));
+  if (!guard.ok) {
+    return guard.status === 403
+      ? new Response(null, { status: 403 })
+      : Response.json(
+          { error: guard.status === 401 ? 'Unauthorized' : 'Supabase credentials are not configured.' },
+          { status: guard.status },
+        );
+  }
+
+  const { activityType } = params;
+
+  const { quiz: source, creatorId, error: sourceError } = await getQuizByActivityType(supabase, activityType);
+  if (sourceError) return Response.json({ error: sourceError.message }, { status: 500 });
+  if (!source) return Response.json({ error: 'Catalog not found.' }, { status: 404 });
+  if (creatorId !== null && creatorId !== guard.user_id) return new Response(null, { status: 403 });
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
+  }
+
+  const { name } = (body ?? {}) as { name?: unknown };
+  if (typeof name !== 'string' || name.trim() === '') {
+    return Response.json({ error: 'name is required.' }, { status: 400 });
+  }
+
+  const keyResult = deriveActivityTypeKey(name);
+  if (!keyResult.ok) return keyResult.response;
+
+  const result = await duplicateCatalog(supabase, {
+    sourceActivityType: activityType,
+    newKey: keyResult.key,
+    newName: name.trim(),
+    creatorId: guard.user_id,
+  });
+
+  if (result.status === 'not_found') return Response.json({ error: 'Catalog not found.' }, { status: 404 });
+  if (result.status === 'name_conflict') {
+    return Response.json({ error: 'A quiz with this name already exists. Choose a different name.' }, { status: 409 });
+  }
+  if (result.status === 'error') return Response.json({ error: result.error.message }, { status: 500 });
+
+  return Response.json({ quiz: result.quiz }, { status: 201 });
+}

--- a/app/api/instructor/quizzes/[activityType]/route.ts
+++ b/app/api/instructor/quizzes/[activityType]/route.ts
@@ -20,12 +20,15 @@ function getToken(request: Request): string | null {
  * contains (GitHub #359), for the catalog detail page's read-only view. Distinct from
  * GET /api/instructor/quizzes/:activityType/:difficultyLevel/questions (own-questions-only, one
  * level, 403s when the caller owns none of that level) — this route answers "what's in this
- * catalog", scoped the same "mine only" way the browse list is: a catalog is visible here only if
- * creator_id matches the caller, so a built-in or colleague's catalog 403s even though it exists.
+ * catalog", scoped the same "mine only" way the browse list is, with one exception (GitHub #478):
+ * a built-in example catalog (creator_id IS NULL) is visible here to every instructor too, always
+ * read-only (quiz.isBuiltIn is what tells the client to lock the page down) — only a colleague's
+ * own catalog still 403s even though it exists.
  *
  * - 401 missing/invalid bearer token
- * - 403 caller isn't an instructor (no body), or is an instructor but doesn't own this catalog
- *   (no body — same 404-then-403 ordering as e.g. lib/courseQueries.ts's findOwnedCourse)
+ * - 403 caller isn't an instructor (no body), or is an instructor but the catalog belongs to a
+ *   different instructor (no body — same 404-then-403 ordering as e.g. lib/courseQueries.ts's
+ *   findOwnedCourse)
  * - 404 activityType matches no catalog
  * - 200 { quiz, questions: CatalogQuestion[], userStories: CatalogUserStory[], titles: StoredTitleRung[] }
  * - 500 Supabase not configured, or either query fails
@@ -55,7 +58,7 @@ export async function GET(request: Request, { params }: { params: { activityType
   const { quiz, creatorId, error: quizError } = await getQuizByActivityType(supabase, activityType);
   if (quizError) return Response.json({ error: quizError.message }, { status: 500 });
   if (!quiz) return Response.json({ error: 'Catalog not found.' }, { status: 404 });
-  if (creatorId !== guard.user_id) return new Response(null, { status: 403 });
+  if (creatorId !== null && creatorId !== guard.user_id) return new Response(null, { status: 403 });
 
   // The mastery title ladder is catalog-level metadata, not a pool, so it comes back for both
   // grading kinds — an llm-graded catalog earns titles exactly the same way an MCQ one does.

--- a/app/api/instructor/quizzes/route.ts
+++ b/app/api/instructor/quizzes/route.ts
@@ -1,6 +1,6 @@
 import { getSupabaseClient } from '../../../../lib/supabase';
 import { requireInstructor } from '../../../../lib/instructorAuth';
-import { listQuizzesWithAuthorAndCount } from '../../../../lib/activityTypeQueries';
+import { listExampleCatalogsWithCount, listQuizzesWithAuthorAndCount } from '../../../../lib/activityTypeQueries';
 
 function getToken(request: Request): string | null {
   const auth = request.headers.get('Authorization');
@@ -19,8 +19,13 @@ function getToken(request: Request): string | null {
  *
  * - 401 missing/invalid bearer token
  * - 403 caller isn't an instructor (no body)
- * - 200 { quizzes: [{ activityType, name, description, authorName, questionCount }] }
- * - 500 Supabase not configured, or the query fails
+ * GitHub #478: also returns exampleCatalogs — the three seeded, ownerless catalogs (creator_id IS
+ * NULL) every instructor sees regardless of what they've created themselves, so a first-time
+ * instructor has something to look at (and duplicate) before their own "mine only" list has
+ * anything in it.
+ *
+ * - 200 { quizzes: [{ activityType, name, description, authorName, questionCount, isBuiltIn }], exampleCatalogs: [...] }
+ * - 500 Supabase not configured, or either query fails
  */
 export async function GET(request: Request) {
   const supabase = getSupabaseClient();
@@ -41,5 +46,10 @@ export async function GET(request: Request) {
     return Response.json({ error: error?.message ?? 'Could not load quizzes.' }, { status: 500 });
   }
 
-  return Response.json({ quizzes }, { status: 200 });
+  const { quizzes: exampleCatalogs, error: exampleError } = await listExampleCatalogsWithCount(supabase);
+  if (exampleError || !exampleCatalogs) {
+    return Response.json({ error: exampleError?.message ?? 'Could not load example catalogs.' }, { status: 500 });
+  }
+
+  return Response.json({ quizzes, exampleCatalogs }, { status: 200 });
 }

--- a/app/api/instructor/user-stories/route.ts
+++ b/app/api/instructor/user-stories/route.ts
@@ -2,6 +2,7 @@ import { getSupabaseClient } from '../../../../lib/supabase';
 import { requireInstructor } from '../../../../lib/instructorAuth';
 import { validateUserStoryInput } from '../../../../lib/userStoryInput';
 import { createUserStory } from '../../../../lib/userStoryAuthoringQueries';
+import { assertCatalogIsEditable } from '../../../../lib/activityTypeQueries';
 import type { InstructorUserStoryEntry } from '../../../../lib/llmActivityTypes';
 
 function getToken(request: Request): string | null {
@@ -76,6 +77,8 @@ export async function GET(request: Request) {
  * - creator_id is taken from the authenticated instructor, never the body. It also decides which
  *   instructor_llm_config grades submissions against this prompt, which is why the seeded
  *   (creator_id NULL) set is ungradable.
+ * - activityType must not be a built-in example catalog (creator_id IS NULL) — 403s otherwise
+ *   (GitHub #478, assertCatalogIsEditable in lib/activityTypeQueries.ts)
  *
  * Two deliberate differences from the questions route, both because user_story is a leaf table:
  * there is no order_number to auto-assign (the column doesn't exist — prompts are ordered by level
@@ -114,6 +117,11 @@ export async function POST(request: Request) {
 
   const validation = await validateUserStoryInput(supabase, { storyText, activityType, difficultyLevel });
   if (!validation.ok) return validation.response;
+
+  // GitHub #478: a built-in example catalog is strictly read-only — no new prompt may be filed
+  // under it, even by an instructor who owns none of its existing prompts.
+  const editable = await assertCatalogIsEditable(supabase, validation.activityType);
+  if (!editable.ok) return editable.response;
 
   const { data: { user }, error: authError } = await supabase.auth.getUser(token!);
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });

--- a/app/instructor/assembled-quizzes/[quizId]/page.tsx
+++ b/app/instructor/assembled-quizzes/[quizId]/page.tsx
@@ -131,7 +131,9 @@ export default function AssembledQuizDetailPage({ params }: { params: { quizId: 
       setExtraUserStories(detailResult.data.extraUserStories);
       setActiveCatalogQuestionIds(detailResult.data.activeCatalogQuestionIds);
       setActiveCatalogUserStoryIds(detailResult.data.activeCatalogUserStoryIds);
-      setAllCatalogs(catalogsResult.data.quizzes);
+      // GitHub #478: a built-in example catalog can be added to a quiz's composition too — linking
+      // only writes to assembled_quiz_catalog, never to the catalog itself.
+      setAllCatalogs([...catalogsResult.data.quizzes, ...catalogsResult.data.exampleCatalogs]);
     });
 
     return () => {

--- a/app/instructor/assembled-quizzes/page.tsx
+++ b/app/instructor/assembled-quizzes/page.tsx
@@ -47,7 +47,10 @@ export default function InstructorAssembledQuizzesPage() {
         if (cancelled) return;
         if (quizzesResult.ok && catalogsResult.ok && coursesResult.ok) {
           setQuizzes(quizzesResult.data.quizzes);
-          setCatalogs(catalogsResult.data.quizzes);
+          // GitHub #478: a quiz can compose a built-in example catalog too, not just the
+          // instructor's own — composing only links it (assembled_quiz_catalog), it never writes
+          // to the catalog itself, so this doesn't compromise "the original is read-only".
+          setCatalogs([...catalogsResult.data.quizzes, ...catalogsResult.data.exampleCatalogs]);
           setCourses(coursesResult.data.courses);
         } else {
           setLoadFailed(true);

--- a/app/instructor/quizzes/[activityType]/page.tsx
+++ b/app/instructor/quizzes/[activityType]/page.tsx
@@ -7,6 +7,7 @@ import { AppShell } from '../../../../components/AppShell';
 import { CatalogPromptCard } from '../../../../components/CatalogPromptCard';
 import { ConfirmModal } from '../../../../components/ConfirmModal';
 import { DeleteQuestionModal } from '../../../../components/DeleteQuestionModal';
+import { DuplicateCatalogModal } from '../../../../components/DuplicateCatalogModal';
 import { PromptFormModal } from '../../../../components/PromptFormModal';
 import { QuestionFormModal } from '../../../../components/QuestionFormModal';
 import { RatingPromptModal } from '../../../../components/RatingPromptModal';
@@ -50,6 +51,15 @@ function TrashIcon() {
       <path d="M8 6V4h8v2" />
       <path d="M19 6l-1 14H6L5 6" />
       <path d="M10 11v6M14 11v6" />
+    </svg>
+  );
+}
+
+function LockIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <rect x="5" y="11" width="14" height="9" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
     </svg>
   );
 }
@@ -105,6 +115,7 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
   const [toastMessage, setToastMessage] = useState<string | null>(null);
   const [showDeleteCatalog, setShowDeleteCatalog] = useState(false);
   const [ratingPromptModalOpen, setRatingPromptModalOpen] = useState(false);
+  const [duplicateModalOpen, setDuplicateModalOpen] = useState(false);
 
   useEffect(() => {
     if (!token) return;
@@ -138,6 +149,10 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
   if (!token || !profile) return null;
 
   const llmGraded = quiz?.gradingKind === 'llm-graded';
+  // GitHub #478: a built-in example catalog is visible to every instructor now, but strictly
+  // read-only — no Edit toggle, no add/edit/delete, no Delete-catalog button. "Duplicate" is the
+  // only action available on one.
+  const isBuiltIn = quiz?.isBuiltIn ?? false;
   const items = llmGraded ? prompts ?? [] : questions ?? [];
   const visibleQuestions = (questions ?? []).filter((question) => level === 'all' || question.level === level);
   const visiblePrompts = (prompts ?? []).filter((prompt) => level === 'all' || prompt.level === level);
@@ -276,6 +291,12 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
     return { ok: true };
   }
 
+  function handleDuplicated(duplicated: { activityType: string }) {
+    // The new catalog is a normal, fully editable one — hand off to its own detail page rather
+    // than staying on this (still read-only) one.
+    router.push(`/instructor/quizzes/${encodeURIComponent(duplicated.activityType)}`);
+  }
+
   return (
     <AppShell active="instructor-quizzes">
       <div className="mx-auto max-w-3xl">
@@ -316,40 +337,61 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
                 </p>
               </div>
               <div className="flex flex-none items-center gap-2">
-                {editMode ? (
+                {isBuiltIn ? (
                   <button
                     type="button"
-                    onClick={() => (llmGraded ? setPromptModalState({ mode: 'add' }) : setModalState({ mode: 'add' }))}
+                    onClick={() => setDuplicateModalOpen(true)}
                     className="flex items-center gap-2 rounded-full bg-brand-purple px-5 py-2.5 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
                   >
-                    <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round">
-                      <path d="M12 5v14M5 12h14" />
-                    </svg>
-                    {llmGraded ? 'New Prompt' : 'New Question'}
+                    Duplicate
                   </button>
-                ) : null}
-                <button
-                  type="button"
-                  onClick={() => setEditMode((current) => !current)}
-                  className={`rounded-full border px-5 py-2.5 text-sm font-extrabold transition ${
-                    editMode
-                      ? 'border-gray-300 bg-white text-gray-600 hover:border-brand-purple hover:text-brand-purple'
-                      : 'border-brand-purple bg-white text-brand-purple hover:bg-brand-purple hover:text-white'
-                  }`}
-                >
-                  {editMode ? 'Done' : 'Edit'}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setShowDeleteCatalog(true)}
-                  aria-label="Delete this catalog"
-                  title="Delete this catalog"
-                  className="flex h-10 w-10 flex-none items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 transition hover:border-brand-danger hover:text-brand-danger"
-                >
-                  <TrashIcon />
-                </button>
+                ) : (
+                  <>
+                    {editMode ? (
+                      <button
+                        type="button"
+                        onClick={() => (llmGraded ? setPromptModalState({ mode: 'add' }) : setModalState({ mode: 'add' }))}
+                        className="flex items-center gap-2 rounded-full bg-brand-purple px-5 py-2.5 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark"
+                      >
+                        <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round">
+                          <path d="M12 5v14M5 12h14" />
+                        </svg>
+                        {llmGraded ? 'New Prompt' : 'New Question'}
+                      </button>
+                    ) : null}
+                    <button
+                      type="button"
+                      onClick={() => setEditMode((current) => !current)}
+                      className={`rounded-full border px-5 py-2.5 text-sm font-extrabold transition ${
+                        editMode
+                          ? 'border-gray-300 bg-white text-gray-600 hover:border-brand-purple hover:text-brand-purple'
+                          : 'border-brand-purple bg-white text-brand-purple hover:bg-brand-purple hover:text-white'
+                      }`}
+                    >
+                      {editMode ? 'Done' : 'Edit'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setShowDeleteCatalog(true)}
+                      aria-label="Delete this catalog"
+                      title="Delete this catalog"
+                      className="flex h-10 w-10 flex-none items-center justify-center rounded-full border border-gray-200 bg-white text-gray-500 transition hover:border-brand-danger hover:text-brand-danger"
+                    >
+                      <TrashIcon />
+                    </button>
+                  </>
+                )}
               </div>
             </div>
+
+            {isBuiltIn ? (
+              <div className="mb-5 mt-5 flex items-center gap-2.5 rounded-brand-md border border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-600">
+                <span className="flex h-6 w-6 flex-none items-center justify-center rounded-full bg-gray-200 text-gray-500">
+                  <LockIcon />
+                </span>
+                This is a built-in example catalog. It's read-only — duplicate it to make your own editable copy.
+              </div>
+            ) : null}
 
             {toastMessage ? (
               <div
@@ -389,13 +431,15 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
                     <p className="text-sm font-medium text-gray-400">Using the built-in default rubric.</p>
                   )}
                 </div>
-                <button
-                  type="button"
-                  onClick={() => setRatingPromptModalOpen(true)}
-                  className="flex-none rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-extrabold text-gray-600 transition hover:border-brand-purple hover:text-brand-purple"
-                >
-                  {quiz.ratingPrompt ? 'Edit rubric' : 'Set rubric'}
-                </button>
+                {isBuiltIn ? null : (
+                  <button
+                    type="button"
+                    onClick={() => setRatingPromptModalOpen(true)}
+                    className="flex-none rounded-full border border-gray-300 bg-white px-4 py-1.5 text-xs font-extrabold text-gray-600 transition hover:border-brand-purple hover:text-brand-purple"
+                  >
+                    {quiz.ratingPrompt ? 'Edit rubric' : 'Set rubric'}
+                  </button>
+                )}
               </div>
             ) : null}
 
@@ -556,6 +600,15 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
           initialValue={quiz?.ratingPrompt ?? ''}
           onCancel={() => setRatingPromptModalOpen(false)}
           onSave={handleSaveRatingPrompt}
+        />
+      ) : null}
+
+      {duplicateModalOpen && quiz ? (
+        <DuplicateCatalogModal
+          catalog={{ activityType: params.activityType, name: quiz.name }}
+          token={token}
+          onClose={() => setDuplicateModalOpen(false)}
+          onCreated={handleDuplicated}
         />
       ) : null}
 

--- a/app/instructor/quizzes/page.tsx
+++ b/app/instructor/quizzes/page.tsx
@@ -5,17 +5,41 @@ import { Suspense, useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { AppShell } from '../../../components/AppShell';
 import { CreateCatalogModal } from '../../../components/CreateCatalogModal';
-import { loadQuizzes, type CreatedQuiz, type QuizSummary } from '../../../lib/quizClient';
+import { DuplicateCatalogModal } from '../../../components/DuplicateCatalogModal';
+import { loadQuizzes, type CreatedQuiz, type DuplicatedQuiz, type QuizSummary } from '../../../lib/quizClient';
 import { useRequireRole } from '../../../lib/useRequireRole';
 
 const TOAST_MS = 3200;
 
+function LockIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <rect x="5" y="11" width="14" height="9" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </svg>
+  );
+}
+
+function GradingKindBadge({ gradingKind }: { gradingKind: QuizSummary['gradingKind'] }) {
+  return (
+    <span
+      className={`rounded-full px-2.5 py-1 text-xs font-extrabold ${
+        gradingKind === 'llm-graded' ? 'bg-brand-teal/15 text-brand-teal-dark' : 'bg-brand-purple/10 text-brand-purple-dark'
+      }`}
+    >
+      {gradingKind === 'llm-graded' ? 'LLM-graded' : 'Multiple choice'}
+    </span>
+  );
+}
+
 /**
- * GitHub #347/#359: every question catalog the calling instructor created, plus the
- * create-catalog flow (a button-triggered popup, GitHub #359 follow-up, replacing the permanently
- * visible inline form this page used to render below the list). Scoped to creator_id = the caller
- * — built-in catalogs and colleagues' catalogs are not shown, the same "mine only" convention the
- * Courses pages already use.
+ * GitHub #347/#359/#478: every question catalog the calling instructor created, plus the built-in
+ * example catalogs every instructor sees regardless (GitHub #478) — two clearly separated lists,
+ * the "mine only" convention the Courses pages already use extended with a second, always-visible
+ * section so a first-time instructor has something concrete to look at (and duplicate) before
+ * their own list has anything in it. Also the create-catalog flow (a button-triggered popup,
+ * GitHub #359 follow-up, replacing the permanently visible inline form this page used to render
+ * below the list).
  *
  * A catalog has no course of its own (activity_type_course, the table that used to link one
  * directly, is gone) — the "Used in" column instead shows how many assembled quizzes (GitHub
@@ -27,7 +51,8 @@ const TOAST_MS = 3200;
  * are the same concept — see CLAUDE.md's Question Catalogs section for why the user-facing name
  * changed but the underlying activity_type-backed plumbing from GitHub #347 didn't. Clicking a
  * row goes to app/instructor/quizzes/[activityType]/page.tsx, the catalog detail/edit view
- * (GitHub #359) that replaces the retired flat Question Bank page.
+ * (GitHub #359) that replaces the retired flat Question Bank page — an example catalog opens the
+ * same page in its strictly read-only mode (GitHub #478).
  */
 export default function InstructorQuizzesPage() {
   return (
@@ -43,10 +68,12 @@ function InstructorQuizzesContent() {
   const fromCourseId = searchParams.get('courseId');
 
   const [quizzes, setQuizzes] = useState<QuizSummary[] | null>(null);
+  const [exampleCatalogs, setExampleCatalogs] = useState<QuizSummary[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
 
   const [showCreateModal, setShowCreateModal] = useState(false);
+  const [duplicateTarget, setDuplicateTarget] = useState<QuizSummary | null>(null);
   const [toastMessage, setToastMessage] = useState<string | null>(null);
 
   useEffect(() => {
@@ -57,8 +84,12 @@ function InstructorQuizzesContent() {
 
     loadQuizzes(token).then((result) => {
       if (cancelled) return;
-      if (result.ok) setQuizzes(result.data.quizzes);
-      else setLoadFailed(true);
+      if (result.ok) {
+        setQuizzes(result.data.quizzes);
+        setExampleCatalogs(result.data.exampleCatalogs);
+      } else {
+        setLoadFailed(true);
+      }
     });
 
     return () => {
@@ -67,6 +98,7 @@ function InstructorQuizzesContent() {
   }, [token, retryCount]);
 
   const visibleQuizzes = quizzes ?? [];
+  const visibleExamples = exampleCatalogs ?? [];
 
   if (loading || !authorized) return null;
   if (!token || !profile) return null;
@@ -87,11 +119,35 @@ function InstructorQuizzesContent() {
         gradingKind: quiz.gradingKind,
         questionCount: 0,
         quizCount: 0,
+        isBuiltIn: false,
       },
       ...(current ?? []),
     ]);
 
     setToastMessage(`"${quiz.name}" created.`);
+    window.setTimeout(() => setToastMessage(null), TOAST_MS);
+  }
+
+  function handleDuplicated(quiz: DuplicatedQuiz) {
+    const fullName = [profile?.first_name, profile?.last_name].filter(Boolean).join(' ').trim();
+    const authorName = fullName || profile?.username || 'You';
+
+    setQuizzes((current) => [
+      {
+        activityType: quiz.activityType,
+        name: quiz.name,
+        description: quiz.description,
+        authorName,
+        gradingKind: quiz.gradingKind,
+        questionCount: quiz.questionCount,
+        quizCount: 0,
+        isBuiltIn: false,
+      },
+      ...(current ?? []),
+    ]);
+
+    setDuplicateTarget(null);
+    setToastMessage(`"${quiz.name}" duplicated to My Catalogs.`);
     window.setTimeout(() => setToastMessage(null), TOAST_MS);
   }
 
@@ -141,9 +197,8 @@ function InstructorQuizzesContent() {
           </div>
         ) : null}
 
-        <div className="mt-6">
-          {loadFailed ? (
-          <div className="mb-6 rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-6 text-center">
+        {loadFailed ? (
+          <div className="mb-6 mt-6 rounded-brand-lg border border-brand-danger/40 bg-brand-danger/10 p-6 text-center">
             <p className="mb-4 text-sm font-semibold text-brand-danger">Failed to load quizzes.</p>
             <button
               type="button"
@@ -153,72 +208,136 @@ function InstructorQuizzesContent() {
               Retry
             </button>
           </div>
-        ) : quizzes === null ? (
-          <p className="mb-6 text-sm font-semibold text-gray-500">Loading…</p>
+        ) : quizzes === null || exampleCatalogs === null ? (
+          <p className="mb-6 mt-6 text-sm font-semibold text-gray-500">Loading…</p>
         ) : (
           <>
-            <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">
-              {visibleQuizzes.length} catalog{visibleQuizzes.length === 1 ? '' : 's'}
-            </p>
+            {/* GitHub #478: shown above "My Catalogs" and unconditionally, so a first-time
+                instructor has something concrete to look at before they've created anything. */}
+            <div className="mt-8">
+              <p className="mb-1 text-xs font-extrabold uppercase tracking-wide text-gray-400">Example Catalogs</p>
+              <p className="mb-3 text-xs font-semibold text-gray-500">
+                Pre-built, ready-to-use catalogs. Browse them for reference, or duplicate one to start your own —
+                the originals never change.
+              </p>
 
-            <div className="mb-8 overflow-x-auto rounded-brand-lg border border-brand-navy-border">
-              <table className="w-full min-w-[640px] text-sm">
-                <thead>
-                  <tr className="bg-brand-navy text-brand-ink-muted">
-                    <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Name</th>
-                    <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Description</th>
-                    <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Type</th>
-                    <th className="whitespace-nowrap px-4 py-3 text-right text-xs font-bold uppercase tracking-wide">Used in</th>
-                    <th className="whitespace-nowrap px-4 py-3 text-right text-xs font-bold uppercase tracking-wide">Questions</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {visibleQuizzes.length === 0 ? (
-                    <tr>
-                      <td colSpan={5} className="bg-brand-navy-2 px-4 py-10 text-center text-sm font-semibold text-brand-ink-muted">
-                        You haven't created any catalogs yet.
-                      </td>
+              <div className="mb-8 overflow-x-auto rounded-brand-lg border border-brand-navy-border">
+                <table className="w-full min-w-[640px] text-sm">
+                  <thead>
+                    <tr className="bg-brand-navy text-brand-ink-muted">
+                      <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Name</th>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Description</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Type</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-right text-xs font-bold uppercase tracking-wide">Questions</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-right text-xs font-bold uppercase tracking-wide">
+                        <span className="sr-only">Actions</span>
+                      </th>
                     </tr>
-                  ) : (
-                    visibleQuizzes.map((quiz) => (
-                      <tr key={quiz.activityType} className="border-t border-gray-100 bg-white transition hover:bg-gray-50">
-                        <td className="whitespace-nowrap px-4 py-3 font-extrabold text-brand-navy">
-                          <Link href={`/instructor/quizzes/${encodeURIComponent(quiz.activityType)}`} className="hover:text-brand-purple hover:underline">
-                            {quiz.name}
-                          </Link>
+                  </thead>
+                  <tbody>
+                    {visibleExamples.length === 0 ? (
+                      <tr>
+                        <td colSpan={5} className="bg-brand-navy-2 px-4 py-10 text-center text-sm font-semibold text-brand-ink-muted">
+                          No example catalogs are available yet.
                         </td>
-                        <td className="px-4 py-3 text-gray-500">{quiz.description || '—'}</td>
-                        <td className="whitespace-nowrap px-4 py-3">
-                          {/* GitHub #379: questionCount counts questions for one kind and prompts
-                              for the other, so the column header alone can't say what the number
-                              means — this badge is what disambiguates it. */}
-                          <span
-                            className={`rounded-full px-2.5 py-1 text-xs font-extrabold ${
-                              quiz.gradingKind === 'llm-graded'
-                                ? 'bg-brand-teal/15 text-brand-teal-dark'
-                                : 'bg-brand-purple/10 text-brand-purple-dark'
-                            }`}
-                          >
-                            {quiz.gradingKind === 'llm-graded' ? 'LLM-graded' : 'Multiple choice'}
-                          </span>
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-right text-gray-500">
-                          {quiz.quizCount} quiz{quiz.quizCount === 1 ? '' : 'zes'}
-                        </td>
-                        <td className="whitespace-nowrap px-4 py-3 text-right font-bold text-gray-600">{quiz.questionCount}</td>
                       </tr>
-                    ))
-                  )}
-                </tbody>
-              </table>
+                    ) : (
+                      visibleExamples.map((quiz) => (
+                        <tr key={quiz.activityType} className="border-t border-gray-100 bg-white transition hover:bg-gray-50">
+                          <td className="whitespace-nowrap px-4 py-3 font-extrabold text-brand-navy">
+                            <Link
+                              href={`/instructor/quizzes/${encodeURIComponent(quiz.activityType)}`}
+                              className="inline-flex items-center gap-1.5 hover:text-brand-purple hover:underline"
+                            >
+                              <span className="text-gray-400">
+                                <LockIcon />
+                              </span>
+                              {quiz.name}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-3 text-gray-500">{quiz.description || '—'}</td>
+                          <td className="whitespace-nowrap px-4 py-3">
+                            <GradingKindBadge gradingKind={quiz.gradingKind} />
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right font-bold text-gray-600">{quiz.questionCount}</td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right">
+                            <button
+                              type="button"
+                              onClick={() => setDuplicateTarget(quiz)}
+                              className="rounded-full border border-gray-300 bg-white px-3.5 py-1.5 text-xs font-extrabold text-gray-600 transition hover:border-brand-purple hover:text-brand-purple"
+                            >
+                              Duplicate
+                            </button>
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div className="mt-2">
+              <p className="mb-1 text-xs font-extrabold uppercase tracking-wide text-gray-400">
+                My Catalogs — {visibleQuizzes.length} catalog{visibleQuizzes.length === 1 ? '' : 's'}
+              </p>
+
+              <div className="mb-8 overflow-x-auto rounded-brand-lg border border-brand-navy-border">
+                <table className="w-full min-w-[640px] text-sm">
+                  <thead>
+                    <tr className="bg-brand-navy text-brand-ink-muted">
+                      <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Name</th>
+                      <th className="px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Description</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-left text-xs font-bold uppercase tracking-wide">Type</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-right text-xs font-bold uppercase tracking-wide">Used in</th>
+                      <th className="whitespace-nowrap px-4 py-3 text-right text-xs font-bold uppercase tracking-wide">Questions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {visibleQuizzes.length === 0 ? (
+                      <tr>
+                        <td colSpan={5} className="bg-brand-navy-2 px-4 py-10 text-center text-sm font-semibold text-brand-ink-muted">
+                          You haven't created any catalogs yet. Duplicate an example above to get started.
+                        </td>
+                      </tr>
+                    ) : (
+                      visibleQuizzes.map((quiz) => (
+                        <tr key={quiz.activityType} className="border-t border-gray-100 bg-white transition hover:bg-gray-50">
+                          <td className="whitespace-nowrap px-4 py-3 font-extrabold text-brand-navy">
+                            <Link href={`/instructor/quizzes/${encodeURIComponent(quiz.activityType)}`} className="hover:text-brand-purple hover:underline">
+                              {quiz.name}
+                            </Link>
+                          </td>
+                          <td className="px-4 py-3 text-gray-500">{quiz.description || '—'}</td>
+                          <td className="whitespace-nowrap px-4 py-3">
+                            <GradingKindBadge gradingKind={quiz.gradingKind} />
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right text-gray-500">
+                            {quiz.quizCount} quiz{quiz.quizCount === 1 ? '' : 'zes'}
+                          </td>
+                          <td className="whitespace-nowrap px-4 py-3 text-right font-bold text-gray-600">{quiz.questionCount}</td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
             </div>
           </>
-          )}
-        </div>
+        )}
       </div>
 
       {showCreateModal ? (
         <CreateCatalogModal token={token} onClose={() => setShowCreateModal(false)} onCreated={handleCreated} />
+      ) : null}
+
+      {duplicateTarget ? (
+        <DuplicateCatalogModal
+          catalog={duplicateTarget}
+          token={token}
+          onClose={() => setDuplicateTarget(null)}
+          onCreated={handleDuplicated}
+        />
       ) : null}
     </AppShell>
   );

--- a/components/DuplicateCatalogModal.tsx
+++ b/components/DuplicateCatalogModal.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useState } from 'react';
+import { duplicateCatalog, type DuplicatedQuiz } from '../lib/quizClient';
+import { useModalDismiss } from './useModalDismiss';
+
+/**
+ * GitHub #478: the popup behind an example catalog's "Duplicate" action — same
+ * ask-for-a-name-then-submit shape as DuplicateCourseModal.tsx, minus that one's reveal-the-code
+ * second phase: a duplicated catalog has nothing analogous to a join code to read back, so success
+ * just closes the modal and hands the new catalog to the caller (a list row + toast on the browse
+ * page, same timing CreateCatalogModal's onCreated already uses).
+ *
+ * Only the name is asked for — grading kind and every question/prompt are copied automatically
+ * server-side (POST /api/instructor/quizzes/{activityType}/duplicate). The source catalog is only
+ * ever read.
+ */
+export function DuplicateCatalogModal({
+  catalog,
+  token,
+  onClose,
+  onCreated,
+}: {
+  catalog: { activityType: string; name: string };
+  token: string;
+  onClose: () => void;
+  onCreated: (quiz: DuplicatedQuiz) => void;
+}) {
+  const [name, setName] = useState(`${catalog.name} (Copy)`);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+
+  const { panelRef, firstFieldRef, requestClose } = useModalDismiss<HTMLDivElement, HTMLInputElement>({
+    onClose,
+    isBlocked: submitting,
+  });
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!name.trim() || submitting) return;
+
+    setSubmitting(true);
+    setError('');
+
+    const result = await duplicateCatalog(token, catalog.activityType, { name: name.trim() });
+    setSubmitting(false);
+
+    if (!result.ok) {
+      // A 409 name collision lands here with the route's own message — shown in place, not
+      // closed, so the instructor can pick another name without retyping anything.
+      setError(result.error);
+      return;
+    }
+
+    onCreated(result.data.quiz);
+    requestClose();
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4 py-8"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) requestClose();
+      }}
+    >
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="duplicate-catalog-title"
+        className="w-full max-w-md rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
+      >
+        <div className="mb-5 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-wide text-brand-gold">Question Catalogs</p>
+            <h2 id="duplicate-catalog-title" className="mt-1 text-xl font-extrabold text-white">
+              Duplicate Catalog
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={requestClose}
+            disabled={submitting}
+            aria-label="Close"
+            className="flex h-8 w-8 flex-none items-center justify-center rounded-full border border-brand-navy-border bg-brand-navy-2 text-brand-ink-muted transition hover:text-white disabled:opacity-60"
+          >
+            <svg viewBox="0 0 24 24" className="h-3.5 w-3.5" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <label className="mb-1.5 block text-xs font-extrabold uppercase tracking-wide text-brand-ink-muted">
+            Copy name
+            <input
+              ref={firstFieldRef}
+              type="text"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              className="mt-1.5 block w-full rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
+            />
+          </label>
+
+          <p className="mt-3 text-xs font-semibold text-brand-ink-muted">
+            Every question copies into your own catalog — "{catalog.name}" is left exactly as it is. You can edit
+            or delete the copy freely afterward.
+          </p>
+
+          {error ? <p className="mt-3 text-xs font-bold text-brand-danger">{error}</p> : null}
+
+          <div className="mt-6 flex justify-end gap-3">
+            <button
+              type="button"
+              onClick={requestClose}
+              disabled={submitting}
+              className="rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-4 py-2 text-sm font-extrabold text-brand-ink-muted transition hover:text-white disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!name.trim() || submitting}
+              className="rounded-brand-md bg-brand-purple px-5 py-2 text-sm font-extrabold text-white transition hover:bg-brand-purple-dark disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {submitting ? 'Duplicating…' : 'Duplicate'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/lib/activityTypeQueries.ts
+++ b/lib/activityTypeQueries.ts
@@ -25,6 +25,10 @@ export type QuizSummary = {
    *  no course of its own, so this is the closest honest answer to "where is this used" the
    *  browse page can show. Zero just means nobody has composed it into a quiz yet, not an error. */
   quizCount: number;
+  /** GitHub #478: true for one of the three seeded example catalogs (creator_id IS NULL) — the
+   *  same test authorNameOf already uses to say "Built-in", surfaced as its own boolean so callers
+   *  don't have to string-match authorName to decide whether to lock the UI down. */
+  isBuiltIn: boolean;
 };
 
 type QuizRow = {
@@ -77,31 +81,54 @@ function authorNameOf(row: QuizRow): string {
  * counts becomes questionCount. Both are fetched unconditionally because it is one query either
  * way; the unused one is always 0, since a catalog only ever fills one pool.
  */
+function buildQuizSummary(row: QuizRow): QuizSummary {
+  const gradingKind = gradingKindOf(row);
+
+  return {
+    activityType: row.activity_type,
+    name: row.quiz_name,
+    description: row.description,
+    authorName: authorNameOf(row),
+    gradingKind,
+    questionCount: itemCountOf(row, gradingKind),
+    quizCount: row.assembled_quiz_catalog?.[0]?.count ?? 0,
+    isBuiltIn: row.creator_id === null,
+  };
+}
+
+const QUIZ_SUMMARY_SELECT =
+  'activity_type, quiz_name, description, grading_kind, creator_id, creator:creator_id(first_name, last_name, username), question(count), user_story(count), assembled_quiz_catalog(count)';
+
 export async function listQuizzesWithAuthorAndCount(supabase: SupabaseClient, instructorId: string) {
   const { data, error } = await supabase
     .from('activity_type')
-    .select(
-      'activity_type, quiz_name, description, grading_kind, creator_id, creator:creator_id(first_name, last_name, username), question(count), user_story(count), assembled_quiz_catalog(count)',
-    )
+    .select(QUIZ_SUMMARY_SELECT)
     .eq('creator_id', instructorId)
     .order('quiz_name', { ascending: true });
 
   if (error) return { quizzes: null, error };
 
-  const quizzes: QuizSummary[] = ((data ?? []) as unknown as QuizRow[]).map((row) => {
-    const gradingKind = gradingKindOf(row);
+  const quizzes: QuizSummary[] = ((data ?? []) as unknown as QuizRow[]).map(buildQuizSummary);
+  return { quizzes, error: null };
+}
 
-    return {
-      activityType: row.activity_type,
-      name: row.quiz_name,
-      description: row.description,
-      authorName: authorNameOf(row),
-      gradingKind,
-      questionCount: itemCountOf(row, gradingKind),
-      quizCount: row.assembled_quiz_catalog?.[0]?.count ?? 0,
-    };
-  });
+/**
+ * GitHub #478: the three seeded, ownerless catalogs (creator_id IS NULL) every instructor sees as
+ * "Example Catalogs" — the opposite scope from listQuizzesWithAuthorAndCount's "mine only" list,
+ * queried with the same row shape so the browse page can render both lists through one QuizSummary
+ * type. Not restricted to exactly three rows — any catalog with no creator counts, so this stays
+ * correct if a future migration seeds more.
+ */
+export async function listExampleCatalogsWithCount(supabase: SupabaseClient) {
+  const { data, error } = await supabase
+    .from('activity_type')
+    .select(QUIZ_SUMMARY_SELECT)
+    .is('creator_id', null)
+    .order('quiz_name', { ascending: true });
 
+  if (error) return { quizzes: null, error };
+
+  const quizzes: QuizSummary[] = ((data ?? []) as unknown as QuizRow[]).map(buildQuizSummary);
   return { quizzes, error: null };
 }
 
@@ -147,6 +174,7 @@ export async function getQuizByActivityType(supabase: SupabaseClient, activityTy
     authorName: authorNameOf(row),
     gradingKind: gradingKindOf(row),
     ratingPrompt: row.rating_prompt,
+    isBuiltIn: row.creator_id === null,
   };
 
   return { quiz, creatorId: row.creator_id, error: null };
@@ -411,4 +439,247 @@ export async function deleteCatalog(supabase: SupabaseClient, activityType: stri
   }
 
   return { status: 'ok' };
+}
+
+export type CatalogEditableCheck = { ok: true } | { ok: false; response: Response };
+
+/**
+ * GitHub #478: refuses to let new content be filed under a built-in example catalog (creator_id
+ * IS NULL). Individual question/prompt edit and delete routes already refuse a seeded, ownerless
+ * row by construction — no instructor's user_id ever equals NULL — but *creating* a new question
+ * or prompt under an existing catalog key was never scoped to that catalog's own ownership at all,
+ * so a built-in catalog could otherwise quietly grow content that was never part of the shipped
+ * example, defeating the "the original example is untouched" guarantee the Duplicate action
+ * depends on.
+ *
+ * An unknown activityType is let through here (`data` comes back null) rather than surfaced as a
+ * second error — the caller's own validation (isActivityType/getGradingKind) already 400s that
+ * case before this runs.
+ */
+export async function assertCatalogIsEditable(supabase: SupabaseClient, activityType: string): Promise<CatalogEditableCheck> {
+  const { data, error } = await supabase
+    .from('activity_type')
+    .select('creator_id')
+    .eq('activity_type', activityType)
+    .maybeSingle();
+
+  if (error) return { ok: false, response: Response.json({ error: error.message }, { status: 500 }) };
+
+  if (data && (data as { creator_id: string | null }).creator_id === null) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: 'This is a built-in example catalog and cannot be edited. Duplicate it to add your own questions or prompts.' },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { ok: true };
+}
+
+export type DuplicateCatalogResult =
+  | {
+      status: 'ok';
+      quiz: {
+        activityType: string;
+        name: string;
+        description: string | null;
+        gradingKind: GradingKind;
+        ratingPrompt: string | null;
+        questionCount: number;
+      };
+    }
+  | { status: 'not_found' }
+  | { status: 'name_conflict' }
+  | { status: 'error'; error: { message: string } };
+
+/**
+ * GitHub #478: copies a catalog's own metadata plus every question/answer ('mcq') or user_story
+ * ('llm-graded') it contains into a brand-new catalog owned by `creatorId` — the mechanism behind
+ * an example catalog's "Duplicate" action. The source catalog is only ever read; nothing about it
+ * is mutated, which is what keeps "the original example is untouched" true by construction rather
+ * than by convention. Copied questions/prompts are attributed to `creatorId` (not left ownerless),
+ * so the new catalog really is "a normal, fully editable catalog like any the instructor creates
+ * themselves" — the copied rows pass the same `user_id`/`creator_id` ownership check every edit/
+ * delete route already enforces.
+ *
+ * `newKey`/`newName` are assumed already validated (lib/activityTypes.ts's deriveActivityTypeKey)
+ * — this function only handles the database side.
+ *
+ * Not transactional (same limitation every other multi-step write in this codebase accepts, since
+ * the Supabase JS client offers no transaction). If any step after the activity_type insert fails,
+ * everything inserted under `newKey` so far — including the activity_type row itself — is deleted.
+ * That cleanup is always safe here (unlike deleteCatalog above, which must check student usage
+ * first): `newKey` did not exist a moment ago, so nothing could have referenced it yet.
+ */
+export async function duplicateCatalog(
+  supabase: SupabaseClient,
+  params: { sourceActivityType: string; newKey: string; newName: string; creatorId: string },
+): Promise<DuplicateCatalogResult> {
+  const { sourceActivityType, newKey, newName, creatorId } = params;
+
+  const { data: sourceRow, error: sourceError } = await supabase
+    .from('activity_type')
+    .select('description, grading_kind, rating_prompt')
+    .eq('activity_type', sourceActivityType)
+    .maybeSingle();
+
+  if (sourceError) return { status: 'error', error: sourceError };
+  if (!sourceRow) return { status: 'not_found' };
+
+  const source = sourceRow as { description: string | null; grading_kind: string; rating_prompt: string | null };
+  const gradingKind: GradingKind = isGradingKind(source.grading_kind) ? source.grading_kind : 'mcq';
+
+  const { error: insertError } = await supabase.from('activity_type').insert({
+    activity_type: newKey,
+    quiz_name: newName,
+    description: source.description,
+    grading_kind: gradingKind,
+    rating_prompt: source.rating_prompt,
+    creator_id: creatorId,
+  });
+
+  if (insertError) {
+    if ((insertError as { code?: string }).code === '23505') return { status: 'name_conflict' };
+    return { status: 'error', error: insertError };
+  }
+
+  if (gradingKind === 'llm-graded') {
+    const { data: storyRows, error: storyFetchError } = await supabase
+      .from('user_story')
+      .select('story_text, difficulty_level')
+      .eq('activity_type', sourceActivityType);
+
+    if (storyFetchError) {
+      await supabase.from('activity_type').delete().eq('activity_type', newKey);
+      return { status: 'error', error: storyFetchError };
+    }
+
+    const stories = (storyRows ?? []) as { story_text: string; difficulty_level: number }[];
+
+    if (stories.length > 0) {
+      const { error: storyInsertError } = await supabase.from('user_story').insert(
+        stories.map((story) => ({
+          user_story_id: crypto.randomUUID(),
+          story_text: story.story_text,
+          difficulty_level: story.difficulty_level,
+          activity_type: newKey,
+          creator_id: creatorId,
+        })),
+      );
+
+      if (storyInsertError) {
+        await supabase.from('user_story').delete().eq('activity_type', newKey);
+        await supabase.from('activity_type').delete().eq('activity_type', newKey);
+        return { status: 'error', error: storyInsertError };
+      }
+    }
+
+    return {
+      status: 'ok',
+      quiz: {
+        activityType: newKey,
+        name: newName,
+        description: source.description,
+        gradingKind,
+        ratingPrompt: source.rating_prompt,
+        questionCount: stories.length,
+      },
+    };
+  }
+
+  type SourceQuestionRow = {
+    question_prompt: string;
+    difficulty_level: number;
+    order_number: number;
+    max_score: number | null;
+    question_to_answer: { answer: { option_text: string; is_correct: boolean; explanation: string | null } | null }[];
+  };
+
+  const { data: questionRows, error: questionFetchError } = await supabase
+    .from('question')
+    .select(
+      'question_prompt, difficulty_level, order_number, max_score, question_to_answer(answer:answer_id(option_text, is_correct, explanation))',
+    )
+    .eq('activity_type', sourceActivityType);
+
+  if (questionFetchError) {
+    await supabase.from('activity_type').delete().eq('activity_type', newKey);
+    return { status: 'error', error: questionFetchError };
+  }
+
+  const sourceQuestions = (questionRows ?? []) as unknown as SourceQuestionRow[];
+
+  const newQuestionRows: Record<string, unknown>[] = [];
+  const newAnswerRows: Record<string, unknown>[] = [];
+  const newLinkRows: Record<string, unknown>[] = [];
+
+  for (const q of sourceQuestions) {
+    const newQuestionId = crypto.randomUUID();
+    newQuestionRows.push({
+      question_id: newQuestionId,
+      question_prompt: q.question_prompt,
+      activity_type: newKey,
+      difficulty_level: q.difficulty_level,
+      order_number: q.order_number,
+      max_score: q.max_score,
+      user_id: creatorId,
+    });
+
+    for (const link of q.question_to_answer) {
+      if (!link.answer) continue;
+      const newAnswerId = crypto.randomUUID();
+      newAnswerRows.push({
+        answer_id: newAnswerId,
+        option_text: link.answer.option_text,
+        is_correct: link.answer.is_correct,
+        explanation: link.answer.explanation,
+      });
+      newLinkRows.push({ question_id: newQuestionId, answer_id: newAnswerId });
+    }
+  }
+
+  async function rollbackMcq() {
+    const newQuestionIds = newQuestionRows.map((r) => r.question_id as string);
+    const newAnswerIds = newAnswerRows.map((r) => r.answer_id as string);
+    if (newQuestionIds.length > 0) await supabase.from('question_to_answer').delete().in('question_id', newQuestionIds);
+    if (newAnswerIds.length > 0) await supabase.from('answer').delete().in('answer_id', newAnswerIds);
+    if (newQuestionIds.length > 0) await supabase.from('question').delete().in('question_id', newQuestionIds);
+    await supabase.from('activity_type').delete().eq('activity_type', newKey);
+  }
+
+  if (newQuestionRows.length > 0) {
+    const { error: questionInsertError } = await supabase.from('question').insert(newQuestionRows);
+    if (questionInsertError) {
+      await supabase.from('activity_type').delete().eq('activity_type', newKey);
+      return { status: 'error', error: questionInsertError };
+    }
+
+    if (newAnswerRows.length > 0) {
+      const { error: answerInsertError } = await supabase.from('answer').insert(newAnswerRows);
+      if (answerInsertError) {
+        await rollbackMcq();
+        return { status: 'error', error: answerInsertError };
+      }
+
+      const { error: linkInsertError } = await supabase.from('question_to_answer').insert(newLinkRows);
+      if (linkInsertError) {
+        await rollbackMcq();
+        return { status: 'error', error: linkInsertError };
+      }
+    }
+  }
+
+  return {
+    status: 'ok',
+    quiz: {
+      activityType: newKey,
+      name: newName,
+      description: source.description,
+      gradingKind,
+      ratingPrompt: source.rating_prompt,
+      questionCount: newQuestionRows.length,
+    },
+  };
 }

--- a/lib/activityTypes.ts
+++ b/lib/activityTypes.ts
@@ -141,3 +141,36 @@ export function slugifyQuizName(name: string): string {
     .replace(/[^A-Z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
 }
+
+// Matches activity_type.activity_type varchar(50) in supabase/schema.sql. Shared by every route
+// that derives a key from an instructor-given name (POST /api/activities/types, POST
+// /api/instructor/quizzes/{activityType}/duplicate) so the two can't drift on how long a name is
+// allowed to be.
+export const MAX_ACTIVITY_TYPE_KEY_LENGTH = 50;
+
+export type ActivityTypeKeyValidation = { ok: true; key: string } | { ok: false; response: Response };
+
+/**
+ * slugifyQuizName plus the two failure modes every caller that derives a key from a name has to
+ * check: an empty result (a name with no letters or digits at all) and a key too long for the
+ * column. Extracted for GitHub #478's duplicate-catalog route, which needs the exact same checks
+ * POST /api/activities/types already made inline.
+ */
+export function deriveActivityTypeKey(name: string): ActivityTypeKeyValidation {
+  const key = slugifyQuizName(name);
+
+  if (key === '') {
+    return { ok: false, response: Response.json({ error: 'name must contain at least one letter or number.' }, { status: 400 }) };
+  }
+  if (key.length > MAX_ACTIVITY_TYPE_KEY_LENGTH) {
+    return {
+      ok: false,
+      response: Response.json(
+        { error: `name is too long — the derived key must be ${MAX_ACTIVITY_TYPE_KEY_LENGTH} characters or fewer.` },
+        { status: 400 },
+      ),
+    };
+  }
+
+  return { ok: true, key };
+}

--- a/lib/quizClient.ts
+++ b/lib/quizClient.ts
@@ -23,6 +23,9 @@ export type QuizSummary = {
   /** How many assembled quizzes (GitHub #360) currently reference this catalog — a catalog has no
    *  course of its own, so this is what the browse page shows instead. */
   quizCount: number;
+  /** GitHub #478: true for one of the built-in example catalogs (creator_id IS NULL) — strictly
+   *  read-only everywhere in the UI; "Duplicate" is the only action available on one. */
+  isBuiltIn: boolean;
 };
 
 export type QuizMeta = Omit<QuizSummary, 'questionCount' | 'quizCount'> & {
@@ -56,9 +59,12 @@ async function request<T>(url: string, init: RequestInit, token: string): Promis
   return { ok: true, data: body as T };
 }
 
-/** Every catalog the calling instructor created (GET /api/instructor/quizzes). */
-export function loadQuizzes(token: string): Promise<ApiResult<{ quizzes: QuizSummary[] }>> {
-  return request<{ quizzes: QuizSummary[] }>('/api/instructor/quizzes', { method: 'GET' }, token);
+/**
+ * Every catalog the calling instructor created, plus the built-in example catalogs every
+ * instructor sees (GET /api/instructor/quizzes, GitHub #478).
+ */
+export function loadQuizzes(token: string): Promise<ApiResult<{ quizzes: QuizSummary[]; exampleCatalogs: QuizSummary[] }>> {
+  return request<{ quizzes: QuizSummary[]; exampleCatalogs: QuizSummary[] }>('/api/instructor/quizzes', { method: 'GET' }, token);
 }
 
 /**
@@ -185,12 +191,48 @@ export function loadTitleNames(token: string): Promise<ApiResult<{ titleNames: s
 /**
  * Deletes a catalog and unlinks it from every assembled quiz it was composed into
  * (DELETE /api/instructor/quizzes/{activityType}). Refuses with a 409 (surfaced as `error`) if a
- * student has already engaged with it.
+ * student has already engaged with it. A built-in example catalog always 403s here — see
+ * duplicateCatalog below for the action that's actually available on one.
  */
 export function deleteCatalog(token: string, activityType: string): Promise<ApiResult<{ activityType: string }>> {
   return request<{ activityType: string }>(
     `/api/instructor/quizzes/${encodeURIComponent(activityType)}`,
     { method: 'DELETE' },
+    token,
+  );
+}
+
+/**
+ * A newly duplicated catalog (POST /api/instructor/quizzes/{activityType}/duplicate) — deliberately
+ * its own type rather than CreatedQuiz: a duplicate never asks for a title ladder up front the way
+ * catalog creation does, and it reports questionCount (the copy's own item count) instead.
+ */
+export type DuplicatedQuiz = {
+  activityType: string;
+  name: string;
+  description: string | null;
+  gradingKind: GradingKind;
+  ratingPrompt: string | null;
+  questionCount: number;
+};
+
+/**
+ * Copies a catalog the caller can view (their own, or a built-in example) into a brand-new,
+ * fully-editable catalog they own — POST /api/instructor/quizzes/{activityType}/duplicate,
+ * GitHub #478's "Duplicate" action. The source is left untouched.
+ */
+export function duplicateCatalog(
+  token: string,
+  activityType: string,
+  input: { name: string },
+): Promise<ApiResult<{ quiz: DuplicatedQuiz }>> {
+  return request<{ quiz: DuplicatedQuiz }>(
+    `/api/instructor/quizzes/${encodeURIComponent(activityType)}/duplicate`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(input),
+    },
     token,
   );
 }


### PR DESCRIPTION
As a new instructor, I want to see one or more pre-built, ready-to-use example Question Catalogs (already filled with real questions) when I open "Question Catalogs," so that I understand what a complete catalog looks like and have a concrete starting point instead of a blank page.

Acceptance Criteria
The three built-in catalogs already seeded in the database (2 MCQ catalogs + 1 LLM-graded catalog, activity_type.creator_id IS NULL) are visible to every instructor as "Example Catalogs," clearly separated from the instructor's own ("mine only") catalog list.
These example catalogs are strictly read-only: no Edit toggle, no add/edit/delete actions on their questions/prompts, and no Delete button — they should visibly communicate "this is a locked example," not just silently fail.
Each example catalog has a "Duplicate" action that creates a new catalog owned by the current instructor — copying its questions/answers (or user stories, for the LLM-graded one) and its grading kind. The original example is untouched; the new copy is a normal, fully editable catalog like any the instructor creates themselves.
A first-time instructor can find these examples without hunting — e.g. they're shown even before the instructor has created any catalog of their own (today's empty state has nothing to look at).

-Resolve #478 