### PR TITLE
Block deleting a catalog still linked into an assembled quiz

### DIFF
--- a/__tests__/api/instructor-quiz-detail.test.ts
+++ b/__tests__/api/instructor-quiz-detail.test.ts
@@ -490,6 +490,7 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
     queue('session_log', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
     queue('question', { data: [{ question_id: 'q-1' }], error: null });
     queue('daily_challenge_attempt', { data: { daily_challenge_attempt_id: 'attempt-1' }, error: null });
 
@@ -500,10 +501,37 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
     expect(h.state.deletes).toEqual([]);
   });
 
+  it('returns 409 and deletes nothing when the catalog is still composed into one or more assembled quizzes', async () => {
+    queueRole('instructor');
+    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
+    queue('session_log', { data: null, error: null });
+    queue('assembled_quiz_catalog', {
+      data: [
+        { assembled_quiz: { assembled_quiz_id: 'quiz-1', quiz_name: 'Sprint 1 Quiz', course: { course_name: 'CS 101' } } },
+        { assembled_quiz: { assembled_quiz_id: 'quiz-2', quiz_name: 'Midterm Review', course: { course_name: 'CS 201' } } },
+      ],
+      error: null,
+    });
+
+    const res = await delReq();
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('"Sprint 1 Quiz" (CS 101)');
+    expect(body.error).toContain('"Midterm Review" (CS 201)');
+    expect(body.quizzes).toEqual([
+      { quizId: 'quiz-1', quizName: 'Sprint 1 Quiz', courseName: 'CS 101' },
+      { quizId: 'quiz-2', quizName: 'Midterm Review', courseName: 'CS 201' },
+    ]);
+    expect(h.state.tables).not.toContain('question');
+    expect(h.state.tables).not.toContain('user_story');
+    expect(h.state.deletes).toEqual([]);
+  });
+
   it('deletes an unused mcq catalog\'s questions/answers, unlinks it from every quiz, and deletes the catalog', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null }); // getQuizByActivityType
     queue('session_log', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
     queue('question', { data: [{ question_id: 'q-1' }, { question_id: 'q-2' }], error: null }); // select ids
     queue('daily_challenge_attempt', { data: null, error: null });
     queue('question_to_answer', { data: [{ answer_id: 'a-1' }, { answer_id: 'a-2' }], error: null }); // select answer ids
@@ -531,6 +559,7 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
     queue('session_log', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
     queue('user_story', { data: null, error: null }); // delete
     queue('title_definition', { data: null, error: null });
     queue('assembled_quiz_catalog', { data: null, error: null });
@@ -549,6 +578,7 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
     queue('session_log', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
     queue('user_story', { data: null, error: null });
     queue('title_definition', { data: null, error: null });
     queue('assembled_quiz_catalog', { data: null, error: null });
@@ -564,6 +594,7 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
     queue('session_log', { data: null, error: null });
+    queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
     queue('user_story', { data: null, error: null });
     queue('title_definition', { data: null, error: null });
     queue('assembled_quiz_catalog', { data: null, error: null });

--- a/app/api/instructor/quizzes/[activityType]/route.ts
+++ b/app/api/instructor/quizzes/[activityType]/route.ts
@@ -145,15 +145,18 @@ export async function PATCH(request: Request, { params }: { params: { activityTy
 
 /**
  * DELETE /api/instructor/quizzes/:activityType — deletes a catalog the caller owns: its own
- * questions/answers (mcq) or user_story prompts (llm-graded), and unlinks it from every assembled
- * quiz that composed it (deleteCatalog, lib/activityTypeQueries.ts, has the exact cascade). Same
- * 404-then-403 ownership check as GET above.
+ * questions/answers (mcq) or user_story prompts (llm-graded). Same 404-then-403 ownership check as
+ * GET above.
  *
  * - 401 missing/invalid bearer token
  * - 403 caller isn't an instructor, or doesn't own this catalog (no body either way)
  * - 404 activityType matches no catalog
  * - 409 a student has already engaged with this catalog (deleteCatalog's own docblock has the
  *   exact usage this checks) — the catalog is left untouched
+ * - 409 the catalog is still composed into one or more assembled quizzes — the catalog is left
+ *   untouched, and the body names exactly which quiz(es)/course(s) still reference it so the
+ *   instructor knows what to remove first (via the existing "remove a catalog from a quiz" action)
+ *   before retrying the delete
  * - 200 { activityType }
  * - 500 Supabase not configured, or a query fails
  */
@@ -181,6 +184,17 @@ export async function DELETE(request: Request, { params }: { params: { activityT
   const result = await deleteCatalog(supabase, activityType, quiz.gradingKind);
   if (result.status === 'in_use') {
     return Response.json({ error: 'This catalog has already been used by a student and cannot be deleted.' }, { status: 409 });
+  }
+  if (result.status === 'linked') {
+    const names = result.quizzes.map((q) => `"${q.quizName}" (${q.courseName})`).join(', ');
+    const plural = result.quizzes.length > 1;
+    return Response.json(
+      {
+        error: `This catalog is still used by ${plural ? 'these assembled quizzes' : 'this assembled quiz'}: ${names}. Remove it from ${plural ? 'them' : 'it'} first, then try deleting the catalog again.`,
+        quizzes: result.quizzes,
+      },
+      { status: 409 },
+    );
   }
   if (result.status === 'error') return Response.json({ error: result.error.message }, { status: 500 });
 

--- a/lib/activityTypeQueries.ts
+++ b/lib/activityTypeQueries.ts
@@ -319,7 +319,18 @@ export async function listCatalogUserStories(supabase: SupabaseClient, activityT
   return { userStories, error: null };
 }
 
-export type DeleteCatalogResult = { status: 'ok' } | { status: 'in_use' } | { status: 'error'; error: { message: string } };
+/** One assembled quiz that still composes a catalog someone is trying to delete. */
+export type LinkedQuizSummary = { quizId: string; quizName: string; courseName: string };
+
+type QuizLinkRow = {
+  assembled_quiz: { assembled_quiz_id: string; quiz_name: string; course: { course_name: string } | null } | null;
+};
+
+export type DeleteCatalogResult =
+  | { status: 'ok' }
+  | { status: 'in_use' }
+  | { status: 'linked'; quizzes: LinkedQuizSummary[] }
+  | { status: 'error'; error: { message: string } };
 
 /**
  * Deletes a catalog (activity_type row) entirely: its own questions/answers (mcq) or user_story
@@ -340,11 +351,17 @@ export type DeleteCatalogResult = { status: 'ok' } | { status: 'in_use' } | { st
  * attempted piecemeal, orphan a student's history — checking first avoids both, the same reasoning
  * DELETE /api/instructor/questions/{questionId} already documents for a single question.
  *
- * Not transactional (the Supabase JS client offers none, same limitation every other multi-step
- * write in this codebase accepts) — ordered children-before-parents so a failure partway through
- * leaves the catalog missing some content rather than a broken half-deleted row. The final delete
- * additionally treats a foreign_key_violation (23503) as 'in_use' rather than a raw error — defense
- * in depth in case some usage isn't one of the tables checked above.
+ * Also refuses with 'linked' — a second, independent pre-flight check, orthogonal to the 'in_use'
+ * one above — if any assembled_quiz_catalog row still references this catalog. Unlike deleting a
+ * single question (which the DELETE /api/instructor/questions/{questionId}?force= path lets an
+ * instructor push through with `force`), there is no "delete anyway" for a catalog: a catalog can
+ * be composed into several quizzes/courses at once (see CLAUDE.md's Assembled quizzes section), so
+ * silently cascading the unlink here — which is exactly what this function used to do, unyoking a
+ * catalog from every quiz it was in without telling anyone — could quietly break a running course
+ * out from under students. The instructor has to remove the catalog from each quiz by hand first
+ * (DELETE /api/instructor/assembled-quizzes/{quizId}/catalogs/{activityType}, the existing "remove
+ * a catalog from a quiz" action) before a delete here is allowed to proceed. This check runs before
+ * the destructive per-kind deletes below so a rejection never leaves the catalog partially deleted.
  */
 export async function deleteCatalog(supabase: SupabaseClient, activityType: string, gradingKind: GradingKind): Promise<DeleteCatalogResult> {
   const { data: sessionUsage, error: sessionUsageError } = await supabase
@@ -355,6 +372,22 @@ export async function deleteCatalog(supabase: SupabaseClient, activityType: stri
     .maybeSingle();
   if (sessionUsageError) return { status: 'error', error: sessionUsageError };
   if (sessionUsage) return { status: 'in_use' };
+
+  const { data: quizLinkRows, error: quizLinkError } = await supabase
+    .from('assembled_quiz_catalog')
+    .select('assembled_quiz:assembled_quiz_id(assembled_quiz_id, quiz_name, course:course_id(course_name))')
+    .eq('activity_type', activityType);
+  if (quizLinkError) return { status: 'error', error: quizLinkError };
+
+  const linkedQuizzes: LinkedQuizSummary[] = ((quizLinkRows ?? []) as unknown as QuizLinkRow[])
+    .map((row) => row.assembled_quiz)
+    .filter((quiz): quiz is NonNullable<QuizLinkRow['assembled_quiz']> => quiz !== null)
+    .map((quiz) => ({
+      quizId: quiz.assembled_quiz_id,
+      quizName: quiz.quiz_name,
+      courseName: quiz.course?.course_name ?? 'Unknown course',
+    }));
+  if (linkedQuizzes.length > 0) return { status: 'linked', quizzes: linkedQuizzes };
 
   if (gradingKind === 'llm-graded') {
     const { error: deleteStoriesError } = await supabase.from('user_story').delete().eq('activity_type', activityType);


### PR DESCRIPTION
## Summary
- Block deleting a Question Catalog while it is still composed into one or more Assembled Quizzes, instead of silently unlinking it and breaking the quiz's composition (and the course it serves) out from under students.
- `deleteCatalog` now runs a second, independent pre-flight check (alongside the existing `session_log` "already used by a student" check) that looks up every `assembled_quiz_catalog` row referencing the catalog, joined to each quiz's name and course name.
- `DELETE /api/instructor/quizzes/{activityType}` returns a 409 naming exactly which quiz(es)/course(s) still reference the catalog (e.g. `This catalog is still used by these assembled quizzes: "Sprint 1 Quiz" (CS 101), "Midterm Review" (CS 201). Remove it from them first, then try deleting the catalog again.`), plus a `quizzes` array in the body for future UI use.
- Once the instructor removes the catalog from every referencing quiz via the existing "remove a catalog from a quiz" action, the delete proceeds normally.
- The existing `session_log` check is untouched: a catalog with real student attempt history still can't be deleted regardless of quiz linkage.

## Error message:

<img width="490" height="361" alt="Bildschirmfoto 2026-08-18 um 19 13 27" src="https://github.com/user-attachments/assets/a8e40236-f857-4684-9491-07dcb80a9fd3" />



resolve #480