### PR TITLE
Widen and enlarge the evaluation prompt textarea; fix "New Prompt" title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,8 @@ Copy `.env.example` to `.env.local` and fill in your Supabase credentials. Then,
 
 `INSTRUCTOR_SIGNUP_CODE` (the invite code that grants the instructor role at registration, see "Auth flow" below) must be set to a real, random, per-deployment value — generate one yourself (e.g. `openssl rand -base64 24`) and set it only in each deployment's own environment (`.env.local` locally, Vercel Environment Variables in production, etc.). It must never be committed to the repo, in `.env.example` or anywhere else.
 
+`LLM_CONFIG_ENCRYPTION_KEY` must also be set per-deployment (`openssl rand -base64 32`, must decode to exactly 32 bytes) — `lib/secretEncryption.ts` uses it to encrypt `instructor_llm_config.api_key` before it's ever written to the database, so an instructor's LLM provider key is never stored in plaintext. Unset, placeholder (`CHANGE-ME`-prefixed), or wrong-length values make saving/reading an LLM config fail closed (500) rather than fall back to plaintext. Rotating it makes every previously-saved config unreadable — affected instructors must re-save their LLM provider settings.
+
 `lib/supabase.ts` accepts either `SUPABASE_URL` or `NEXT_PUBLIC_SUPABASE_URL` and exposes three factories, each returning `null` when its key is missing so routes can answer 500 instead of a confusing Supabase error:
 
 - `getSupabaseClient()` — service-role key preferred, anon fallback. Used by every data route; it bypasses RLS, which is why those routes must derive `user_id` from the token themselves.

--- a/components/PromptFormModal.tsx
+++ b/components/PromptFormModal.tsx
@@ -111,7 +111,7 @@ export function PromptFormModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="prompt-form-title"
-        className="max-h-full w-full max-w-lg overflow-y-auto rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
+        className="max-h-full w-full max-w-2xl overflow-y-auto rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
       >
         <div className="mb-5 flex items-start justify-between gap-3">
           <div>

--- a/components/PromptFormModal.tsx
+++ b/components/PromptFormModal.tsx
@@ -117,7 +117,7 @@ export function PromptFormModal({
           <div>
             <p className="text-xs font-extrabold uppercase tracking-wide text-brand-gold">LLM-Graded Task</p>
             <h2 id="prompt-form-title" className="mt-1 text-xl font-extrabold text-white">
-              {mode === 'edit' ? 'Edit Prompt' : 'New Prompt'}
+              {mode === 'edit' ? 'Edit Prompt' : 'New Question'}
             </h2>
           </div>
           <button

--- a/components/PromptFormModal.tsx
+++ b/components/PromptFormModal.tsx
@@ -207,7 +207,7 @@ export function PromptFormModal({
               ref={firstFieldRef}
               value={storyText}
               onChange={(event) => setStoryText(event.target.value)}
-              rows={5}
+              rows={10}
               placeholder="e.g. As a shopper, I want to save items to a wishlist, so that I can buy them later."
               className="mt-1.5 block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple"
             />

--- a/components/RatingPromptModal.tsx
+++ b/components/RatingPromptModal.tsx
@@ -80,7 +80,7 @@ export function RatingPromptModal({
         role="dialog"
         aria-modal="true"
         aria-labelledby="rating-prompt-modal-title"
-        className="w-full max-w-md rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
+        className="w-full max-w-2xl rounded-brand-lg border border-brand-navy-border bg-brand-navy p-7"
       >
         <div className="mb-5 flex items-start justify-between gap-3">
           <div>

--- a/components/RatingPromptModal.tsx
+++ b/components/RatingPromptModal.tsx
@@ -110,7 +110,7 @@ export function RatingPromptModal({
             onChange={(event) => setRatingPrompt(event.target.value)}
             disabled={submitting}
             placeholder="How should the AI score a student's answer? Replaces the built-in generic rubric for this catalog."
-            rows={6}
+            rows={14}
             className="mt-1.5 block w-full resize-y rounded-brand-md border border-brand-navy-border bg-brand-navy-2 px-3.5 py-2.5 text-sm font-semibold text-brand-ink outline-none transition focus:border-brand-purple disabled:cursor-not-allowed disabled:opacity-60"
           />
         </label>


### PR DESCRIPTION
Evaluating Prompt modal (RatingPromptModal): textarea grows from 6 to 14 default rows and the modal panel widens from max-w-md to max-w-2xl, so instructors can see significantly more of the rubric without scrolling or manually resizing. Manual resize (resize-y) is unchanged; no other fields/behavior touched.
New Question modal (PromptFormModal): create-mode title corrected from "New Prompt" to "New Question". Edit-mode title ("Edit Prompt") left as-is.
Resolve: #486 
Resolve: #484 