### PR TITLE
Roll Daily Challenge points into the cumulative score

### DIFF
--- a/__tests__/api/score.test.ts
+++ b/__tests__/api/score.test.ts
@@ -90,6 +90,7 @@ describe('GET /api/students/{studentId}/score', () => {
   // AC 3: no completed sessions at all.
   it('returns 0 when the student has no completed sessions', async () => {
     queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [], error: null });
 
     const response = await GET(req(), ctx);
     const body = await response.json();
@@ -123,14 +124,16 @@ describe('GET /api/students/{studentId}/score', () => {
   // REQ-GAM-DL-1 counts completed sessions, not passed ones: the query filters on status,
   // so a running or abandoned attempt never reaches the sum, while a finished-but-failed
   // one keeps the points it earned.
-  it('scopes the query to the student and to completed sessions', async () => {
+  it('scopes the queries to the student, and session_log additionally to completed sessions', async () => {
     queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [], error: null });
 
     await GET(req(), ctx);
 
     expect(h.state.filters).toEqual([
       { table: 'session_log', column: 'user_id', value: STUDENT_ID },
       { table: 'session_log', column: 'status', value: 'completed' },
+      { table: 'daily_challenge_attempt', column: 'user_id', value: STUDENT_ID },
     ]);
   });
 
@@ -199,8 +202,64 @@ describe('GET /api/students/{studentId}/score', () => {
     expect(body.score).toBe(275);
   });
 
+  // A submitted Daily Challenge attempt's already-doubled score (lib/dailyChallengeRules.ts's
+  // scoreForDailyChallenge) is added on top of the session-derived total.
+  it('adds a submitted Daily Challenge attempt score to the total', async () => {
+    queue('session_log', {
+      data: [{ activity_type: 'IDENTIFY_WEAK_USER_STORIES', difficulty_level: 1, cumulative_score: 100 }],
+      error: null,
+    });
+    queue('daily_challenge_attempt', { data: [{ score: 40 }], error: null });
+
+    const body = await (await GET(req(), ctx)).json();
+
+    expect(body.score).toBe(140);
+  });
+
+  // Every day's attempt is its own row (uq_daily_challenge_attempt_user_date caps it at one per
+  // day) — unlike sessions there's no (activity_type, difficulty_level) to dedupe on, so every
+  // submitted attempt's score is summed, not just the best.
+  it('sums Daily Challenge scores across multiple days rather than keeping only the best', async () => {
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [{ score: 20 }, { score: 40 }, { score: 10 }], error: null });
+
+    const body = await (await GET(req(), ctx)).json();
+
+    expect(body.score).toBe(70);
+  });
+
+  // A `null` score means the attempt was never submitted (deadline passed first, see the table's
+  // own doc comment in supabase/schema.sql) — it must contribute 0, not throw or count as points.
+  it('treats an unsubmitted Daily Challenge attempt (null score) as contributing 0', async () => {
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [{ score: null }], error: null });
+
+    const body = await (await GET(req(), ctx)).json();
+
+    expect(body.score).toBe(0);
+  });
+
+  // Daily Challenge attempts are not sessions and must not inflate sessionsCompleted (GitHub #39),
+  // which is defined purely off the session_log row count.
+  it('does not count Daily Challenge attempts toward sessionsCompleted', async () => {
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [{ score: 40 }], error: null });
+
+    const body = await (await GET(req(), ctx)).json();
+
+    expect(body.sessionsCompleted).toBe(0);
+  });
+
   it('returns 500 when the session_log query fails', async () => {
     queue('session_log', { data: null, error: { message: 'db down' } });
+
+    const response = await GET(req(), ctx);
+    expect(response.status).toBe(500);
+  });
+
+  it('returns 500 when the daily_challenge_attempt query fails', async () => {
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: null, error: { message: 'db down' } });
 
     const response = await GET(req(), ctx);
     expect(response.status).toBe(500);

--- a/app/daily-challenge/page.tsx
+++ b/app/daily-challenge/page.tsx
@@ -6,9 +6,11 @@ import { useCallback, useEffect, useState } from 'react';
 import { AppShell } from '../../components/AppShell';
 import { FeedbackCard } from '../../components/FeedbackCard';
 import { QuestionCard } from '../../components/QuestionCard';
+import { useUser } from '../../components/UserProvider';
 import { loadDailyChallenge, startDailyChallenge, submitDailyChallengeAnswer } from '../../lib/dailyChallengeClient';
 import type { DailyChallengeState } from '../../lib/dailyChallengeTypes';
 import { toInstant } from '../../lib/dateTime';
+import { clearCachedLeaderboard } from '../../lib/leaderboardStore';
 import { useRequireRole } from '../../lib/useRequireRole';
 
 function formatRemaining(ms: number): string {
@@ -52,6 +54,7 @@ function BackToDashboardLink() {
 export default function DailyChallengePage() {
   const router = useRouter();
   const { token, loading, authorized } = useRequireRole('student');
+  const { refreshScore } = useUser();
 
   const [state, setState] = useState<DailyChallengeState | null>(null);
   const [starting, setStarting] = useState(false);
@@ -162,6 +165,16 @@ export default function DailyChallengePage() {
           }
         : current,
     );
+
+    // GitHub #392-style fix: a submitted attempt finalizes daily_challenge_attempt.score (0 on a
+    // wrong answer, doubled on a correct one — lib/dailyChallengeRules.ts), which
+    // computeStudentScore now folds into the cumulative total. Nothing else on this page
+    // invalidates the sidebar's cached score or the leaderboard cache, so both must be kicked
+    // here, the same pair the other two play flows' finish handlers already call. Not awaited —
+    // unlike those flows, this page doesn't navigate away afterward, so the UI above doesn't
+    // depend on either finishing first.
+    void refreshScore();
+    clearCachedLeaderboard();
   }
 
   if (error) {

--- a/lib/scoreQueries.ts
+++ b/lib/scoreQueries.ts
@@ -31,18 +31,28 @@ export function sumBestScores(sessions: SessionRow[]): number {
 
 /**
  * Sum of the student's best cumulative_score at each (activity_type, difficulty_level) pair,
- * counting every completed session (see sumBestScores for the reduction itself).
+ * counting every completed session (see sumBestScores for the reduction itself), plus every
+ * Daily Challenge attempt's own (already-doubled, see lib/dailyChallengeRules.ts) score.
  *
  * Completed, not passed: an attempt that ended below the 75% threshold still earned its points
  * and contributes them. Only sessions that are still running or were abandoned stay out — their
  * cumulative_score is a partial tally of an attempt that was never finished.
  *
- * sessionsCompleted (GitHub #39) is the row count behind that same query — every completed
- * session counts once here, unlike the score sum, which only keeps each level's best attempt.
- * Returned alongside score rather than via a second query, since it's already the row set the
- * score is computed from.
+ * The Daily Challenge side is a plain sum, not a sumBestScores-style reduction: unlike a session,
+ * a daily_challenge_attempt doesn't have an (activity_type, difficulty_level) key to dedupe on —
+ * uq_daily_challenge_attempt_user_date already caps the table at one row per user per calendar
+ * day, so every submitted attempt is a distinct day's points and all of them count. A `score` of
+ * `null` (never submitted, or the deadline passed first) contributes 0, the same "unfinished
+ * attempt earns nothing yet" rule sessions follow.
  *
- * A student with no completed sessions gets score 0 and sessionsCompleted 0.
+ * sessionsCompleted (GitHub #39) is the row count behind the session_log query only — every
+ * completed session counts once here, unlike the score sum, which only keeps each level's best
+ * attempt. Daily Challenge attempts are not sessions and don't affect this count. Returned
+ * alongside score rather than via a second query, since it's already the row set the score is
+ * computed from.
+ *
+ * A student with no completed sessions and no Daily Challenge attempts gets score 0 and
+ * sessionsCompleted 0.
  */
 export async function computeStudentScore(supabase: SupabaseClient, userId: string) {
   const { data, error } = await supabase
@@ -55,5 +65,17 @@ export async function computeStudentScore(supabase: SupabaseClient, userId: stri
 
   const sessions = (data ?? []) as SessionRow[];
 
-  return { score: sumBestScores(sessions), sessionsCompleted: sessions.length, error: null };
+  const { data: dailyChallengeData, error: dailyChallengeError } = await supabase
+    .from('daily_challenge_attempt')
+    .select('score')
+    .eq('user_id', userId);
+
+  if (dailyChallengeError) return { score: null, sessionsCompleted: null, error: dailyChallengeError };
+
+  const dailyChallengeScore = ((dailyChallengeData ?? []) as { score: number | null }[]).reduce(
+    (sum, row) => sum + (row.score ?? 0),
+    0,
+  );
+
+  return { score: sumBestScores(sessions) + dailyChallengeScore, sessionsCompleted: sessions.length, error: null };
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -502,9 +502,11 @@ CREATE TABLE answered_question_log (
 -- submitted_option/is_correct/score/submitted_at are nullable for the same write-before-disclose
 -- reason as answered_question_log/submission: the row is inserted at draw time (locking in the
 -- question and today's deadline), then filled in only if the student submits before deadline_at.
--- A missed deadline is left unfinalized on purpose — nothing outside this table reads it for
--- scoring, so an unfinalized row's only job is to keep uq_daily_challenge_attempt_user_date
--- blocking a second attempt that day, finished or not.
+-- A missed deadline is left unfinalized on purpose: an unfinalized row's `score` stays NULL, which
+-- lib/scoreQueries.ts's computeStudentScore treats as contributing 0 to the cumulative total (the
+-- same "unfinished attempt earns nothing yet" rule session_log follows), so an unfinalized row's
+-- only other job is to keep uq_daily_challenge_attempt_user_date blocking a second attempt that
+-- day, finished or not.
 -- ---------------------------------------------------------------------
 CREATE TABLE daily_challenge_attempt (
     daily_challenge_attempt_id uuid      NOT NULL,


### PR DESCRIPTION
## Summary

Fixes a bug where completing the Daily Challenge did not add its (doubled) points to the student's cumulative score.

- `computeStudentScore` (`lib/scoreQueries.ts`) only ever summed `session_log`. The Daily Challenge writes its score exclusively to `daily_challenge_attempt`, which nothing read for scoring — the points were calculated and stored correctly, just never rolled into the total shown to the student.
- `app/daily-challenge/page.tsx` never called `refreshScore()` after submitting, unlike the MCQ and LLM-graded play flows (see GitHub #392), so even a server-side fix wouldn't show up without an unrelated cache revalidation.

## Changes

- `lib/scoreQueries.ts` — `computeStudentScore` now also sums `daily_challenge_attempt.score` for the user. Every submitted attempt counts (not best-of): `uq_daily_challenge_attempt_user_date` already caps the table at one row per day, so there's no `(activity_type, difficulty_level)` key to dedupe on the way sessions have. A `null` score (never submitted, or the deadline passed first) contributes 0. `sessionsCompleted` is unaffected — it stays scoped to `session_log` only.
- `app/daily-challenge/page.tsx` — `handleSubmit` now calls `refreshScore()` and `clearCachedLeaderboard()` after a successful submit, mirroring the pattern already used in `app/activities/[slug]/play/page.tsx` and `components/LlmPlayView.tsx`.
- `supabase/schema.sql` — corrected the `daily_challenge_attempt` table's doc comment, which claimed "nothing outside this table reads it for scoring" (no longer true). Comment-only, no DDL/migration change.
- `__tests__/api/score.test.ts` — updated the existing exact-filters assertion for the new query, and added cases: adds a submitted attempt's score to the total, sums across multiple days rather than best-of, treats a `null` score as 0, doesn't count Daily Challenge rows toward `sessionsCompleted`, and 500s if the new query fails.

## Known scope boundary (not fixed here)

`lib/leaderboardQueries.ts`'s course and global leaderboards compute points by re-reading `session_log` directly, not via `computeStudentScore` — so a student's sidebar score and their leaderboard rank will now disagree by their Daily Challenge total. Daily Challenge points aren't tied to any single course, so folding them into a *course* leaderboard isn't a clean fit; deliberately left out to keep this fix scoped to the reported bug (cumulative score) rather than deciding a product-ranking question unilaterally.

resolve #493 