### PR TITLE
REQ-PL-3.4.4 — Number of Students and User Interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .devcontainer/devcontainer-lock.json
 tsconfig.tsbuildinfo
 .DS_Store
+test-credentials.txt

--- a/__tests__/api/instructor-activities.test.ts
+++ b/__tests__/api/instructor-activities.test.ts
@@ -34,6 +34,7 @@ const h = vi.hoisted(() => {
         state.filters.push({ table, column: `${column} (in)`, value });
         return builder;
       },
+      range: () => builder,
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });
         return builder;

--- a/__tests__/api/instructor-courses-detail.test.ts
+++ b/__tests__/api/instructor-courses-detail.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      range: () => builder,
       order: () => builder,
       update: (payload: unknown) => {
         state.updates.push({ table, payload });

--- a/__tests__/api/instructor-courses-export.test.ts
+++ b/__tests__/api/instructor-courses-export.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      range: () => builder,
       order: () => builder,
       maybeSingle: async () => result,
       single: async () => result,

--- a/__tests__/api/sessions-in-progress.test.ts
+++ b/__tests__/api/sessions-in-progress.test.ts
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      range: () => builder,
       order: () => builder,
       insert: (payload: unknown) => {
         state.inserts.push({ table, payload });

--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -19,6 +19,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      range: () => builder,
       limit: () => builder,
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });

--- a/__tests__/api/students-activities.test.ts
+++ b/__tests__/api/students-activities.test.ts
@@ -14,6 +14,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      range: () => builder,
       order: () => builder,
       // PostgrestFilterBuilder is thenable — queries without .single() are awaited directly.
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/components/CourseLeaderboard.tsx
+++ b/components/CourseLeaderboard.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { LeaderboardTable } from './LeaderboardTable';
+import { LeaderboardTable, YourPositionStrip } from './LeaderboardTable';
 import { LeaderboardSkeleton } from './LeaderboardSkeleton';
+import { Pagination } from './Pagination';
 import { loadCourseLeaderboard } from '../lib/studentCourseClient';
 import type { LeaderboardEntry } from '../lib/leaderboardTypes';
+
+// Smaller than app/leaderboard/page.tsx's PAGE_SIZE (10) — this table is one embedded section on
+// the course page, not the whole page, so a shorter window keeps it from dominating the layout.
+const PAGE_SIZE = 5;
 
 /**
  * GitHub #432 follow-up: this course's own leaderboard, embedded directly in the course's quiz
@@ -21,9 +26,13 @@ import type { LeaderboardEntry } from '../lib/leaderboardTypes';
  * Reuses LeaderboardTable as-is rather than the dashboard's smaller LeaderboardPreview rows: this
  * page has full single-column width to render a table in (unlike the dashboard's ~600px column),
  * and reusing it verbatim is what keeps rank badges, avatars and points formatting from ever
- * drifting between the two leaderboard surfaces. No pagination and no top-N cut — a single
- * course's roster is the right size for one table, and LeaderboardTable's own empty state ("No one
- * in this course has completed an activity yet") already fits this exact context.
+ * drifting between the two leaderboard surfaces.
+ *
+ * Paged the same way app/leaderboard/page.tsx is (shared Pagination + YourPositionStrip when the
+ * viewer's own row falls off the current page) — a full, unpaginated roster scrolled forever once
+ * a course had more than a handful of students, which is exactly the load-test scale GitHub #275
+ * exists to catch. Paging stays client-side: computeCourseLeaderboard already returns the whole
+ * ranked roster in one call, same as the global leaderboard.
  */
 export function CourseLeaderboard({
   token,
@@ -36,11 +45,13 @@ export function CourseLeaderboard({
 }) {
   const [entries, setEntries] = useState<LeaderboardEntry[] | null>(null);
   const [failed, setFailed] = useState(false);
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     let cancelled = false;
     setEntries(null);
     setFailed(false);
+    setPage(1);
 
     loadCourseLeaderboard(token, courseId).then((result) => {
       if (cancelled) return;
@@ -56,6 +67,14 @@ export function CourseLeaderboard({
     };
   }, [token, courseId]);
 
+  const rows = entries ?? [];
+  const totalPages = Math.max(1, Math.ceil(rows.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageEntries = rows.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  const me = rows.find((entry) => entry.studentId === studentId) ?? null;
+  const meOnPage = pageEntries.some((entry) => entry.studentId === studentId);
+
   return (
     <section className="mt-8">
       <h3 className="mb-5 text-lg font-extrabold text-brand-navy">Course Leaderboard</h3>
@@ -67,7 +86,21 @@ export function CourseLeaderboard({
       ) : entries === null ? (
         <LeaderboardSkeleton />
       ) : (
-        <LeaderboardTable entries={entries} currentStudentId={studentId} />
+        <>
+          <LeaderboardTable entries={pageEntries} currentStudentId={studentId} />
+
+          {me && !meOnPage ? <YourPositionStrip entry={me} /> : null}
+
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+            <span className="text-xs font-semibold text-gray-500">
+              {rows.length === 0
+                ? '0 students'
+                : `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(currentPage * PAGE_SIZE, rows.length)} of ${rows.length} students`}
+            </span>
+
+            <Pagination currentPage={currentPage} totalPages={totalPages} onPageChange={setPage} />
+          </div>
+        </>
       )}
     </section>
   );

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -12,6 +12,7 @@ import {
 import type { InstructorActivityEntry, InstructorSessionEntry, SessionListEntry, SessionRecord } from './sessionTypes';
 import { shuffleArray } from './shuffleArray';
 import { listCoursesForActivityTypes } from './activityCourseQueries';
+import { fetchAllRowsByIds } from './supabasePaging';
 
 export type SupabaseClient = NonNullable<ReturnType<typeof getSupabaseClient>>;
 
@@ -647,6 +648,13 @@ export async function loadAllStudentSessions(supabase: SupabaseClient) {
  * `user_story_id` is carried in SessionPosition's `question_id` field and submission's
  * `user_story_id` in the `answered` set's question-id slot — same shape nextUnansweredPosition
  * already accepts, so "which position comes next" needs no AC-specific derivation.
+ *
+ * GitHub #275 load test (150 students/course): a course-wide caller (loadStudentActivityForIds)
+ * can pass several hundred session ids here. A bare .in('session_id', sessionIds) put every id in
+ * one query string — ~600 ids reliably timed out against Supabase (12s+, then a 500) instead of
+ * erroring loudly, exactly the failure mode lib/supabasePaging.ts's header comment warns about.
+ * fetchAllRowsByIds chunks each of the four queries the same way; still four Promise.all'd calls,
+ * just each one now safe at class scale.
  */
 export async function loadProgressForSessions(supabase: SupabaseClient, sessionIds: string[]) {
   if (sessionIds.length === 0) {
@@ -659,22 +667,18 @@ export async function loadProgressForSessions(supabase: SupabaseClient, sessionI
     { data: storyRows, error: storyError },
     { data: submissionRows, error: submissionError },
   ] = await Promise.all([
-    supabase
-      .from('session_to_question')
-      .select('session_id, position, question_id')
-      .in('session_id', sessionIds),
-    supabase
-      .from('answered_question_log')
-      .select('session_id, question_id')
-      .in('session_id', sessionIds),
-    supabase
-      .from('session_to_user_story')
-      .select('session_id, position, user_story_id')
-      .in('session_id', sessionIds),
-    supabase
-      .from('submission')
-      .select('session_id, user_story_id')
-      .in('session_id', sessionIds),
+    fetchAllRowsByIds(sessionIds, (chunk, from, to) =>
+      supabase.from('session_to_question').select('session_id, position, question_id').in('session_id', chunk).range(from, to),
+    ),
+    fetchAllRowsByIds(sessionIds, (chunk, from, to) =>
+      supabase.from('answered_question_log').select('session_id, question_id').in('session_id', chunk).range(from, to),
+    ),
+    fetchAllRowsByIds(sessionIds, (chunk, from, to) =>
+      supabase.from('session_to_user_story').select('session_id, position, user_story_id').in('session_id', chunk).range(from, to),
+    ),
+    fetchAllRowsByIds(sessionIds, (chunk, from, to) =>
+      supabase.from('submission').select('session_id, user_story_id').in('session_id', chunk).range(from, to),
+    ),
   ]);
 
   const error = positionError ?? answerError ?? storyError ?? submissionError ?? null;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "test": "vitest run"
+    "test": "vitest run",
+    "seed:load-test": "node scripts/seed-load-test.js",
+    "cleanup:load-test": "node scripts/cleanup-load-test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.115.0",

--- a/scripts/cleanup-load-test.js
+++ b/scripts/cleanup-load-test.js
@@ -1,0 +1,126 @@
+'use strict';
+
+// Undoes scripts/seed-load-test.js. Finds everything to remove the same way the seed script
+// finds what already exists — by the three deterministic anchors documented in
+// loadTestConfig.js's header (the @test.local email suffix, the fixed course codes, and the
+// catalogs' derived activity_type keys) — never a stored "is test data" flag, since none exists.
+//
+// Deletes in FK-safe order (children before the parents that RESTRICT their deletion; tables with
+// ON DELETE CASCADE are left for Postgres to clear automatically — see the comment at each step):
+//   1. session_log for every test student   -> cascades answered_question_log, session_to_question, submission
+//   2. the 3 test courses                    -> cascades student_course, assembled_quiz (+ its own cascades,
+//                                                which covers every quiz linked to a test course, not just one)
+//   3. question_to_answer, answer, question for every test catalog (no cascade from activity_type)
+//   4. every test catalog (activity_type) — COURSES[].quizzes.length per course, not just one
+//   5. every @test.local auth user           -> cascades its "user" profile row
+//
+// Dry-run by default — pass --confirm (or --yes) to actually delete anything.
+//
+// Run: node scripts/cleanup-load-test.js --confirm  (or `npm run cleanup:load-test -- --confirm`)
+
+const { createClient } = require('@supabase/supabase-js');
+const { COURSES, slugifyQuizName, loadEnv, chunk, mapLimit, listAllTestUsers } = require('./loadTestConfig');
+
+async function main() {
+  const startedAt = Date.now();
+  const confirmed = process.argv.slice(2).some((arg) => arg === '--confirm' || arg === '--yes');
+
+  const env = loadEnv();
+  const url = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing from .env.local');
+    process.exit(1);
+  }
+  const supabase = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+  console.log(`${confirmed ? 'Cleaning up' : 'DRY RUN — would clean up'} load-test data on ${url}\n`);
+
+  // ---- Discover what exists ----
+  const testUsers = await listAllTestUsers(supabase);
+  const testUserIds = [...testUsers.values()].map((u) => u.id);
+  console.log(`Found ${testUserIds.length} @test.local auth accounts.`);
+
+  const courseCodes = COURSES.map((c) => c.courseCode);
+  const { data: courseRows, error: courseErr } = await supabase.from('course').select('course_id, course_name, course_code').in('course_code', courseCodes);
+  if (courseErr) throw new Error(`course lookup failed: ${courseErr.message}`);
+  console.log(`Found ${courseRows.length} test course(s): ${courseRows.map((c) => c.course_name).join(', ') || '(none)'}.`);
+
+  const activityTypes = COURSES.flatMap((c) => c.quizzes.map((q) => slugifyQuizName(q.name)));
+  const { data: questionRows, error: qErr } = await supabase.from('question').select('question_id').in('activity_type', activityTypes);
+  if (qErr) throw new Error(`question lookup failed: ${qErr.message}`);
+  console.log(`Found ${questionRows.length} questions across ${activityTypes.length} test catalogs.`);
+
+  if (!confirmed) {
+    console.log('\nNothing deleted. Re-run with --confirm to actually remove the rows above.');
+    return;
+  }
+
+  // ---- 1. session_log for every test user (cascades answered_question_log/session_to_question/submission) ----
+  let deletedSessions = 0;
+  for (const batch of chunk(testUserIds, 200)) {
+    if (batch.length === 0) continue;
+    const { data, error } = await supabase.from('session_log').delete().in('user_id', batch).select('session_id');
+    if (error) throw new Error(`session_log delete failed: ${error.message}`);
+    deletedSessions += data.length;
+  }
+  console.log(`\nDeleted ${deletedSessions} sessions (cascaded their answers/submissions).`);
+
+  // ---- 2. the test courses (cascades student_course, assembled_quiz + its own children) ----
+  const courseIds = courseRows.map((c) => c.course_id);
+  if (courseIds.length > 0) {
+    const { data, error } = await supabase.from('course').delete().in('course_id', courseIds).select('course_id');
+    if (error) throw new Error(`course delete failed: ${error.message}`);
+    console.log(`Deleted ${data.length} courses (cascaded enrollments/assembled quizzes).`);
+  }
+
+  // ---- 3. question/answer/question_to_answer for the test catalogs (no cascade from activity_type) ----
+  const questionIds = questionRows.map((q) => q.question_id);
+  const answerIds = [];
+  for (const batch of chunk(questionIds, 300)) {
+    if (batch.length === 0) continue;
+    const { data, error } = await supabase.from('question_to_answer').select('answer_id').in('question_id', batch);
+    if (error) throw new Error(`question_to_answer lookup failed: ${error.message}`);
+    answerIds.push(...data.map((r) => r.answer_id));
+  }
+  for (const batch of chunk(questionIds, 300)) {
+    if (batch.length === 0) continue;
+    const { error } = await supabase.from('question_to_answer').delete().in('question_id', batch);
+    if (error) throw new Error(`question_to_answer delete failed: ${error.message}`);
+  }
+  for (const batch of chunk(answerIds, 300)) {
+    if (batch.length === 0) continue;
+    const { error } = await supabase.from('answer').delete().in('answer_id', batch);
+    if (error) throw new Error(`answer delete failed: ${error.message}`);
+  }
+  for (const batch of chunk(questionIds, 300)) {
+    if (batch.length === 0) continue;
+    const { error } = await supabase.from('question').delete().in('question_id', batch);
+    if (error) throw new Error(`question delete failed: ${error.message}`);
+  }
+  console.log(`Deleted ${questionIds.length} questions and ${answerIds.length} answers.`);
+
+  // ---- 4. the test catalogs themselves ----
+  const { data: deletedCatalogs, error: catDelErr } = await supabase.from('activity_type').delete().in('activity_type', activityTypes).select('activity_type');
+  if (catDelErr) throw new Error(`activity_type delete failed: ${catDelErr.message}`);
+  console.log(`Deleted ${deletedCatalogs.length} catalogs.`);
+
+  // ---- 5. every @test.local auth user (cascades its "user" profile row via fk_user_auth_users) ----
+  let deletedUsers = 0;
+  await mapLimit(testUserIds, 10, async (id) => {
+    const { error } = await supabase.auth.admin.deleteUser(id);
+    if (error && !/not.*found/i.test(error.message || '')) {
+      throw new Error(`deleteUser(${id}) failed: ${error.message}`);
+    }
+    deletedUsers++;
+  });
+  console.log(`Deleted ${deletedUsers} auth accounts (profiles cascaded).`);
+
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log(`\nCleanup done in ${elapsed}s.`);
+}
+
+main().catch((err) => {
+  console.error('\nCleanup script failed:', err);
+  process.exit(1);
+});

--- a/scripts/loadTestConfig.js
+++ b/scripts/loadTestConfig.js
@@ -1,0 +1,333 @@
+'use strict';
+
+// Shared config + helpers for scripts/seed-load-test.js and scripts/cleanup-load-test.js
+// (GitHub #275 / REQ-PL-3.4.4 — "3 courses, 3 instructors, 150 students each" load-test data).
+//
+// Both scripts connect directly to Supabase with the service-role key (same credential
+// lib/supabase.ts's getSupabaseAdminClient() uses) rather than going through the Next.js HTTP
+// API — the API has no bulk-insert routes, and hitting POST /api/sessions 450+ times would be
+// far slower than batched table inserts. The one call that genuinely has no bulk equivalent is
+// Supabase's auth admin API (auth.admin.createUser/deleteUser) — every other insert/delete here
+// is chunked into as few round trips as the payload size allows.
+//
+// Every row this creates is identifiable by construction, without a schema change:
+//   - every account's email ends in @test.local (TEST_EMAIL_DOMAIN)
+//   - the 3 courses use fixed, recognizable course codes (COURSES[].courseCode)
+//   - every catalog's activity_type key derives from a fixed, recognizable name (COURSES[].quizzes[].name)
+// cleanup-load-test.js locates everything to remove through those three anchors, not a stored flag.
+//
+// Follow-up to the original #275 seed (3 quizzes/course + deterministic result groups, so the
+// instructor dashboard and student leaderboard have something other than one uniform quiz to
+// show): every course gets COURSES[].quizzes.length separate catalogs+assembled quizzes, not one,
+// and every (student, quiz) pair is independently placed into one of RESULT_GROUPS below rather
+// than a free-form random score. Login credentials for one instructor+student pair per course are
+// printed at the end of seed-load-test.js and written to test-credentials.txt.
+
+const fs = require('fs');
+const path = require('path');
+
+const TEST_EMAIL_DOMAIN = '@test.local';
+const TEST_PASSWORD = 'LoadTest#2026!';
+
+// Overridable via LOAD_TEST_STUDENTS_PER_COURSE for a cheap dry run (e.g. 5 students/course)
+// before committing to the full 150 — everything else in this file stays identical either way.
+const STUDENTS_PER_COURSE = Number(process.env.LOAD_TEST_STUDENTS_PER_COURSE) || 150;
+
+// Mirrors lib/sessionRules.ts — kept as separate constants here (not a shared import) because
+// this script runs standalone with `node`, outside the Next.js/TypeScript build.
+const QUESTIONS_PER_LEVEL = 4; // QUESTIONS_PER_SESSION / MIN_QUESTIONS_PER_LEVEL
+const MAX_DIFFICULTY_LEVEL = 3;
+const PASS_RATIO = 0.75;
+const MCQ_POINTS_BY_DIFFICULTY = { 1: 10, 2: 20, 3: 30 };
+
+/** Mirrors lib/activityTypes.ts's slugifyQuizName exactly, so the derived activity_type key here is
+ * the same one POST /api/activities/types would have produced for the same catalog name. */
+function slugifyQuizName(name) {
+  return name
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
+function studentEmail(prefix, n) {
+  return `${prefix}${String(n).padStart(3, '0')}${TEST_EMAIL_DOMAIN}`;
+}
+
+// Each course gets 3 quizzes (AC: "mindestens 2-3"): the first is the full 3-level catalog the
+// original #275 seed had, the other two are deliberately smaller ("ein paar einfache
+// Testfragen") — Easy-only, 4 questions, just enough to satisfy MIN_QUESTIONS_PER_LEVEL and let a
+// session actually be played. Every quiz gets its own catalog (activity_type) — "inkl.
+// zugehörigem Fragenkatalog" — never shared across quizzes, so excluding/editing one never
+// touches another.
+const COURSES = [
+  {
+    key: 'A',
+    courseName: 'Load Test Course A',
+    courseCode: 'TESTCLASS1',
+    studentEmailPrefix: 'student_c1_',
+    instructor: { email: 'prof_test_1@test.local', firstName: 'Prof.', lastName: 'Test One', username: 'prof_test_1' },
+    quizzes: [
+      { name: 'Load Test Quiz Bank A1', levels: [1, 2, 3] },
+      { name: 'Load Test Quiz Bank A2', levels: [1] },
+      { name: 'Load Test Quiz Bank A3', levels: [1] },
+    ],
+  },
+  {
+    key: 'B',
+    courseName: 'Load Test Course B',
+    courseCode: 'TESTCLASS2',
+    studentEmailPrefix: 'student_c2_',
+    instructor: { email: 'prof_test_2@test.local', firstName: 'Prof.', lastName: 'Test Two', username: 'prof_test_2' },
+    quizzes: [
+      { name: 'Load Test Quiz Bank B1', levels: [1, 2, 3] },
+      { name: 'Load Test Quiz Bank B2', levels: [1] },
+      { name: 'Load Test Quiz Bank B3', levels: [1] },
+    ],
+  },
+  {
+    key: 'C',
+    courseName: 'Load Test Course C',
+    courseCode: 'TESTCLASS3',
+    studentEmailPrefix: 'student_c3_',
+    instructor: { email: 'prof_test_3@test.local', firstName: 'Prof.', lastName: 'Test Three', username: 'prof_test_3' },
+    quizzes: [
+      { name: 'Load Test Quiz Bank C1', levels: [1, 2, 3] },
+      { name: 'Load Test Quiz Bank C2', levels: [1] },
+      { name: 'Load Test Quiz Bank C3', levels: [1] },
+    ],
+  },
+];
+
+/**
+ * Follow-up AC: every (student, quiz) pair independently lands in one of these 4 groups, ~25%
+ * each ("ungefähr gleiche Teile") — so two quizzes in the same course don't show identical
+ * per-student results. correctFraction is out of QUESTIONS_PER_LEVEL (always 4): 'full' passes
+ * (>=75%), 'partial' and 'zero' both fail, 'notStarted' gets no session_log row at all.
+ */
+const RESULT_GROUPS = [
+  { key: 'full', label: 'Fully correct', correctFraction: 1 },
+  { key: 'partial', label: 'Partially correct', correctFraction: 0.5 },
+  { key: 'zero', label: 'Fully incorrect', correctFraction: 0 },
+  { key: 'notStarted', label: 'Not started', correctFraction: null },
+];
+
+// 4 questions per level x 3 levels per catalog — QUESTIONS_PER_LEVEL exactly, so every session
+// (which always draws the whole level pool here) has a full, non-repeating set of 4 questions,
+// same as a real MCQ catalog needs at minimum (MIN_QUESTIONS_PER_LEVEL). Reused verbatim across
+// all 3 catalogs — they're independent activity_type keys, so identical text across catalogs A/B/C
+// is not a collision.
+const QUESTION_BANK = {
+  1: [
+    {
+      prompt: 'Which of the following best describes a functional requirement?',
+      options: [
+        { text: 'A statement of what the system must do', correct: true },
+        { text: 'A statement of how fast the system must respond', correct: false },
+        { text: "A description of the team's coding standards", correct: false },
+        { text: 'A description of the deployment environment', correct: false },
+      ],
+    },
+    {
+      prompt: 'What is the primary purpose of a user story?',
+      options: [
+        { text: 'To capture a feature from the perspective of an end user', correct: true },
+        { text: 'To document the database schema', correct: false },
+        { text: 'To list every acceptance test in full detail', correct: false },
+        { text: 'To replace the need for a requirements document', correct: false },
+      ],
+    },
+    {
+      prompt: 'Which of these is a non-functional requirement?',
+      options: [
+        { text: 'The system must respond within 2 seconds', correct: true },
+        { text: 'The system must let a user reset their password', correct: false },
+        { text: 'The system must display a list of products', correct: false },
+        { text: 'The system must send a confirmation email', correct: false },
+      ],
+    },
+    {
+      prompt: 'What does the acronym MVP stand for in product development?',
+      options: [
+        { text: 'Minimum Viable Product', correct: true },
+        { text: 'Most Valuable Prototype', correct: false },
+        { text: 'Managed Verification Process', correct: false },
+        { text: 'Minimum Validated Plan', correct: false },
+      ],
+    },
+  ],
+  2: [
+    {
+      prompt: 'Which INVEST criterion means a user story should be understandable without needing other stories to be completed first?',
+      options: [
+        { text: 'Independent', correct: true },
+        { text: 'Negotiable', correct: false },
+        { text: 'Estimable', correct: false },
+        { text: 'Testable', correct: false },
+      ],
+    },
+    {
+      prompt: "A requirement stating 'the system must handle 10,000 concurrent users' is best classified as which type of requirement?",
+      options: [
+        { text: 'Performance / scalability requirement', correct: true },
+        { text: 'Functional requirement', correct: false },
+        { text: 'Business rule', correct: false },
+        { text: 'User interface requirement', correct: false },
+      ],
+    },
+    {
+      prompt: "What is the main risk of writing a requirement as 'the system should be fast'?",
+      options: [
+        { text: 'It is not measurable or testable', correct: true },
+        { text: 'It is too short to read', correct: false },
+        { text: 'It is a functional requirement', correct: false },
+        { text: 'It cannot be assigned to a developer', correct: false },
+      ],
+    },
+    {
+      prompt: 'Which elicitation technique is most suitable for gathering requirements from a large, diverse group of stakeholders at once?',
+      options: [
+        { text: 'Workshops or focus groups', correct: true },
+        { text: 'One-on-one interviews only', correct: false },
+        { text: 'Reading competitor documentation', correct: false },
+        { text: 'Guessing based on similar products', correct: false },
+      ],
+    },
+  ],
+  3: [
+    {
+      prompt: 'In a distributed system, which non-functional requirement category addresses the ability to add capacity without redesigning the architecture?',
+      options: [
+        { text: 'Scalability', correct: true },
+        { text: 'Usability', correct: false },
+        { text: 'Maintainability', correct: false },
+        { text: 'Portability', correct: false },
+      ],
+    },
+    {
+      prompt: 'Which requirements engineering artifact best captures the rationale behind a specific design decision?',
+      options: [
+        { text: 'An architectural decision record (ADR)', correct: true },
+        { text: 'A user story', correct: false },
+        { text: 'A use case diagram', correct: false },
+        { text: 'A test case', correct: false },
+      ],
+    },
+    {
+      prompt: 'Two stakeholders provide directly conflicting requirements. Which technique is most appropriate to resolve the conflict?',
+      options: [
+        { text: 'Prioritization and negotiation with both stakeholders', correct: true },
+        { text: 'Implementing whichever requirement was received first', correct: false },
+        { text: 'Ignoring both requirements', correct: false },
+        { text: 'Letting a single developer decide unilaterally', correct: false },
+      ],
+    },
+    {
+      prompt: 'Which format best captures a non-functional requirement in a precise, testable way?',
+      options: [
+        { text: 'A quality attribute scenario (stimulus, environment, response, response measure)', correct: true },
+        { text: 'A single adjective describing the desired quality', correct: false },
+        { text: 'A user story written in first person', correct: false },
+        { text: 'A free-text paragraph with no structure', correct: false },
+      ],
+    },
+  ],
+};
+
+/** Minimal .env.local parser — this script runs standalone via `node`, so it can't rely on
+ * Next.js's own env loading. Same two keys app/api/auth/register/route.ts's getSupabaseAdminClient
+ * needs: SUPABASE_URL (or NEXT_PUBLIC_SUPABASE_URL) and SUPABASE_SERVICE_ROLE_KEY. */
+function loadEnv() {
+  const envPath = path.join(__dirname, '..', '.env.local');
+  const content = fs.readFileSync(envPath, 'utf8');
+  const env = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    let value = trimmed.slice(eq + 1).trim();
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+function chunk(array, size) {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += size) chunks.push(array.slice(i, i + size));
+  return chunks;
+}
+
+/** Runs `fn` over `items` with at most `limit` in flight at once — used for the per-account auth
+ * admin calls, which have no bulk equivalent (see the header comment above). */
+async function mapLimit(items, limit, fn) {
+  const results = new Array(items.length);
+  let index = 0;
+  async function worker() {
+    while (index < items.length) {
+      const current = index++;
+      results[current] = await fn(items[current], current);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return results;
+}
+
+async function withRetry(fn, { attempts = 4, baseDelayMs = 500 } = {}) {
+  let lastError;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastError = err;
+      if (i < attempts - 1) await new Promise((resolve) => setTimeout(resolve, baseDelayMs * 2 ** i));
+    }
+  }
+  throw lastError;
+}
+
+/** Every auth user whose email ends in @test.local, keyed by lower-cased email — the one query
+ * both scripts need: seed uses it to skip accounts that already exist, cleanup uses it to find
+ * every account to remove. Paginated (perPage 1000) since auth.admin.listUsers has no `.in()`. */
+async function listAllTestUsers(supabase) {
+  const result = new Map();
+  let page = 1;
+  const perPage = 1000;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+    if (error) throw new Error(`auth.admin.listUsers failed: ${error.message}`);
+    for (const u of data.users) {
+      if (u.email && u.email.toLowerCase().endsWith(TEST_EMAIL_DOMAIN)) {
+        result.set(u.email.toLowerCase(), u);
+      }
+    }
+    if (data.users.length < perPage) break;
+    page++;
+  }
+  return result;
+}
+
+module.exports = {
+  TEST_EMAIL_DOMAIN,
+  TEST_PASSWORD,
+  STUDENTS_PER_COURSE,
+  QUESTIONS_PER_LEVEL,
+  MAX_DIFFICULTY_LEVEL,
+  PASS_RATIO,
+  MCQ_POINTS_BY_DIFFICULTY,
+  QUESTION_BANK,
+  COURSES,
+  RESULT_GROUPS,
+  slugifyQuizName,
+  studentEmail,
+  loadEnv,
+  chunk,
+  mapLimit,
+  withRetry,
+  listAllTestUsers,
+};

--- a/scripts/seed-load-test.js
+++ b/scripts/seed-load-test.js
@@ -1,0 +1,534 @@
+'use strict';
+
+// GitHub #275 / REQ-PL-3.4.4 — seeds 3 courses, taught by 3 different instructors, with 150
+// students each (450 total), plus enough real session_log/answered_question_log activity per
+// student that the instructor dashboard, course cards, leaderboards and activity logs all have
+// non-empty, realistically-varying data to load-test against.
+//
+// Follow-up (same issue thread): 3 quizzes per course instead of 1, every (student, quiz) pair
+// independently placed into one of RESULT_GROUPS (loadTestConfig.js) rather than a free-form
+// random score, and login credentials for one instructor+student pair per course printed at the
+// end — see main()'s final section and test-credentials.txt.
+//
+// Idempotent: every entity is looked up by a deterministic key before being created (email for
+// accounts, course_code for courses, the derived activity_type for catalogs, (course_id,user_id)
+// for enrollments, "does this student already have a session for this activity_type" for activity
+// data) — rerunning this script tops up whatever is missing instead of duplicating anything. One
+// known limitation: a student who landed in the 'notStarted' group has, by definition, no
+// session_log row, so a rerun can't tell "deliberately not started" apart from "never processed"
+// and may draw them into a fresh group assignment — harmless (still no duplicates, ratios stay
+// close to even) but worth knowing if you rerun the same course multiple times.
+//
+// Run: node scripts/seed-load-test.js  (or `npm run seed:load-test`)
+// Undo: node scripts/cleanup-load-test.js --confirm  (or `npm run cleanup:load-test`)
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { createClient } = require('@supabase/supabase-js');
+const {
+  TEST_PASSWORD,
+  STUDENTS_PER_COURSE,
+  QUESTIONS_PER_LEVEL,
+  PASS_RATIO,
+  MCQ_POINTS_BY_DIFFICULTY,
+  QUESTION_BANK,
+  COURSES,
+  RESULT_GROUPS,
+  slugifyQuizName,
+  studentEmail,
+  loadEnv,
+  chunk,
+  mapLimit,
+  withRetry,
+  listAllTestUsers,
+} = require('./loadTestConfig');
+
+function shuffle(array) {
+  const copy = array.slice();
+  for (let i = copy.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+}
+
+// Zone-less, matching every other timestamp column in the schema (see CLAUDE.md's "Timestamps
+// are zone-less" section) — a naive wall-clock string, not UTC-with-offset.
+function randomTimestampWithinDays(days) {
+  const past = Date.now() - Math.floor(Math.random() * days * 24 * 60 * 60 * 1000);
+  return new Date(past).toISOString().replace('Z', '');
+}
+
+// Weighted toward Easy among whichever levels this quiz actually has questions for — a smaller
+// quiz (levels: [1]) always resolves to level 1; the full 3-level quiz keeps the original 60/25/15
+// spread. Not a progression simulation, just variety across the quizzes that have more than one level.
+const LEVEL_WEIGHT = { 1: 0.6, 2: 0.25, 3: 0.15 };
+function pickLevel(availableLevels) {
+  if (availableLevels.length === 1) return availableLevels[0];
+  const total = availableLevels.reduce((sum, l) => sum + LEVEL_WEIGHT[l], 0);
+  let r = Math.random() * total;
+  for (const level of availableLevels) {
+    if (r < LEVEL_WEIGHT[level]) return level;
+    r -= LEVEL_WEIGHT[level];
+  }
+  return availableLevels[availableLevels.length - 1];
+}
+
+async function selectExistingIds(supabase, table, column, ids) {
+  const found = new Set();
+  for (const batch of chunk(ids, 300)) {
+    if (batch.length === 0) continue;
+    const { data, error } = await supabase.from(table).select(column).in(column, batch);
+    if (error) throw new Error(`select ${table}.${column} failed: ${error.message}`);
+    for (const row of data) found.add(row[column]);
+  }
+  return found;
+}
+
+async function ensureCourse(supabase, course, instructorId) {
+  const { data: existing, error: selErr } = await supabase
+    .from('course')
+    .select('course_id, course_name, course_code')
+    .eq('course_code', course.courseCode)
+    .maybeSingle();
+  if (selErr) throw new Error(`course lookup failed: ${selErr.message}`);
+  if (existing) {
+    console.log(`  Course "${existing.course_name}" already exists (code ${existing.course_code}).`);
+    return existing;
+  }
+
+  const { data, error } = await supabase
+    .from('course')
+    .insert({
+      course_id: crypto.randomUUID(),
+      creator_id: instructorId,
+      course_name: course.courseName,
+      course_code: course.courseCode,
+    })
+    .select('course_id, course_name, course_code')
+    .single();
+  if (error) throw new Error(`course insert failed: ${error.message}`);
+  console.log(`  Created course "${data.course_name}" (code ${data.course_code}).`);
+  return data;
+}
+
+/** Every existing question for this catalog, joined to its correct/wrong answer id via two flat
+ * lookups instead of a nested PostgREST embed — simpler to get right than reasoning about embed
+ * filter syntax, and this only ever runs once per course. */
+async function loadExistingQuestions(supabase, activityType) {
+  const { data: questions, error: qErr } = await supabase
+    .from('question')
+    .select('question_id, difficulty_level')
+    .eq('activity_type', activityType);
+  if (qErr) throw new Error(`question lookup failed: ${qErr.message}`);
+
+  const byLevel = { 1: [], 2: [], 3: [] };
+  if (questions.length === 0) return byLevel;
+
+  const questionIds = questions.map((q) => q.question_id);
+  const linkRows = [];
+  for (const batch of chunk(questionIds, 300)) {
+    const { data, error } = await supabase.from('question_to_answer').select('question_id, answer_id').in('question_id', batch);
+    if (error) throw new Error(`question_to_answer lookup failed: ${error.message}`);
+    linkRows.push(...data);
+  }
+
+  const answerIds = linkRows.map((l) => l.answer_id);
+  const answerRows = [];
+  for (const batch of chunk(answerIds, 300)) {
+    const { data, error } = await supabase.from('answer').select('answer_id, is_correct').in('answer_id', batch);
+    if (error) throw new Error(`answer lookup failed: ${error.message}`);
+    answerRows.push(...data);
+  }
+
+  const isCorrectByAnswerId = new Map(answerRows.map((a) => [a.answer_id, a.is_correct]));
+  const answerIdsByQuestionId = new Map();
+  for (const link of linkRows) {
+    if (!answerIdsByQuestionId.has(link.question_id)) answerIdsByQuestionId.set(link.question_id, []);
+    answerIdsByQuestionId.get(link.question_id).push(link.answer_id);
+  }
+
+  for (const q of questions) {
+    const ids = answerIdsByQuestionId.get(q.question_id) || [];
+    const correctAnswerId = ids.find((id) => isCorrectByAnswerId.get(id) === true);
+    const wrongAnswerId = ids.find((id) => isCorrectByAnswerId.get(id) === false);
+    if (!correctAnswerId || !wrongAnswerId) continue; // leftover from an interrupted run; ignored, top-up below replaces it
+    byLevel[q.difficulty_level].push({ questionId: q.question_id, correctAnswerId, wrongAnswerId });
+  }
+  return byLevel;
+}
+
+async function createQuestionsBatch(supabase, activityType, level, prompts, instructorId, orderOffset) {
+  const answerRows = [];
+  const questionRows = [];
+  const linkRows = [];
+  const created = [];
+
+  prompts.forEach((item, idx) => {
+    const questionId = crypto.randomUUID();
+    questionRows.push({
+      question_id: questionId,
+      question_prompt: item.prompt,
+      difficulty_level: level,
+      activity_type: activityType,
+      order_number: orderOffset + idx + 1,
+      max_score: MCQ_POINTS_BY_DIFFICULTY[level],
+      user_id: instructorId,
+    });
+
+    let correctAnswerId = null;
+    let wrongAnswerId = null;
+    for (const option of item.options) {
+      const answerId = crypto.randomUUID();
+      answerRows.push({ answer_id: answerId, option_text: option.text, is_correct: option.correct, explanation: null });
+      linkRows.push({ question_id: questionId, answer_id: answerId });
+      if (option.correct) correctAnswerId = answerId;
+      else if (!wrongAnswerId) wrongAnswerId = answerId;
+    }
+    created.push({ questionId, correctAnswerId, wrongAnswerId });
+  });
+
+  // answer/question have no FK to each other; question_to_answer needs both, so it goes last.
+  for (const batch of chunk(answerRows, 500)) {
+    const { error } = await supabase.from('answer').insert(batch);
+    if (error) throw new Error(`answer insert failed: ${error.message}`);
+  }
+  for (const batch of chunk(questionRows, 500)) {
+    const { error } = await supabase.from('question').insert(batch);
+    if (error) throw new Error(`question insert failed: ${error.message}`);
+  }
+  for (const batch of chunk(linkRows, 500)) {
+    const { error } = await supabase.from('question_to_answer').insert(batch);
+    if (error) throw new Error(`question_to_answer insert failed: ${error.message}`);
+  }
+  return created;
+}
+
+async function ensureCatalogAndQuestions(supabase, quizConfig, activityType, instructorId) {
+  const { data: existingCatalog, error: catErr } = await supabase
+    .from('activity_type')
+    .select('activity_type, quiz_name')
+    .eq('activity_type', activityType)
+    .maybeSingle();
+  if (catErr) throw new Error(`catalog lookup failed: ${catErr.message}`);
+
+  if (!existingCatalog) {
+    const { error: insErr } = await supabase.from('activity_type').insert({
+      activity_type: activityType,
+      quiz_name: quizConfig.name,
+      description: 'Load-test seed data (GitHub #275) — safe to remove via scripts/cleanup-load-test.js.',
+      grading_kind: 'mcq',
+      creator_id: instructorId,
+    });
+    if (insErr) throw new Error(`catalog insert failed: ${insErr.message}`);
+    console.log(`  Created catalog "${quizConfig.name}" (${activityType}).`);
+  } else {
+    console.log(`  Catalog "${existingCatalog.quiz_name}" already exists (${activityType}).`);
+  }
+
+  const byLevel = await loadExistingQuestions(supabase, activityType);
+  for (const level of quizConfig.levels) {
+    const have = byLevel[level].length;
+    const need = QUESTIONS_PER_LEVEL - have;
+    if (need <= 0) continue;
+    const prompts = QUESTION_BANK[level].slice(have, have + need);
+    const created = await createQuestionsBatch(supabase, activityType, level, prompts, instructorId, have);
+    byLevel[level].push(...created);
+  }
+  console.log(`  Questions (levels ${quizConfig.levels.join(',')}): ${quizConfig.levels.map((l) => `L${l}=${byLevel[l].length}`).join(', ')}.`);
+  return byLevel;
+}
+
+async function ensureAssembledQuiz(supabase, quizName, courseId, activityType, instructorId) {
+  const { data: existing, error: selErr } = await supabase
+    .from('assembled_quiz')
+    .select('assembled_quiz_id, quiz_name')
+    .eq('course_id', courseId)
+    .eq('quiz_name', quizName)
+    .maybeSingle();
+  if (selErr) throw new Error(`assembled_quiz lookup failed: ${selErr.message}`);
+
+  let assembledQuizId;
+  if (existing) {
+    assembledQuizId = existing.assembled_quiz_id;
+    console.log(`  Assembled quiz "${existing.quiz_name}" already exists.`);
+  } else {
+    const { data, error } = await supabase
+      .from('assembled_quiz')
+      .insert({
+        assembled_quiz_id: crypto.randomUUID(),
+        quiz_name: quizName,
+        description: 'Load-test seed data (GitHub #275).',
+        course_id: courseId,
+        creator_id: instructorId,
+        grading_kind: 'mcq',
+        questions_per_level: QUESTIONS_PER_LEVEL,
+      })
+      .select('assembled_quiz_id, quiz_name')
+      .single();
+    if (error) throw new Error(`assembled_quiz insert failed: ${error.message}`);
+    assembledQuizId = data.assembled_quiz_id;
+    console.log(`  Created assembled quiz "${data.quiz_name}", granting the course access to the catalog.`);
+  }
+
+  const { data: existingLink } = await supabase
+    .from('assembled_quiz_catalog')
+    .select('assembled_quiz_catalog_id')
+    .eq('assembled_quiz_id', assembledQuizId)
+    .eq('activity_type', activityType)
+    .maybeSingle();
+  if (!existingLink) {
+    const { error } = await supabase.from('assembled_quiz_catalog').insert({ assembled_quiz_id: assembledQuizId, activity_type: activityType });
+    if (error && error.code !== '23505') throw new Error(`assembled_quiz_catalog insert failed: ${error.message}`);
+  }
+
+  return assembledQuizId;
+}
+
+async function ensureEnrollments(supabase, courseId, students) {
+  const studentIds = students.map((s) => s.userId);
+  const existing = new Set();
+  for (const batch of chunk(studentIds, 300)) {
+    const { data, error } = await supabase.from('student_course').select('user_id').eq('course_id', courseId).in('user_id', batch);
+    if (error) throw new Error(`student_course lookup failed: ${error.message}`);
+    for (const row of data) existing.add(row.user_id);
+  }
+
+  const missing = students.filter((s) => !existing.has(s.userId));
+  const rows = missing.map((s) => ({ user_id: s.userId, course_id: courseId }));
+  for (const batch of chunk(rows, 500)) {
+    const { error } = await supabase.from('student_course').insert(batch);
+    if (error) throw new Error(`student_course insert failed: ${error.message}`);
+  }
+  console.log(`  Enrollments: ${missing.length} created, ${existing.size} already existed.`);
+}
+
+/** Builds the 4 session_to_question rows + this session's answered_question_log rows for one
+ * session, marking exactly `correctCount` of the 4 questions correct (random which ones). */
+function buildSessionQuestionRows(sessionId, pool, levelPoints, correctCount, timestamp) {
+  const positions = shuffle([0, 1, 2, 3]);
+  const correctSlots = new Set(shuffle([0, 1, 2, 3]).slice(0, correctCount));
+  const sessionToQuestionRows = [];
+  const answeredRows = [];
+
+  pool.forEach((question, idx) => {
+    sessionToQuestionRows.push({ session_id: sessionId, question_id: question.questionId, position: positions[idx] });
+    const isCorrect = correctSlots.has(idx);
+    answeredRows.push({
+      log_id: crypto.randomUUID(),
+      submitted_at: timestamp,
+      score: isCorrect ? levelPoints : 0,
+      session_id: sessionId,
+      question_id: question.questionId,
+      submitted_option: isCorrect ? question.correctAnswerId : question.wrongAnswerId,
+    });
+  });
+
+  return { sessionToQuestionRows, answeredRows };
+}
+
+/**
+ * Follow-up AC: every (student, quiz) pair independently lands in one of RESULT_GROUPS, ~25%
+ * each — shuffle-then-modulo gives an exactly even split (e.g. 150/4 -> 38/38/37/37) and a
+ * different shuffle per quiz, so the same student's group varies quiz to quiz ("Ergebnisse pro
+ * Student und Quiz können variieren"). 'notStarted' students are simply skipped — no session_log
+ * row at all, which is what makes them show up as "not attempted" everywhere that reads it.
+ */
+async function ensureActivityData(supabase, activityType, questionsByLevel, students) {
+  const studentIds = students.map((s) => s.userId);
+  const alreadySeeded = new Set();
+  for (const batch of chunk(studentIds, 300)) {
+    const { data, error } = await supabase.from('session_log').select('user_id').eq('activity_type', activityType).in('user_id', batch);
+    if (error) throw new Error(`session_log lookup failed: ${error.message}`);
+    for (const row of data) alreadySeeded.add(row.user_id);
+  }
+
+  const toSeed = students.filter((s) => !alreadySeeded.has(s.userId));
+  if (toSeed.length === 0) {
+    console.log(`  Activity data: already seeded for all ${students.length} students.`);
+    return;
+  }
+
+  const availableLevels = Object.keys(questionsByLevel)
+    .map(Number)
+    .filter((level) => questionsByLevel[level].length > 0);
+
+  const sessionRows = [];
+  const sessionToQuestionRows = [];
+  const answeredRows = [];
+  const groupCounts = Object.fromEntries(RESULT_GROUPS.map((g) => [g.key, 0]));
+
+  shuffle(toSeed).forEach((student, idx) => {
+    const group = RESULT_GROUPS[idx % RESULT_GROUPS.length];
+    groupCounts[group.key]++;
+    if (group.correctFraction === null) return; // 'notStarted' — no session_log row at all
+
+    const level = pickLevel(availableLevels);
+    const pool = questionsByLevel[level];
+    const levelPoints = MCQ_POINTS_BY_DIFFICULTY[level];
+    const maxScore = QUESTIONS_PER_LEVEL * levelPoints;
+    const correctCount = Math.round(QUESTIONS_PER_LEVEL * group.correctFraction);
+    const sessionId = crypto.randomUUID();
+    const [startedAt, endedAt] = [randomTimestampWithinDays(60), randomTimestampWithinDays(60)].sort();
+
+    sessionRows.push({
+      session_id: sessionId,
+      user_id: student.userId,
+      activity_type: activityType,
+      difficulty_level: level,
+      started_at: startedAt,
+      ended_at: endedAt,
+      status: 'completed',
+      cumulative_score: 0, // trg_answered_question_log_score rolls this up as the answers below are inserted
+      max_score: maxScore,
+      passed: correctCount >= Math.ceil(QUESTIONS_PER_LEVEL * PASS_RATIO),
+    });
+
+    const { sessionToQuestionRows: stq, answeredRows: ans } = buildSessionQuestionRows(sessionId, pool, levelPoints, correctCount, endedAt);
+    sessionToQuestionRows.push(...stq);
+    answeredRows.push(...ans);
+  });
+
+  for (const batch of chunk(sessionRows, 500)) {
+    const { error } = await supabase.from('session_log').insert(batch);
+    if (error) throw new Error(`session_log insert failed: ${error.message}`);
+  }
+  for (const batch of chunk(sessionToQuestionRows, 800)) {
+    const { error } = await supabase.from('session_to_question').insert(batch);
+    if (error) throw new Error(`session_to_question insert failed: ${error.message}`);
+  }
+  for (const batch of chunk(answeredRows, 800)) {
+    const { error } = await supabase.from('answered_question_log').insert(batch);
+    if (error) throw new Error(`answered_question_log insert failed: ${error.message}`);
+  }
+
+  const groupSummary = RESULT_GROUPS.map((g) => `${g.label}=${groupCounts[g.key]}`).join(', ');
+  console.log(`  Activity data: ${sessionRows.length} sessions for ${toSeed.length} students (${groupSummary}).`);
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const env = loadEnv();
+  const url = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceKey) {
+    console.error('SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY missing from .env.local');
+    process.exit(1);
+  }
+  const supabase = createClient(url, serviceKey, { auth: { persistSession: false } });
+
+  const totalStudents = COURSES.length * STUDENTS_PER_COURSE;
+  console.log(`Seeding load-test data against ${url}`);
+  console.log(`Plan: ${COURSES.length} instructors, ${COURSES.length} courses, ${totalStudents} students.\n`);
+
+  // ---- 1. Resolve/create every auth user (instructors + students) ----
+  const plannedAccounts = [];
+  for (const course of COURSES) {
+    plannedAccounts.push({ ...course.instructor, role: 'instructor' });
+    for (let i = 1; i <= STUDENTS_PER_COURSE; i++) {
+      plannedAccounts.push({
+        email: studentEmail(course.studentEmailPrefix, i),
+        firstName: 'TestStudent',
+        lastName: `${course.key}${String(i).padStart(3, '0')}`,
+        username: `teststudent_${course.key.toLowerCase()}${String(i).padStart(3, '0')}`,
+        role: 'student',
+      });
+    }
+  }
+
+  const existingTestUsers = await listAllTestUsers(supabase);
+  let createdAuthCount = 0;
+  await mapLimit(plannedAccounts, 10, async (account) => {
+    const existing = existingTestUsers.get(account.email.toLowerCase());
+    if (existing) {
+      account.userId = existing.id;
+      return;
+    }
+    const { data, error } = await withRetry(() =>
+      supabase.auth.admin.createUser({
+        email: account.email,
+        password: TEST_PASSWORD,
+        email_confirm: true,
+        user_metadata: { role: account.role },
+      }),
+    );
+    if (error) throw new Error(`createUser(${account.email}) failed: ${error.message}`);
+    account.userId = data.user.id;
+    createdAuthCount++;
+  });
+  console.log(`Auth accounts: ${createdAuthCount} created, ${plannedAccounts.length - createdAuthCount} already existed.`);
+
+  // ---- 2. Ensure "user" profile rows ----
+  const allIds = plannedAccounts.map((a) => a.userId);
+  const existingProfileIds = await selectExistingIds(supabase, 'user', 'user_id', allIds);
+  const missingProfiles = plannedAccounts.filter((a) => !existingProfileIds.has(a.userId));
+  if (missingProfiles.length > 0) {
+    const rows = missingProfiles.map((a) => ({
+      user_id: a.userId,
+      username: a.username,
+      biography: '',
+      role: a.role,
+      first_name: a.firstName,
+      last_name: a.lastName,
+    }));
+    for (const batch of chunk(rows, 500)) {
+      const { error } = await supabase.from('user').insert(batch);
+      if (error) throw new Error(`profile insert failed: ${error.message}`);
+    }
+  }
+  console.log(`Profiles: ${missingProfiles.length} created, ${existingProfileIds.size} already existed.`);
+
+  const byEmail = new Map(plannedAccounts.map((a) => [a.email, a]));
+
+  // ---- 3. Per course: course row, enrollments, then per quiz: catalog + questions, assembled
+  // quiz, activity data ----
+  for (const course of COURSES) {
+    console.log(`\n--- ${course.courseName} (${course.courseCode}) ---`);
+    const instructor = byEmail.get(course.instructor.email);
+
+    const courseRow = await ensureCourse(supabase, course, instructor.userId);
+
+    const students = [];
+    for (let i = 1; i <= STUDENTS_PER_COURSE; i++) {
+      students.push(byEmail.get(studentEmail(course.studentEmailPrefix, i)));
+    }
+    await ensureEnrollments(supabase, courseRow.course_id, students);
+
+    for (const quizConfig of course.quizzes) {
+      console.log(`  · ${quizConfig.name}`);
+      const activityType = slugifyQuizName(quizConfig.name);
+      const questionsByLevel = await ensureCatalogAndQuestions(supabase, quizConfig, activityType, instructor.userId);
+      await ensureAssembledQuiz(supabase, `${quizConfig.name} Quiz`, courseRow.course_id, activityType, instructor.userId);
+      await ensureActivityData(supabase, activityType, questionsByLevel, students);
+    }
+  }
+
+  // ---- 4. Print + save login credentials (AC: one instructor + one student per course) ----
+  const credentialLines = ['Requirements Coach — Load Test Credentials (GitHub #275)', `Generated: ${new Date().toISOString()}`, ''];
+  for (const course of COURSES) {
+    const sampleStudentEmail = studentEmail(course.studentEmailPrefix, 1);
+    credentialLines.push(
+      `${course.courseName} (code ${course.courseCode})`,
+      `  Instructor — email: ${course.instructor.email}  password: ${TEST_PASSWORD}`,
+      `  Student    — email: ${sampleStudentEmail}  password: ${TEST_PASSWORD}`,
+      '',
+    );
+  }
+  credentialLines.push(
+    `All ${plannedAccounts.length} test accounts share the password above.`,
+    `Student email pattern: <prefix><001-${String(STUDENTS_PER_COURSE).padStart(3, '0')}>@test.local, e.g. ${studentEmail(COURSES[0].studentEmailPrefix, 1)}.`,
+    'Remove everything with: node scripts/cleanup-load-test.js --confirm',
+  );
+  const credentialsText = credentialLines.join('\n') + '\n';
+  fs.writeFileSync(path.join(__dirname, '..', 'test-credentials.txt'), credentialsText);
+  console.log('\n' + credentialsText);
+
+  const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+  console.log(`Done in ${elapsed}s. Credentials written to test-credentials.txt.`);
+}
+
+main().catch((err) => {
+  console.error('\nSeed script failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
Fix instructor course detail timeout at class scale: GET /api/instructor/courses/{id} reliably timed out (~12.5s, then HTTP 500) once a course reached ~150 students / ~600 sessions, because loadProgressForSessions ran four unchunked .in('session_id', ...) queries. Routed through the existing fetchAllRowsByIds/chunked helpers instead — now a reliable ~3s.
Add load-test seed/cleanup scripts (scripts/seed-load-test.js, cleanup-load-test.js, loadTestConfig.js) for GitHub #275: provisions 3 instructors, 3 courses, 450 students, and 3 quizzes per course (each with its own catalog), then splits every (student, quiz) pair into 4 deterministic result groups (~25% each: fully correct / partially correct / fully incorrect / not started) for realistic, non-uniform dashboard and leaderboard data. Idempotent, bulk-inserted, @test.local-tagged for easy cleanup; prints login credentials per course.
Paginate the course leaderboard: CourseLeaderboard used to render every enrolled student in one unbroken list. Now pages 5 rows at a time via the shared Pagination component, pinning the viewer's own rank below when it's off-page — same pattern the global leaderboard already uses.