### PR TITLE
Remove redundant "Question Catalogs" section from course detail page &&  Remove non-functional settings icon from student sidebar:

### DIFF
--- a/components/AppShell.tsx
+++ b/components/AppShell.tsx
@@ -403,9 +403,10 @@ export function AppShell({
         </nav>
 
         <div className="flex gap-2">
-          {/* GitHub #150: role-dependent behavior — instructors open the LLM provider settings
-              modal; students have no settings surface yet, so this stays inert exactly as it
-              already was, rather than opening something that doesn't exist. */}
+          {/* GitHub #150/#500 follow-up: instructors open the LLM provider settings modal here.
+              Students have no settings surface (nothing for this gear to do), so nothing renders
+              for them at all — this used to render an inert, unclickable placeholder span with the
+              same gear icon, which looked like a dead button rather than simply not being one. */}
           {isInstructor ? (
             <button
               type="button"
@@ -420,14 +421,7 @@ export function AppShell({
             >
               <GearIcon />
             </button>
-          ) : (
-            <span
-              className="flex h-11 w-11 cursor-default items-center justify-center rounded-[9px] border border-[#332b6b] bg-[#241f52] text-[#A79FC9]"
-              title="Settings"
-            >
-              <GearIcon />
-            </span>
-          )}
+          ) : null}
           {/* GitHub #318: always-visible alternative to the Profile page's "Show tour again" —
               same startTour() from OnboardingTourProvider, so there is exactly one restart path,
               just two ways to reach it. Visible for both roles, unlike the gear button above,

--- a/components/CourseQuizzesList.tsx
+++ b/components/CourseQuizzesList.tsx
@@ -9,6 +9,14 @@ import type { AssembledQuizSummary } from '../lib/assembledQuizClient';
  * point is now the "+" button next to the Quizzes heading, which opens the Create Quiz popup
  * (components/CreateQuizModal.tsx) pre-scoped to this course, regardless of whether any catalog
  * is linked yet — the modal itself says "No catalogs of this type exist yet." when none are.
+ *
+ * GitHub #500: this used to also render a standalone "Question Catalogs" list above the Quizzes
+ * section (every distinct catalog across quizzes.flatMap((q) => q.catalogs), deduped by
+ * activityType) — removed as redundant: a catalog a quiz draws from is already named right on
+ * that quiz's own card via quiz.catalogNames below, and catalog management belongs on the
+ * Question Catalogs page (the sidebar nav item), not duplicated here. No separate fetch backed
+ * that list — it was derived from the same `quizzes` prop this component already gets via
+ * loadCourseQuizzes — so removing it drops no API call, just the derived list and its markup.
  */
 export function CourseQuizzesList({
   quizzes,
@@ -17,35 +25,8 @@ export function CourseQuizzesList({
   quizzes: AssembledQuizSummary[];
   onAddQuiz: () => void;
 }) {
-  const uniqueCatalogs = [
-    ...new Map(
-      quizzes.flatMap((q) => q.catalogs).map((c) => [c.activityType, c]),
-    ).values(),
-  ];
-
-  const hasCatalogs = uniqueCatalogs.length > 0;
-
   return (
     <>
-      {hasCatalogs ? (
-        <div className="mb-8">
-          <p className="mb-3 text-xs font-extrabold uppercase tracking-wide text-gray-400">
-            Question Catalogs ({uniqueCatalogs.length})
-          </p>
-          <div className="flex flex-col gap-2.5">
-            {uniqueCatalogs.map((catalog) => (
-              <Link
-                key={catalog.activityType}
-                href={`/instructor/quizzes/${encodeURIComponent(catalog.activityType)}`}
-                className="block rounded-brand-lg border border-gray-100 bg-gray-50 p-4 transition hover:border-brand-purple/40"
-              >
-                <span className="font-extrabold text-brand-navy">{catalog.name}</span>
-              </Link>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
       <div className="mb-3 flex items-center justify-between gap-2">
         <p className="text-xs font-extrabold uppercase tracking-wide text-gray-400">
           Quizzes {quizzes.length > 0 ? `(${quizzes.length})` : ''}


### PR DESCRIPTION
Remove redundant "Question Catalogs" section from course detail page (#500): CourseQuizzesList used to render a standalone list of every catalog used by the course's quizzes, derived from the already-fetched quiz data (no separate API call existed). Removed it — each catalog is still visible on its quiz's own card ("1 catalog — ...").
Remove non-functional settings icon from student sidebar: AppShell's sidebar footer rendered an inert, unclickable gear icon for student accounts (visually present but dead — students have no settings surface). Removed it for students only; the instructor's gear button (opens LLM Provider Settings) is unchanged.