### PR TITLE
Include Daily Challenge points in the global leaderboard

### DIFF
--- a/__tests__/lib/leaderboardQueries.test.ts
+++ b/__tests__/lib/leaderboardQueries.test.ts
@@ -339,6 +339,19 @@ describe('computeCourseLeaderboard', () => {
 
     expect(result).toEqual({ data: null, error: { message: 'db down' } });
   });
+
+  // AC: Daily Challenge isn't scoped to any course, so a course leaderboard must not add it to a
+  // student's course-specific total, unlike computeGlobalLeaderboard below.
+  it('never queries daily_challenge_attempt at all', async () => {
+    queue('student_course', { data: [rosterRow('stu-1', 'ada')], error: null });
+    queue('assembled_quiz_catalog', { data: [catalogLinkRow('IDENTIFY_WEAK_USER_STORIES')], error: null });
+    queue('session_log', { data: [sessionRow('stu-1', 'IDENTIFY_WEAK_USER_STORIES', 1, 100)], error: null });
+
+    const result = await computeCourseLeaderboard(makeSupabase(), COURSE_ID);
+
+    expect(state.tables).not.toContain('daily_challenge_attempt');
+    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, points: 100, streak: 0, title: null }]);
+  });
 });
 
 function globalUserRow(userId: string, username: string, avatarUrl: string | null = null, selectedTitle: string | null = null) {
@@ -426,6 +439,76 @@ describe('computeGlobalLeaderboard', () => {
   it('returns the error and no data when the session query fails', async () => {
     queue('user', { data: [globalUserRow('stu-1', 'ada')], error: null });
     queue('session_log', { data: null, error: { message: 'db down' } });
+
+    const result = await computeGlobalLeaderboard(makeSupabase());
+
+    expect(result).toEqual({ data: null, error: { message: 'db down' } });
+  });
+
+  // AC: the bug this suite covers — "All" must agree with computeStudentScore (the sidebar pill)
+  // about a student's total, which already includes every daily_challenge_attempt.score.
+  it("adds a student's daily challenge points on top of their session points", async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada')], error: null });
+    queue('session_log', { data: [sessionRow('stu-1', 'SOME_CATALOG', 1, 50)], error: null });
+    queue('daily_challenge_attempt', { data: [{ user_id: 'stu-1', score: 20 }], error: null });
+
+    const result = await computeGlobalLeaderboard(makeSupabase());
+
+    expect(result.data).toEqual([{ rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, title: null, points: 70, streak: 0 }]);
+  });
+
+  // AC: like computeStudentScore, every submitted attempt counts (uq_daily_challenge_attempt_user_date
+  // caps the table at one per day, so there's no key to dedupe on) and a null score (unsubmitted or
+  // expired) contributes 0.
+  it("sums every one of a student's daily challenge attempts flat, treating a null score as 0", async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada')], error: null });
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', {
+      data: [
+        { user_id: 'stu-1', score: 10 },
+        { user_id: 'stu-1', score: 6 },
+        { user_id: 'stu-1', score: null },
+      ],
+      error: null,
+    });
+
+    const result = await computeGlobalLeaderboard(makeSupabase());
+
+    expect(result.data?.[0].points).toBe(16);
+  });
+
+  // AC: a student who's only done the daily challenge, never a session, still shows up scored.
+  it('gives a student with only daily challenge attempts their points, with no session history', async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada'), globalUserRow('stu-2', 'bea')], error: null });
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [{ user_id: 'stu-1', score: 12 }], error: null });
+
+    const result = await computeGlobalLeaderboard(makeSupabase());
+
+    expect(result.data).toEqual([
+      { rank: 1, studentId: 'stu-1', username: 'ada', avatarUrl: null, title: null, points: 12, streak: 0 },
+      { rank: 2, studentId: 'stu-2', username: 'bea', avatarUrl: null, title: null, points: 0, streak: 0 },
+    ]);
+  });
+
+  it('scopes the daily_challenge_attempt query to the roster', async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada'), globalUserRow('stu-2', 'bea')], error: null });
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [], error: null });
+
+    await computeGlobalLeaderboard(makeSupabase());
+
+    expect(state.filters).toContainEqual({
+      table: 'daily_challenge_attempt',
+      column: 'user_id',
+      value: ['stu-1', 'stu-2'],
+    });
+  });
+
+  it('returns the error and no data when the daily_challenge_attempt query fails', async () => {
+    queue('user', { data: [globalUserRow('stu-1', 'ada')], error: null });
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: null, error: { message: 'db down' } });
 
     const result = await computeGlobalLeaderboard(makeSupabase());
 

--- a/lib/leaderboardQueries.ts
+++ b/lib/leaderboardQueries.ts
@@ -51,16 +51,18 @@ type CombinedSessionRow = SessionRow & StreakSessionRow & { user_id: string; pas
 /**
  * Shared tail of both computeCourseLeaderboard and computeGlobalLeaderboard below: given a roster
  * and every completed session for it, reduce each student's points (via pointsFilter, the one
- * thing that differs between the two callers) and streak (always the student's full, unfiltered
- * session set — see computeCourseLeaderboard's own comment on why streak never gets course-
- * scoped), then apply the one ranking rule both leaderboards share: standard competition ranking
- * on points (ties share a rank, the next rank skips: 1, 2, 2, 4), username ascending as the
- * deterministic tiebreaker.
+ * thing that differs between the two callers, plus extraPointsByStudent — points that don't come
+ * from session_log at all, see computeGlobalLeaderboard's Daily Challenge note) and streak (always
+ * the student's full, unfiltered session set — see computeCourseLeaderboard's own comment on why
+ * streak never gets course-scoped), then apply the one ranking rule both leaderboards share:
+ * standard competition ranking on points (ties share a rank, the next rank skips: 1, 2, 2, 4),
+ * username ascending as the deterministic tiebreaker.
  */
 function rankRoster(
   roster: RosterRow[],
   sessionsByStudent: Map<string, CombinedSessionRow[]>,
   pointsFilter: (sessions: CombinedSessionRow[]) => CombinedSessionRow[],
+  extraPointsByStudent: Map<string, number> = new Map(),
 ): LeaderboardRow[] {
   const unranked = roster
     .map((row) => {
@@ -70,7 +72,7 @@ function rankRoster(
         username: row.student.username,
         avatarUrl: row.student.avatar_url,
         title: row.student.selected_title?.title_name ?? null,
-        points: sumBestScores(pointsFilter(sessions)),
+        points: sumBestScores(pointsFilter(sessions)) + (extraPointsByStudent.get(row.user_id) ?? 0),
         streak: computeStreakFromSessions(sessions.filter((session) => session.passed)),
       };
     })
@@ -212,6 +214,14 @@ type GlobalUserRow = {
  * Same roster-then-sessions shape as computeCourseLeaderboard, and the same rankRoster tail — the
  * two can't disagree about what "rank" or "tie" means, only about which points count and who's
  * ranked at all.
+ *
+ * Unlike computeCourseLeaderboard, this also folds in every daily_challenge_attempt.score for the
+ * roster (summed flat, same reasoning as computeStudentScore in lib/scoreQueries.ts — no
+ * (activity_type, difficulty_level) key to dedupe on, and a null score contributes 0) via
+ * rankRoster's extraPointsByStudent param, so "All" agrees with the sidebar score pill about a
+ * student's total. The course leaderboard deliberately does not: Daily Challenge isn't scoped to
+ * any course, so folding it into a course-specific ranking would attribute points to a course the
+ * student didn't earn them in.
  */
 export async function computeGlobalLeaderboard(
   supabase: SupabaseClient,
@@ -252,7 +262,20 @@ export async function computeGlobalLeaderboard(
     sessionsByStudent.set(row.user_id, list);
   }
 
-  const data = rankRoster(roster, sessionsByStudent, (sessions) => sessions);
+  const { data: dailyChallengeData, error: dailyChallengeError } = await supabase
+    .from('daily_challenge_attempt')
+    .select('user_id, score')
+    .in('user_id', studentIds);
+
+  if (dailyChallengeError) return { data: null, error: dailyChallengeError };
+
+  const dailyChallengePointsByStudent = new Map<string, number>();
+  for (const row of (dailyChallengeData ?? []) as { user_id: string; score: number | null }[]) {
+    const current = dailyChallengePointsByStudent.get(row.user_id) ?? 0;
+    dailyChallengePointsByStudent.set(row.user_id, current + (row.score ?? 0));
+  }
+
+  const data = rankRoster(roster, sessionsByStudent, (sessions) => sessions, dailyChallengePointsByStudent);
 
   return { data, error: null };
 }


### PR DESCRIPTION
## Summary
- Fix the "All"-scope leaderboard so it includes Daily Challenge points, matching the sidebar score total
- Course-scoped leaderboards are unaffected: they continue to show only points earned in that specific course

## Problem
`computeGlobalLeaderboard` ranked students using only `session_log` points via `sumBestScores`, but `computeStudentScore` (which powers the sidebar score pill) also adds every `daily_challenge_attempt.score`. A student's rank on the global "All" leaderboard could therefore disagree with their own displayed total.

## Fix
- `rankRoster` (shared by both leaderboard functions) now accepts an optional `extraPointsByStudent` map that's added on top of session-derived points.
- `computeGlobalLeaderboard` fetches `daily_challenge_attempt` rows for the roster, sums each student's scores flat (mirroring `computeStudentScore`'s handling of `null` scores as 0), and passes that into `rankRoster`.
- `computeCourseLeaderboard` is untouched — no extra-points map is passed, so course leaderboards keep reflecting only points earned within that course's own activity types.

resolve #507 