### PR TITLE
Adds a countdown timer to the Daily Challenge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,17 @@ npm run build      # production build
 npm test           # run all tests (vitest)
 npx vitest run __tests__/api/sessions.test.ts              # run a single test file
 npx vitest run __tests__/api/sessions.test.ts -t "resume"  # run tests matching a name
+npm run seed:load-test              # seed 3 courses / 450 students of realistic activity data (GitHub #275/REQ-PL-3.4.4)
+npm run cleanup:load-test -- --confirm  # undo it (dry-run without --confirm)
 ```
 
 There is no lint or typecheck script; `npm run build` is the type check.
 
+`scripts/seed-load-test.js`/`cleanup-load-test.js` are idempotent and identify their own rows by deterministic anchors (an `@test.local` email suffix, fixed course codes, derived catalog `activity_type` keys) rather than a stored "is test data" flag — see each script's header comment before changing either.
+
 ## Environment setup
 
-Copy `.env.example` to `.env.local` and fill in your Supabase credentials. Then, in the Supabase SQL editor, run `supabase/schema.sql` followed by `supabase/seed.sql` (the question bank — without it every session start returns 400), and create two **public** Storage buckets: `avatars` for profile images, and `course-covers` (GitHub #363 follow-up) for instructor-uploaded course cover images. (README.md's mention of a `myapp_profile` table is stale — the profile table is `"user"`.)
+Copy `.env.example` to `.env.local` and fill in your Supabase credentials. Then, in the Supabase SQL editor, run `supabase/schema.sql` followed by `supabase/seed.sql` (the question bank — without it every session start returns 400), and create two **public** Storage buckets: `avatars` for profile images (Allowed MIME types `image/png, image/jpeg, image/webp`, file size limit 2 MB — the upload route enforces the same rules, but the bucket is public, so the bucket-level limit is a second line of defence), and `course-covers` (GitHub #363 follow-up) for instructor-uploaded course cover images. (README.md's mention of a `myapp_profile` table is stale — the profile table is `"user"`.)
 
 `INSTRUCTOR_SIGNUP_CODE` (the invite code that grants the instructor role at registration, see "Auth flow" below) must be set to a real, random, per-deployment value — generate one yourself (e.g. `openssl rand -base64 24`) and set it only in each deployment's own environment (`.env.local` locally, Vercel Environment Variables in production, etc.). It must never be committed to the repo, in `.env.example` or anywhere else.
 

--- a/__tests__/lib/dailyChallengeRules.test.ts
+++ b/__tests__/lib/dailyChallengeRules.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { nextChallengeAt } from '../../lib/dailyChallengeRules';
+
+describe('nextChallengeAt', () => {
+  it('returns the start of the UTC calendar day after challengeDate', () => {
+    expect(nextChallengeAt('2026-08-14').toISOString()).toBe('2026-08-15T00:00:00.000Z');
+  });
+
+  it('rolls over the month/year boundary correctly', () => {
+    expect(nextChallengeAt('2026-12-31').toISOString()).toBe('2027-01-01T00:00:00.000Z');
+  });
+});

--- a/__tests__/lib/dailyChallengeStatus.test.ts
+++ b/__tests__/lib/dailyChallengeStatus.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { dailyChallengeCardStatusLabel, deriveDailyChallengeCardStatus } from '../../lib/dailyChallengeStatus';
+import { dailyChallengeCardStatusLabel, deriveDailyChallengeCardStatus, formatCountdown } from '../../lib/dailyChallengeStatus';
 
 describe('deriveDailyChallengeCardStatus', () => {
   it('reports loading before the first fetch resolves', () => {
@@ -41,6 +41,7 @@ describe('deriveDailyChallengeCardStatus', () => {
     expect(deriveDailyChallengeCardStatus({ attempt, question: null, expired: true })).toEqual({
       kind: 'done',
       result: null,
+      nextAvailableAt: '2026-08-15T00:00:00.000Z',
     });
   });
 
@@ -54,7 +55,12 @@ describe('deriveDailyChallengeCardStatus', () => {
         score: 50,
         expired: false,
       }),
-    ).toEqual({ kind: 'done', result: { correct: true, score: 50 } });
+    ).toEqual({ kind: 'done', result: { correct: true, score: 50 }, nextAvailableAt: '2026-08-15T00:00:00.000Z' });
+  });
+
+  it('computes the next-attempt instant as the UTC midnight after the attempt\'s challenge_date', () => {
+    const status = deriveDailyChallengeCardStatus({ attempt, question: null, expired: true });
+    expect(status).toMatchObject({ nextAvailableAt: '2026-08-15T00:00:00.000Z' });
   });
 });
 
@@ -64,16 +70,37 @@ describe('dailyChallengeCardStatusLabel', () => {
   });
 
   it('shows the score for a completed attempt', () => {
-    expect(dailyChallengeCardStatusLabel({ kind: 'done', result: { correct: true, score: 50 } })).toBe(
-      'You scored 50 pts today — come back tomorrow.',
-    );
+    expect(
+      dailyChallengeCardStatusLabel({
+        kind: 'done',
+        result: { correct: true, score: 50 },
+        nextAvailableAt: '2026-08-15T00:00:00.000Z',
+      }),
+    ).toBe('You scored 50 pts today — come back tomorrow.');
   });
 
   it('shows a distinct message for an expired, unfinished attempt', () => {
-    expect(dailyChallengeCardStatusLabel({ kind: 'done', result: null })).toBe('Time ran out today — come back tomorrow.');
+    expect(
+      dailyChallengeCardStatusLabel({ kind: 'done', result: null, nextAvailableAt: '2026-08-15T00:00:00.000Z' }),
+    ).toBe('Time ran out today — come back tomorrow.');
   });
 
   it('invites joining a course when unavailable', () => {
     expect(dailyChallengeCardStatusLabel({ kind: 'unavailable' })).toMatch(/join a course/i);
+  });
+});
+
+describe('formatCountdown', () => {
+  it('formats sub-hour durations as minutes and seconds', () => {
+    expect(formatCountdown(65_000)).toBe('1m 05s');
+  });
+
+  it('includes hours once the duration is an hour or more', () => {
+    expect(formatCountdown(3_661_000)).toBe('1h 01m 01s');
+  });
+
+  it('clamps a negative or zero duration to 0', () => {
+    expect(formatCountdown(-1000)).toBe('0m 00s');
+    expect(formatCountdown(0)).toBe('0m 00s');
   });
 });

--- a/app/daily-challenge/page.tsx
+++ b/app/daily-challenge/page.tsx
@@ -8,9 +8,12 @@ import { FeedbackCard } from '../../components/FeedbackCard';
 import { QuestionCard } from '../../components/QuestionCard';
 import { useUser } from '../../components/UserProvider';
 import { loadDailyChallenge, startDailyChallenge, submitDailyChallengeAnswer } from '../../lib/dailyChallengeClient';
+import { nextChallengeAt } from '../../lib/dailyChallengeRules';
+import { formatCountdown } from '../../lib/dailyChallengeStatus';
 import type { DailyChallengeState } from '../../lib/dailyChallengeTypes';
 import { toInstant } from '../../lib/dateTime';
 import { clearCachedLeaderboard } from '../../lib/leaderboardStore';
+import { useCountdown } from '../../lib/useCountdown';
 import { useRequireRole } from '../../lib/useRequireRole';
 
 function formatRemaining(ms: number): string {
@@ -111,6 +114,13 @@ export default function DailyChallengePage() {
       clearInterval(interval);
     };
   }, [state?.attempt, state?.expired, refresh]);
+
+  // Once today's attempt is submitted or expired, show a live countdown to the next UTC calendar
+  // day (nextChallengeAt) rather than a static "come back tomorrow" — re-fetches on hitting zero,
+  // the same "server's version wins" reasoning the deadline countdown above already follows.
+  const isDone = !!state?.attempt && (!!state.attempt.submitted_at || !!state.expired);
+  const nextAvailableAt = isDone && state?.attempt ? nextChallengeAt(state.attempt.challenge_date).toISOString() : null;
+  const nextAttemptMs = useCountdown(nextAvailableAt, refresh);
 
   if (loading || !authorized) return null;
 
@@ -251,6 +261,11 @@ export default function DailyChallengePage() {
             <p className="mt-5 text-center text-sm font-semibold text-gray-500">
               That’s today’s Daily Challenge — come back tomorrow for another one.
             </p>
+            {nextAttemptMs !== null ? (
+              <p className="mt-1 text-center text-sm font-extrabold text-gray-700">
+                Next attempt in {formatCountdown(nextAttemptMs)}
+              </p>
+            ) : null}
           </>
         ) : state.expired ? (
           <div className="rounded-2xl border border-[#332b6b] bg-[#1b1642] p-6 text-[#F3F1FF]">
@@ -258,6 +273,11 @@ export default function DailyChallengePage() {
             <p className="mb-4 text-sm font-semibold text-[#A79FC9]">
               Today’s attempt has closed. Come back tomorrow for a new question.
             </p>
+            {nextAttemptMs !== null ? (
+              <p className="mb-4 text-sm font-extrabold text-white">
+                Next attempt in {formatCountdown(nextAttemptMs)}
+              </p>
+            ) : null}
             <Link
               href="/dashboard"
               className="inline-block rounded-[10px] bg-[#7C4DFF] px-5 py-2.5 text-sm font-extrabold text-white hover:bg-[#6234d1]"

--- a/components/DailyChallengeCard.tsx
+++ b/components/DailyChallengeCard.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { dailyChallengeCardStatusLabel, deriveDailyChallengeCardStatus } from '../lib/dailyChallengeStatus';
+import { dailyChallengeCardStatusLabel, deriveDailyChallengeCardStatus, formatCountdown } from '../lib/dailyChallengeStatus';
 import type { DailyChallengeState } from '../lib/dailyChallengeTypes';
+import { useCountdown } from '../lib/useCountdown';
 
 /**
  * The dashboard's Daily Challenge entry point (GitHub #336) — same dark-card visual language as
@@ -13,6 +14,7 @@ export function DailyChallengeCard({ state }: { state: DailyChallengeState | nul
   const status = deriveDailyChallengeCardStatus(state);
   const label = dailyChallengeCardStatusLabel(status);
   const canPlay = status.kind === 'available' || status.kind === 'in-progress';
+  const remainingMs = useCountdown(status.kind === 'done' ? status.nextAvailableAt : null);
 
   return (
     <div className="mb-7 flex flex-col gap-5 rounded-2xl bg-[#1b1642] p-6 text-[#F3F1FF] sm:flex-row sm:items-center">
@@ -27,6 +29,11 @@ export function DailyChallengeCard({ state }: { state: DailyChallengeState | nul
         <p className={`mb-4 text-sm font-semibold text-[#A79FC9] ${status.kind === 'loading' ? 'opacity-60' : ''}`}>
           {label}
         </p>
+        {status.kind === 'done' && remainingMs !== null && remainingMs > 0 ? (
+          <p className="mb-4 text-xs font-bold uppercase tracking-wide text-[#A79FC9]">
+            Next attempt in <span className="text-white">{formatCountdown(remainingMs)}</span>
+          </p>
+        ) : null}
         {canPlay ? (
           <Link
             href="/daily-challenge"

--- a/lib/dailyChallengeRules.ts
+++ b/lib/dailyChallengeRules.ts
@@ -26,3 +26,15 @@ export function scoreForDailyChallenge(isCorrect: boolean, questionMaxScore: num
 export function isExpired(deadlineAt: string, now: Date = new Date()): boolean {
   return now.getTime() > new Date(toInstant(deadlineAt)).getTime();
 }
+
+/**
+ * The instant a fresh Daily Challenge becomes drawable again — the start of the UTC calendar day
+ * after `challengeDate` (today's attempt's own date, in the "YYYY-MM-DD" shape todayUtc()
+ * produces). uq_daily_challenge_attempt_user_date caps a student at one attempt per UTC day, so
+ * this is always the exact instant, not an estimate.
+ */
+export function nextChallengeAt(challengeDate: string): Date {
+  const next = new Date(`${challengeDate}T00:00:00Z`);
+  next.setUTCDate(next.getUTCDate() + 1);
+  return next;
+}

--- a/lib/dailyChallengeStatus.ts
+++ b/lib/dailyChallengeStatus.ts
@@ -7,6 +7,7 @@
 // "come back tomorrow." The finer distinction (was there a score to show) only matters on the
 // attempt page itself, where the two need visibly different screens.
 
+import { nextChallengeAt } from './dailyChallengeRules';
 import type { DailyChallengeState } from './dailyChallengeTypes';
 
 export type DailyChallengeCardStatus =
@@ -14,7 +15,7 @@ export type DailyChallengeCardStatus =
   | { kind: 'unavailable' }
   | { kind: 'available' }
   | { kind: 'in-progress' }
-  | { kind: 'done'; result: { correct: boolean; score: number } | null };
+  | { kind: 'done'; result: { correct: boolean; score: number } | null; nextAvailableAt: string };
 
 /** Which of the five states the card is in, from the raw GET /api/daily-challenge response. */
 export function deriveDailyChallengeCardStatus(state: DailyChallengeState | null): DailyChallengeCardStatus {
@@ -24,15 +25,28 @@ export function deriveDailyChallengeCardStatus(state: DailyChallengeState | null
     return state.available ? { kind: 'available' } : { kind: 'unavailable' };
   }
 
+  const nextAvailableAt = nextChallengeAt(state.attempt.challenge_date).toISOString();
+
   if (state.attempt.submitted_at) {
-    return { kind: 'done', result: { correct: state.correct ?? false, score: state.score ?? 0 } };
+    return { kind: 'done', result: { correct: state.correct ?? false, score: state.score ?? 0 }, nextAvailableAt };
   }
 
   if (state.expired) {
-    return { kind: 'done', result: null };
+    return { kind: 'done', result: null, nextAvailableAt };
   }
 
   return { kind: 'in-progress' };
+}
+
+/** "23h 59m 59s"-style countdown for the next-attempt timer — hours only appear once there are any. */
+export function formatCountdown(ms: number): string {
+  const totalSeconds = Math.max(0, Math.ceil(ms / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) return `${hours}h ${minutes.toString().padStart(2, '0')}m ${seconds.toString().padStart(2, '0')}s`;
+  return `${minutes}m ${seconds.toString().padStart(2, '0')}s`;
 }
 
 /** The card's status line. One place, so the wording can't drift between the five states. */

--- a/lib/useCountdown.ts
+++ b/lib/useCountdown.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Milliseconds remaining until `targetIso`, ticking every second — the same live-countdown shape
+ * app/daily-challenge/page.tsx already hand-rolls for its own 60-second answer timer, pulled out
+ * so the Daily Challenge's "next attempt" timer (dashboard card and attempt page alike) doesn't
+ * duplicate the interval bookkeeping. Returns null while there is no target to count down to.
+ *
+ * `onReachZero`, when given, fires once when the countdown first hits 0 — for a caller (the
+ * attempt page) that wants to re-fetch from the server at that point rather than trust the local
+ * clock, the same "server's version wins" reasoning the page's own deadline countdown already
+ * follows. Intentionally not called on every render once at zero, only on the transition.
+ */
+export function useCountdown(targetIso: string | null | undefined, onReachZero?: () => void): number | null {
+  const [remainingMs, setRemainingMs] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!targetIso) {
+      setRemainingMs(null);
+      return;
+    }
+
+    const target = new Date(targetIso).getTime();
+    let reachedZero = false;
+
+    function tick() {
+      const remaining = Math.max(0, target - Date.now());
+      setRemainingMs(remaining);
+      if (remaining <= 0 && !reachedZero) {
+        reachedZero = true;
+        onReachZero?.();
+      }
+    }
+
+    tick();
+    const interval = setInterval(tick, 1000);
+    return () => clearInterval(interval);
+    // Deliberately keyed on targetIso alone — onReachZero isn't a dep, so a caller passing a new
+    // function identity each render doesn't restart the interval.
+  }, [targetIso]);
+
+  return remainingMs;
+}


### PR DESCRIPTION
## Summary

Adds a countdown timer to the Daily Challenge so students can see exactly when their next attempt becomes available, instead of a static "come back tomorrow" message.

- Shows a live "Next attempt in Hh MMm SSs" countdown once today's attempt is submitted **or** its time limit expires — on both the dashboard's Daily Challenge card and the `/daily-challenge` attempt page.
- The countdown targets the exact UTC instant a new challenge becomes drawable (start of the next UTC calendar day), matching the one-attempt-per-day database constraint (`uq_daily_challenge_attempt_user_date`).
- On the attempt page, the countdown auto-refreshes from the server when it hits zero, so the page flips to "available" without a manual reload — the same pattern already used for the in-attempt answer timer.

## Changes

- `lib/dailyChallengeRules.ts` — new `nextChallengeAt(challengeDate)` helper.
- `lib/dailyChallengeStatus.ts` — `'done'` status now carries `nextAvailableAt`; new shared `formatCountdown()` formatter.
- `lib/useCountdown.ts` (new) — reusable ticking-countdown hook with an optional `onReachZero` callback, shared by the card and the attempt page.
- `components/DailyChallengeCard.tsx` — renders the countdown under the status line.
- `app/daily-challenge/page.tsx` — renders the countdown on the submitted/expired screens and re-fetches state at zero.
- `CLAUDE.md` — minor doc fixes (unrelated housekeeping): documents the `seed:load-test`/`cleanup:load-test` npm scripts and the avatars bucket's MIME-type/size-limit constraints.


<img width="737" height="200" alt="Bildschirmfoto 2026-08-19 um 11 53 33" src="https://github.com/user-attachments/assets/87336a21-e237-4f54-afa7-434abfc183e6" />

resolve #510