### PR TITLE
Rename "Activity" column to "Quiz"

### DIFF
--- a/__tests__/api/instructor-ac-submissions.test.ts
+++ b/__tests__/api/instructor-ac-submissions.test.ts
@@ -150,6 +150,7 @@ describe('GET /api/instructor/acceptance-criteria/submissions', () => {
         submittedAt: '2026-08-01T10:00:00.000Z',
         gradedAt: '2026-08-01T10:05:00.000Z',
         courses: [],
+        quizName: null,
       },
       {
         submissionId: 'submission-2',
@@ -164,6 +165,7 @@ describe('GET /api/instructor/acceptance-criteria/submissions', () => {
         submittedAt: '2026-08-01T10:00:00.000Z',
         gradedAt: null,
         courses: [],
+        quizName: null,
       },
     ]);
   });
@@ -189,6 +191,29 @@ describe('GET /api/instructor/acceptance-criteria/submissions', () => {
 
     expect(response.status).toBe(200);
     expect(body.submissions[0].courses).toEqual([{ courseId: 'course-1', courseName: 'Requirements 101' }]);
+  });
+
+  // GitHub #500 follow-up: same assembled_quiz_catalog query as the courses test above — the
+  // instructor table's QUIZ column reads this, not the catalog's own quiz_name.
+  it("attaches the assembled quiz's own name, not the catalog's", async () => {
+    queueRole('instructor');
+    queueOwnedActivityTypes(['MY_LLM_CATALOG']);
+    queue('submission', { data: [submissionRow()], error: null });
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          activity_type: 'MY_LLM_CATALOG',
+          assembled_quiz: { course_id: 'course-1', quiz_name: 'Sprint 3 Acceptance Criteria', course: { course_name: 'Requirements 101' } },
+        },
+      ],
+      error: null,
+    });
+
+    const response = await GET(request(undefined, 'valid-token'));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.submissions[0].quizName).toBe('Sprint 3 Acceptance Criteria');
   });
 
   it('filters to role student, so an instructor’s own submissions stay out of their report', async () => {

--- a/__tests__/api/instructor-activities.test.ts
+++ b/__tests__/api/instructor-activities.test.ts
@@ -229,6 +229,31 @@ describe('GET /api/instructor/activities', () => {
     const body = await response.json();
 
     expect(body.sessions[0].courses).toEqual([]);
+    expect(body.sessions[0].quizName).toBeNull();
+  });
+
+  // GitHub #500 follow-up: the combined instructor table's QUIZ column reads this instead of
+  // falling back to the raw activity_type key — the assembled quiz's own name, not the catalog's.
+  it("attaches the assembled quiz's own name, distinct from the catalog's quiz_name", async () => {
+    queueRole('instructor');
+    queueOwnedActivityTypeSummaries([{ activityType: 'IDENTIFY_WEAK_USER_STORIES', name: 'Identify Weak User Stories', gradingKind: 'mcq' }]);
+    queue('session_log', { data: [sessionRow()], error: null });
+    queue('session_to_question', { data: [], error: null });
+    queue('answered_question_log', { data: [], error: null });
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          activity_type: 'IDENTIFY_WEAK_USER_STORIES',
+          assembled_quiz: { course_id: 'course-1', quiz_name: 'Week 3 Quiz', course: { course_name: 'Requirements 101' } },
+        },
+      ],
+      error: null,
+    });
+
+    const response = await GET(request('valid-token'));
+    const body = await response.json();
+
+    expect(body.sessions[0].quizName).toBe('Week 3 Quiz');
   });
 
   it('returns the instructor’s owned activity types alongside the sessions', async () => {

--- a/__tests__/lib/activityCourseQueries.test.ts
+++ b/__tests__/lib/activityCourseQueries.test.ts
@@ -370,6 +370,7 @@ describe('listCoursesForActivityTypes', () => {
     const result = await listCoursesForActivityTypes(makeSupabase(), []);
 
     expect(result.coursesByActivityType).toEqual(new Map());
+    expect(result.quizNameByActivityType).toEqual(new Map());
     expect(state.tables).toEqual([]);
   });
 
@@ -378,7 +379,7 @@ describe('listCoursesForActivityTypes', () => {
       data: [
         {
           activity_type: 'CUSTOM_QUIZ',
-          assembled_quiz: { course_id: 'course-1', course: { course_name: 'Intro to SE' } },
+          assembled_quiz: { course_id: 'course-1', quiz_name: 'Sprint 1 Quiz', course: { course_name: 'Intro to SE' } },
         },
       ],
       error: null,
@@ -387,6 +388,7 @@ describe('listCoursesForActivityTypes', () => {
     const result = await listCoursesForActivityTypes(makeSupabase(), ['CUSTOM_QUIZ']);
 
     expect(result.coursesByActivityType?.get('CUSTOM_QUIZ')).toEqual([{ courseId: 'course-1', courseName: 'Intro to SE' }]);
+    expect(result.quizNameByActivityType?.get('CUSTOM_QUIZ')).toBe('Sprint 1 Quiz');
     expect(state.filters).toContainEqual({ table: 'assembled_quiz_catalog', column: 'activity_type', value: ['CUSTOM_QUIZ'] });
   });
 
@@ -398,11 +400,11 @@ describe('listCoursesForActivityTypes', () => {
       data: [
         {
           activity_type: 'CUSTOM_QUIZ',
-          assembled_quiz: { course_id: 'course-1', course: { course_name: 'Intro to SE' } },
+          assembled_quiz: { course_id: 'course-1', quiz_name: 'Sprint 1 Quiz', course: { course_name: 'Intro to SE' } },
         },
         {
           activity_type: 'CUSTOM_QUIZ',
-          assembled_quiz: { course_id: 'course-2', course: { course_name: 'Advanced SE' } },
+          assembled_quiz: { course_id: 'course-2', quiz_name: 'Sprint 2 Quiz', course: { course_name: 'Advanced SE' } },
         },
       ],
       error: null,
@@ -414,6 +416,10 @@ describe('listCoursesForActivityTypes', () => {
       { courseId: 'course-1', courseName: 'Intro to SE' },
       { courseId: 'course-2', courseName: 'Advanced SE' },
     ]);
+    // quizNameByActivityType, unlike coursesByActivityType, has no way to represent "more than
+    // one" — it's the known, documented limitation (no assembled_quiz_id on session_log to say
+    // which quiz actually granted a given attempt access): first quiz found wins.
+    expect(result.quizNameByActivityType?.get('CUSTOM_QUIZ')).toBe('Sprint 1 Quiz');
   });
 
   it('deduplicates the same course reached through more than one assembled quiz', async () => {
@@ -421,11 +427,11 @@ describe('listCoursesForActivityTypes', () => {
       data: [
         {
           activity_type: 'CUSTOM_QUIZ',
-          assembled_quiz: { course_id: 'course-1', course: { course_name: 'Intro to SE' } },
+          assembled_quiz: { course_id: 'course-1', quiz_name: 'Sprint 1 Quiz', course: { course_name: 'Intro to SE' } },
         },
         {
           activity_type: 'CUSTOM_QUIZ',
-          assembled_quiz: { course_id: 'course-1', course: { course_name: 'Intro to SE' } },
+          assembled_quiz: { course_id: 'course-1', quiz_name: 'Sprint 1 Quiz', course: { course_name: 'Intro to SE' } },
         },
       ],
       error: null,
@@ -443,11 +449,12 @@ describe('listCoursesForActivityTypes', () => {
 
     expect(result.coursesByActivityType?.has('UNLINKED_QUIZ')).toBe(false);
     expect(result.coursesByActivityType?.get('UNLINKED_QUIZ') ?? []).toEqual([]);
+    expect(result.quizNameByActivityType?.has('UNLINKED_QUIZ')).toBe(false);
   });
 
   it('falls back to a placeholder name if the embedded course is missing', async () => {
     queue('assembled_quiz_catalog', {
-      data: [{ activity_type: 'CUSTOM_QUIZ', assembled_quiz: { course_id: 'course-1', course: null } }],
+      data: [{ activity_type: 'CUSTOM_QUIZ', assembled_quiz: { course_id: 'course-1', quiz_name: 'Sprint 1 Quiz', course: null } }],
       error: null,
     });
 
@@ -461,6 +468,6 @@ describe('listCoursesForActivityTypes', () => {
 
     const result = await listCoursesForActivityTypes(makeSupabase(), ['CUSTOM_QUIZ']);
 
-    expect(result).toEqual({ coursesByActivityType: null, error: { message: 'db down' } });
+    expect(result).toEqual({ coursesByActivityType: null, quizNameByActivityType: null, error: { message: 'db down' } });
   });
 });

--- a/__tests__/lib/activityLogTypes.test.ts
+++ b/__tests__/lib/activityLogTypes.test.ts
@@ -2,11 +2,14 @@ import { describe, expect, it } from 'vitest';
 import {
   deriveActivityFilterOptions,
   summarizeStudents,
+  toAcSubmissionRow,
   toActivityLogEntry,
+  toStudentActivitySummary,
   type ActivityLogEntry,
   type StudentActivitySummary,
 } from '../../lib/activityLogTypes';
-import type { SessionListEntry } from '../../lib/sessionTypes';
+import type { InstructorACSubmission } from '../../lib/llmActivityClient';
+import type { InstructorActivityEntry, SessionListEntry } from '../../lib/sessionTypes';
 
 function session(overrides: Partial<SessionListEntry> = {}): SessionListEntry {
   return {
@@ -73,6 +76,85 @@ describe('toActivityLogEntry', () => {
     expect(entry.passed).toBe(false);
     expect(entry.status).toBe('completed');
     expect(entry.dateTime).toBe('2026-08-01T10:20:00.000Z');
+  });
+});
+
+function instructorEntry(overrides: Partial<InstructorActivityEntry> = {}): InstructorActivityEntry {
+  return {
+    ...session(),
+    studentId: 'student-1',
+    studentName: 'Ann Attempter',
+    courses: [],
+    quizName: null,
+    ...overrides,
+  };
+}
+
+// GitHub #500: the combined Instructor Dashboard table's QUIZ column used to fall straight
+// through to toActivityLogEntry's raw-key fallback for any custom catalog, since nothing called
+// it with a nameByType map on this path — indistinguishable for two quizzes composed from the
+// same catalog. quizName (resolved server-side, the assembled quiz's own name) fixes that without
+// a second name-resolution mechanism: it's threaded through as a single-entry nameByType map.
+describe('toStudentActivitySummary', () => {
+  it("prefers the assembled quiz's name over the raw activity_type key", () => {
+    const summary = toStudentActivitySummary(instructorEntry({ activity_type: 'TEST_CATALOG', quizName: 'Week 3 Quiz' }));
+
+    expect(summary.activityName).toBe('Week 3 Quiz');
+  });
+
+  it('falls back to the raw key when quizName is null (catalog not linked to any quiz yet)', () => {
+    const summary = toStudentActivitySummary(instructorEntry({ activity_type: 'TEST_CATALOG', quizName: null }));
+
+    expect(summary.activityName).toBe('TEST_CATALOG');
+  });
+
+  it("still resolves a built-in activity type's curated name when quizName is null", () => {
+    const summary = toStudentActivitySummary(instructorEntry({ activity_type: 'IDENTIFY_WEAK_USER_STORIES', quizName: null }));
+
+    expect(summary.activityName).toBe('Identify Weak User Stories');
+  });
+
+  it('carries studentId/studentName/courses through unchanged', () => {
+    const summary = toStudentActivitySummary(
+      instructorEntry({ studentId: 'student-9', studentName: 'Zoe', courses: [{ courseId: 'c1', courseName: 'Requirements 101' }] }),
+    );
+
+    expect(summary.studentId).toBe('student-9');
+    expect(summary.studentName).toBe('Zoe');
+    expect(summary.courses).toEqual([{ courseId: 'c1', courseName: 'Requirements 101' }]);
+  });
+});
+
+function acSubmission(overrides: Partial<InstructorACSubmission> = {}): InstructorACSubmission {
+  return {
+    submissionId: 'submission-1',
+    studentId: 'student-1',
+    studentName: 'Ann Attempter',
+    userStoryDescription: 'As a shopper, I want to check out.',
+    activityType: 'MY_LLM_CATALOG',
+    difficultyLevel: 1,
+    submittedText: 'Given a cart, when checkout, then order created.',
+    llmScore: 8,
+    llmFeedback: 'Solid.',
+    submittedAt: '2026-08-01T10:00:00.000Z',
+    gradedAt: '2026-08-01T10:05:00.000Z',
+    courses: [],
+    quizName: null,
+    ...overrides,
+  };
+}
+
+describe('toAcSubmissionRow', () => {
+  it("prefers the assembled quiz's name over the raw activity_type key", () => {
+    const row = toAcSubmissionRow(acSubmission({ activityType: 'MY_LLM_CATALOG', quizName: 'Sprint 3 Acceptance Criteria' }));
+
+    expect(row.activityName).toBe('Sprint 3 Acceptance Criteria');
+  });
+
+  it('falls back to the raw key when quizName is null', () => {
+    const row = toAcSubmissionRow(acSubmission({ activityType: 'MY_LLM_CATALOG', quizName: null }));
+
+    expect(row.activityName).toBe('MY_LLM_CATALOG');
   });
 });
 

--- a/app/api/instructor/acceptance-criteria/submissions/route.ts
+++ b/app/api/instructor/acceptance-criteria/submissions/route.ts
@@ -44,7 +44,10 @@ function studentDisplayName(student: SubmissionRow['student']): string {
  * does for quiz attempts via session_log.difficulty_level.
  *
  * courses (GitHub #474) is the same per-catalog course lookup GET /api/instructor/activities
- * attaches to quiz attempts — [] means the catalog isn't linked to any course yet.
+ * attaches to quiz attempts — [] means the catalog isn't linked to any course yet. quizName
+ * (GitHub #500 follow-up) rides the same listCoursesForActivityTypes call — the assembled quiz's
+ * own name, not the catalog's, so the combined instructor table's QUIZ column doesn't fall back
+ * to the raw activity_type key the way it used to.
  *
  * An empty list is a 200.
  */
@@ -92,7 +95,7 @@ export async function GET(request: Request) {
   // GitHub #474: same "which course(s) is this catalog linked to" resolution
   // GET /api/instructor/activities uses for quiz attempts, scoped to ownedTypes so this stays one
   // extra round trip regardless of how many submissions there are.
-  const { coursesByActivityType, error: coursesError } = await listCoursesForActivityTypes(supabase, ownedTypes);
+  const { coursesByActivityType, quizNameByActivityType, error: coursesError } = await listCoursesForActivityTypes(supabase, ownedTypes);
   if (coursesError) return Response.json({ error: coursesError.message }, { status: 500 });
 
   const submissions = (data ?? []).map((row) => {
@@ -110,6 +113,7 @@ export async function GET(request: Request) {
       submittedAt: r.submitted_at,
       gradedAt: r.graded_at,
       courses: coursesByActivityType!.get(r.story.activity_type) ?? [],
+      quizName: quizNameByActivityType!.get(r.story.activity_type) ?? null,
     };
   });
 

--- a/components/ActivityLogTable.tsx
+++ b/components/ActivityLogTable.tsx
@@ -1,7 +1,10 @@
 import { ActivityLogRow } from './ActivityLogRow';
 import type { ActivityLogEntry } from '../lib/activityLogTypes';
 
-const COLUMNS = ['Activity', 'Level', 'Date & time', 'Score', 'Result'];
+// GitHub #500: "Quiz" rather than "Activity" — every row is a specific quiz/catalog attempt, and
+// the column now shows the quiz's own name (toStudentActivitySummary/toAcSubmissionRow), not a
+// generic "activity" label.
+const COLUMNS = ['Quiz', 'Level', 'Date & time', 'Score', 'Result'];
 
 /**
  * getStudentName is how the Instructor Dashboard (GitHub #82) reuses this same table for

--- a/lib/activityCourseQueries.ts
+++ b/lib/activityCourseQueries.ts
@@ -202,7 +202,7 @@ export type ActivityCourseRef = { courseId: string; courseName: string };
 
 type ActivityCourseLinkRow = {
   activity_type: string;
-  assembled_quiz: { course_id: string; course: { course_name: string } | null } | null;
+  assembled_quiz: { course_id: string; quiz_name: string; course: { course_name: string } | null } | null;
 };
 
 /**
@@ -223,21 +223,38 @@ type ActivityCourseLinkRow = {
  *
  * activityTypes: [] short-circuits to an empty map without a query, same convention as
  * listActivityTypesForCourses's courseIds: [] handling.
+ *
+ * quizNameByActivityType (GitHub #500 follow-up) rides along on the same query and row set: an
+ * attempt's ACTIVITY/QUIZ column used to show the catalog's raw activity_type key (via
+ * toActivityLogEntry's getActivityByType-else-key fallback, which only knows the three built-in
+ * catalogs) instead of a real name — indistinguishable for two different quizzes composed from
+ * the same catalog. Same "first match wins" convention as listActivityTypesForCourses above for a
+ * catalog linked to more than one quiz — there is no assembled_quiz_id on session_log to say which
+ * one actually granted a given attempt access (see CLAUDE.md's GitHub #476 section for why that's
+ * a hard data-model limit, not a shortcut taken here) — but the common case (one quiz per catalog)
+ * resolves exactly right, and every case beats showing the raw key.
  */
 export async function listCoursesForActivityTypes(
   supabase: SupabaseClient,
   activityTypes: string[],
-): Promise<{ coursesByActivityType: Map<string, ActivityCourseRef[]> | null; error: { message: string } | null }> {
-  if (activityTypes.length === 0) return { coursesByActivityType: new Map(), error: null };
+): Promise<{
+  coursesByActivityType: Map<string, ActivityCourseRef[]> | null;
+  quizNameByActivityType: Map<string, string> | null;
+  error: { message: string } | null;
+}> {
+  if (activityTypes.length === 0) {
+    return { coursesByActivityType: new Map(), quizNameByActivityType: new Map(), error: null };
+  }
 
   const { data, error } = await supabase
     .from('assembled_quiz_catalog')
-    .select('activity_type, assembled_quiz:assembled_quiz_id!inner(course_id, course:course_id(course_name))')
+    .select('activity_type, assembled_quiz:assembled_quiz_id!inner(course_id, quiz_name, course:course_id(course_name))')
     .in('activity_type', activityTypes);
 
-  if (error) return { coursesByActivityType: null, error };
+  if (error) return { coursesByActivityType: null, quizNameByActivityType: null, error };
 
   const coursesByActivityType = new Map<string, ActivityCourseRef[]>();
+  const quizNameByActivityType = new Map<string, string>();
 
   for (const row of (data ?? []) as unknown as ActivityCourseLinkRow[]) {
     if (!row.assembled_quiz) continue;
@@ -248,7 +265,11 @@ export async function listCoursesForActivityTypes(
     const existing = coursesByActivityType.get(row.activity_type) ?? [];
     if (!existing.some((course) => course.courseId === courseId)) existing.push({ courseId, courseName });
     coursesByActivityType.set(row.activity_type, existing);
+
+    if (!quizNameByActivityType.has(row.activity_type)) {
+      quizNameByActivityType.set(row.activity_type, row.assembled_quiz.quiz_name);
+    }
   }
 
-  return { coursesByActivityType, error: null };
+  return { coursesByActivityType, quizNameByActivityType, error: null };
 }

--- a/lib/activityLogTypes.ts
+++ b/lib/activityLogTypes.ts
@@ -173,10 +173,18 @@ export function summarizeStudents(
  * The instructor-side counterpart (GitHub #171): the same adaptation, plus the two fields that
  * say whose attempt it was. Built on toActivityLogEntry rather than beside it, so the student
  * log and the class-wide table cannot drift apart in how they read a session.
+ *
+ * GitHub #500 follow-up: session.quizName (the assembled quiz's own name, resolved server-side by
+ * loadAllStudentActivity/loadStudentActivityForIds) is threaded through as a single-entry
+ * nameByType map — toActivityLogEntry's existing GitHub #476 mechanism, not a second one — so the
+ * combined instructor table's QUIZ column shows the quiz an attempt actually belongs to instead
+ * of falling all the way back to the raw activity_type key.
  */
 export function toStudentActivitySummary(session: InstructorActivityEntry): StudentActivitySummary {
+  const nameByType = session.quizName ? new Map([[session.activity_type, session.quizName]]) : undefined;
+
   return {
-    ...toActivityLogEntry(session),
+    ...toActivityLogEntry(session, nameByType),
     studentId: session.studentId,
     studentName: session.studentName,
     courses: session.courses,
@@ -249,10 +257,13 @@ export function toAcSubmissionRow(submission: InstructorACSubmission): AcSubmiss
     studentId: submission.studentId,
     studentName: submission.studentName,
     // GitHub #379: read off the submission rather than hardcoded — more than one activity can be
-    // llm-graded now, so a fixed key would mislabel every instructor-created one. Same
-    // getActivityByType-else-key fallback toActivityLogEntry already uses for a custom catalog.
+    // llm-graded now, so a fixed key would mislabel every instructor-created one. GitHub #500
+    // follow-up: prefer the assembled quiz's own name (submission.quizName) over the
+    // getActivityByType-else-key fallback toActivityLogEntry uses for a custom catalog — the same
+    // fix toStudentActivitySummary applies to quiz attempts, so the combined table's QUIZ column
+    // can't show the raw key for one row kind and a real name for the other.
     activityType: submission.activityType,
-    activityName: getActivityByType(submission.activityType)?.name ?? submission.activityType,
+    activityName: submission.quizName ?? getActivityByType(submission.activityType)?.name ?? submission.activityType,
     level: submission.difficultyLevel,
     dateTime: submission.submittedAt,
     status: graded ? 'completed' : 'in-progress',

--- a/lib/llmActivityClient.ts
+++ b/lib/llmActivityClient.ts
@@ -149,6 +149,9 @@ export type InstructorACSubmission = {
   gradedAt: string | null;
   /** GitHub #474: every course this submission's catalog is currently linked to; [] means none yet. */
   courses: { courseId: string; courseName: string }[];
+  /** GitHub #500 follow-up: the assembled quiz's own name, not the catalog's — see
+   *  InstructorActivityEntry.quizName's own comment for the same reasoning and its known limit. */
+  quizName: string | null;
 };
 
 /** GET /api/instructor/acceptance-criteria/submissions — all AC submissions, optionally scoped to one student. */

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -514,7 +514,7 @@ export async function loadAllStudentActivity(supabase: SupabaseClient, ownedMcqT
 
   if (progressError) return { activities: null, error: progressError };
 
-  const { coursesByActivityType, error: coursesError } = await listCoursesForActivityTypes(supabase, ownedMcqTypes);
+  const { coursesByActivityType, quizNameByActivityType, error: coursesError } = await listCoursesForActivityTypes(supabase, ownedMcqTypes);
   if (coursesError) return { activities: null, error: coursesError };
 
   // The embed is destructured off rather than spread along: it carries role and username, which
@@ -530,6 +530,7 @@ export async function loadAllStudentActivity(supabase: SupabaseClient, ownedMcqT
       studentId: session.user_id,
       studentName: studentDisplayName(student),
       courses: coursesByActivityType!.get(session.activity_type) ?? [],
+      quizName: quizNameByActivityType!.get(session.activity_type) ?? null,
     };
   });
 
@@ -577,7 +578,7 @@ export async function loadStudentActivityForIds(supabase: SupabaseClient, studen
   // Unlike loadAllStudentActivity, this has no pre-known activity_type list to scope the course
   // lookup by — a roster can have attempted anything, not just catalogs linked to the course
   // being exported — so the distinct set is derived from the rows themselves after the fetch.
-  const { coursesByActivityType, error: coursesError } = await listCoursesForActivityTypes(supabase, [
+  const { coursesByActivityType, quizNameByActivityType, error: coursesError } = await listCoursesForActivityTypes(supabase, [
     ...new Set(rows.map((row) => row.activity_type)),
   ]);
   if (coursesError) return { activities: null, error: coursesError };
@@ -593,6 +594,7 @@ export async function loadStudentActivityForIds(supabase: SupabaseClient, studen
       studentId: session.user_id,
       studentName: studentDisplayName(student),
       courses: coursesByActivityType!.get(session.activity_type) ?? [],
+      quizName: quizNameByActivityType!.get(session.activity_type) ?? null,
     };
   });
 

--- a/lib/sessionTypes.ts
+++ b/lib/sessionTypes.ts
@@ -47,6 +47,13 @@ export type InstructorActivityEntry = SessionListEntry & {
    * more than one course at once, so this is a list, not a single name.
    */
   courses: ActivityCourseRef[];
+  /**
+   * The assembled quiz's own name (GitHub #500 follow-up) — not the catalog's, so two different
+   * quizzes composed from the same catalog show up distinguishably. Null means the catalog isn't
+   * linked to any assembled quiz yet, the same case courses: [] represents; toActivityLogEntry
+   * falls back to the catalog lookup and then the raw key when this is null.
+   */
+  quizName: string | null;
 };
 
 /**


### PR DESCRIPTION
Rename "Activity" column to "Quiz" in the combined Instructor Dashboard's activity table (ActivityLogTable), matching the fact that every row is a specific quiz attempt.
Fix wrong quiz name in that column: rows showed the raw activity_type key (e.g. "TEST_CATALOG") instead of a real name, so two different quizzes built from the same catalog were indistinguishable. Root cause: toStudentActivitySummary (quiz attempts) and toAcSubmissionRow (AC submissions) had no name lookup at all for instructor-created catalogs — they fell straight through to the raw key.
Extended listCoursesForActivityTypes (already querying assembled_quiz for the Course column, GitHub #474) to also resolve each catalog's assembled quiz name in the same query — no extra round trip — and threaded it through both row-mapping functions via the existing GitHub #476 nameByType mechanism.
Known limitation, consistent with prior precedent (#476): since session_log has no assembled_quiz_id, a catalog composed into multiple quizzes resolves to whichever one is found first — the common one-quiz-per-catalog case is exact.