### PR TITLE
Fix: two quizzes sharing a catalog are indistinguishable to students 

### DIFF
--- a/__tests__/api/activities-list.test.ts
+++ b/__tests__/api/activities-list.test.ts
@@ -95,6 +95,7 @@ describe('GET /api/activities', () => {
           activity_type: 'IDENTIFY_WEAK_USER_STORIES',
           catalog: { quiz_name: 'Identify Weak User Stories', description: null, grading_kind: 'mcq' },
           assembled_quiz: {
+            assembled_quiz_id: 'quiz-1',
             course_id: 'course-1',
             quiz_name: 'Weak Stories — Sprint 2',
             description: 'Sprint 2 edition',
@@ -105,6 +106,7 @@ describe('GET /api/activities', () => {
           activity_type: 'MY_CUSTOM_QUIZ',
           catalog: { quiz_name: 'My Custom Quiz', description: 'A quiz about things', grading_kind: 'llm-graded' },
           assembled_quiz: {
+            assembled_quiz_id: 'quiz-2',
             course_id: 'course-2',
             quiz_name: 'Advanced Practice Set',
             description: 'For the advanced section',
@@ -127,6 +129,7 @@ describe('GET /api/activities', () => {
         gradingKind: 'mcq',
         courseId: 'course-1',
         courseName: 'Software Requirements',
+        assembledQuizId: 'quiz-1',
       },
       {
         activityType: 'MY_CUSTOM_QUIZ',
@@ -135,6 +138,7 @@ describe('GET /api/activities', () => {
         gradingKind: 'llm-graded',
         courseId: 'course-2',
         courseName: 'Advanced SE',
+        assembledQuizId: 'quiz-2',
       },
     ]);
 
@@ -171,6 +175,46 @@ describe('GET /api/activities', () => {
       column: 'assembled_quiz.course_id',
       value: ['course-1'],
     });
+  });
+
+  // GitHub #583: the actual bug — two assembled quizzes built on the same catalog for the same
+  // course used to collapse into a single discovery-list entry, so a student never saw the second.
+  it('surfaces two quizzes composed from the same catalog as separate entries', async () => {
+    queue('student_course', { data: [{ course_id: 'course-1' }], error: null });
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          activity_type: 'SHARED_CATALOG',
+          catalog: { quiz_name: 'Shared Catalog', description: null, grading_kind: 'mcq' },
+          assembled_quiz: {
+            assembled_quiz_id: 'quiz-a',
+            course_id: 'course-1',
+            quiz_name: 'Quiz A',
+            description: null,
+            course: { course_name: 'Software Requirements' },
+          },
+        },
+        {
+          activity_type: 'SHARED_CATALOG',
+          catalog: { quiz_name: 'Shared Catalog', description: null, grading_kind: 'mcq' },
+          assembled_quiz: {
+            assembled_quiz_id: 'quiz-b',
+            course_id: 'course-1',
+            quiz_name: 'Quiz B',
+            description: null,
+            course: { course_name: 'Software Requirements' },
+          },
+        },
+      ],
+      error: null,
+    });
+
+    const res = await GET(req());
+    const body = await res.json();
+
+    expect(body.activities).toHaveLength(2);
+    expect(body.activities.map((a: { name: string }) => a.name)).toEqual(['Quiz A', 'Quiz B']);
+    expect(body.activities.map((a: { assembledQuizId: string }) => a.assembledQuizId)).toEqual(['quiz-a', 'quiz-b']);
   });
 
   it('returns 403 with an empty body when ?courseId= is a course the caller is not enrolled in', async () => {

--- a/__tests__/api/activities-meta.test.ts
+++ b/__tests__/api/activities-meta.test.ts
@@ -82,6 +82,7 @@ function queueEnrolled(overrides: { quizName?: string | null; description?: stri
     data: [
       {
         assembled_quiz: {
+          assembled_quiz_id: 'quiz-1',
           course_id: 'course-1',
           quiz_name: 'quizName' in overrides ? overrides.quizName : 'Course-Specific Requirements Quiz',
           description: 'description' in overrides ? overrides.description : 'Assembled for this course',
@@ -153,7 +154,20 @@ describe('GET /api/activities/:activityType', () => {
       gradingKind: 'mcq',
       courseId: 'course-1',
       courseName: 'Software Requirements',
+      assembledQuizId: 'quiz-1',
     });
+  });
+
+  // GitHub #583: a caller that already knows which quiz it means (the ?quiz= a student followed
+  // from a course page card) can disambiguate between two quizzes composing the same catalog.
+  it('accepts an assembledQuizId query param without erroring', async () => {
+    queue('activity_type', { data: quizRow(), error: null });
+    queueEnrolled();
+
+    const res = await GET(req('MY_CUSTOM_QUIZ?assembledQuizId=quiz-1'), PARAMS('MY_CUSTOM_QUIZ'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.activity.assembledQuizId).toBe('quiz-1');
   });
 
   it('falls back to the catalog description when the assembled quiz has none', async () => {

--- a/__tests__/api/llm-sessions-current.test.ts
+++ b/__tests__/api/llm-sessions-current.test.ts
@@ -88,8 +88,8 @@ const existingSubmissions = [
   },
 ];
 
-function req(token: string | null = 'valid-token') {
-  return new Request('http://localhost/api/activities/write-acceptance-criteria/sessions/current', {
+function req(token: string | null = 'valid-token', query = '') {
+  return new Request(`http://localhost/api/activities/write-acceptance-criteria/sessions/current${query}`, {
     headers: token ? { authorization: `Bearer ${token}` } : {},
   });
 }
@@ -209,5 +209,19 @@ describe('GET /api/activities/[activityType]/llm/sessions/current', () => {
     const body = await (await GET(req(), PARAMS())).json();
 
     expect(body.nextPosition).toBe(1);
+  });
+
+  // GitHub #583: an assembledQuizId query param must be accepted and forwarded without erroring
+  // — the underlying filter itself is verified at the source in __tests__/lib/sessionQueries.test.ts.
+  it('accepts an assembledQuizId query param and resumes normally', async () => {
+    queue('session_log', { data: sessionRow, error: null });
+    queue('session_to_user_story', { data: drawnStories, error: null });
+    queue('submission', { data: existingSubmissions, error: null });
+
+    const response = await GET(req('valid-token', '?assembledQuizId=quiz-1'), PARAMS());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session).toEqual(sessionRow);
   });
 });

--- a/__tests__/api/llm-sessions.test.ts
+++ b/__tests__/api/llm-sessions.test.ts
@@ -394,6 +394,33 @@ describe('POST /api/activities/[activityType]/llm/sessions', () => {
     expect((await response.json()).error).toMatch(/profile/i);
   });
 
+  // GitHub #583: the granting quiz's id (resolved by getAccessibleCourseForActivity, queueEnrolled's
+  // fixture returns 'quiz-1') is persisted onto the session, the same as POST /api/sessions.
+  it("persists the granting quiz's id onto the session", async () => {
+    queueHappyPath();
+
+    const response = await POST(req(), PARAMS());
+
+    expect(response.status).toBe(201);
+    const sessionInsert = h.state.inserts.find((i) => i.table === 'session_log')!.payload as Record<string, unknown>;
+    expect(sessionInsert).toMatchObject({ assembled_quiz_id: 'quiz-1' });
+  });
+
+  it('accepts an explicit assembledQuizId in the request body without erroring', async () => {
+    queueHappyPath();
+
+    const response = await POST(req({ assembledQuizId: 'quiz-1' }), PARAMS());
+
+    expect(response.status).toBe(201);
+  });
+
+  it('returns 400 when assembledQuizId is not a string', async () => {
+    const response = await POST(req({ assembledQuizId: 42 }), PARAMS());
+
+    expect(response.status).toBe(400);
+    expect(h.state.tables).toEqual([]);
+  });
+
   it('removes the session when its prompts could not be stored', async () => {
     queueGradingKind('llm-graded');
     queueEnrolled();

--- a/__tests__/api/sessions-completed.test.ts
+++ b/__tests__/api/sessions-completed.test.ts
@@ -196,6 +196,26 @@ describe('GET /api/sessions/completed', () => {
     ]);
   });
 
+  // GitHub #583: an assembledQuizId query param scopes history to one quiz, so two quizzes
+  // sharing a catalog don't show each other's completed attempts.
+  it('additionally filters by assembled_quiz_id when the query param is present', async () => {
+    queueValidActivityType();
+    queue('session_log', { data: [], error: null });
+
+    await GET(req(`?activityType=${ACTIVITY}&assembledQuizId=quiz-1`));
+
+    expect(h.state.filters).toContainEqual({ table: 'session_log', column: 'assembled_quiz_id', value: 'quiz-1' });
+  });
+
+  it('does not filter by assembled_quiz_id when the query param is absent', async () => {
+    queueValidActivityType();
+    queue('session_log', { data: [], error: null });
+
+    await GET(req());
+
+    expect(h.state.filters.some((f) => f.column === 'assembled_quiz_id')).toBe(false);
+  });
+
   it('returns 500 when the session_log query fails', async () => {
     queueValidActivityType();
     queue('session_log', { data: null, error: { message: 'db down' } });

--- a/__tests__/api/sessions-current.test.ts
+++ b/__tests__/api/sessions-current.test.ts
@@ -256,4 +256,21 @@ describe('GET /api/sessions/current', () => {
 
     expect(body.nextPosition).toBe(2);
   });
+
+  // GitHub #583: an assembledQuizId query param must be accepted and forwarded without erroring
+  // — the underlying filter itself is verified at the source in __tests__/lib/sessionQueries.test.ts,
+  // since this harness's .eq() is a no-op and can't record it.
+  it('accepts an assembledQuizId query param and resumes normally', async () => {
+    queueValidActivityType();
+    queue('session_log', { data: sessionRow, error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+    queue('answered_question_log', { data: submittedAnswers, error: null });
+
+    const url = `http://localhost/api/sessions/current?activityType=${ACTIVITY}&assembledQuizId=quiz-1`;
+    const response = await GET(new Request(url, { headers: { authorization: 'Bearer valid-token' } }));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.session).toEqual(sessionRow);
+  });
 });

--- a/__tests__/api/sessions-in-progress.test.ts
+++ b/__tests__/api/sessions-in-progress.test.ts
@@ -232,6 +232,21 @@ describe('GET /api/sessions/in-progress', () => {
     expect((await GET(req(`?activityType=${ACTIVITY_TYPE}`))).status).toBe(500);
   });
 
+  // GitHub #583: assembledQuizId narrows further than activityType alone, to one specific quiz
+  // — accepted here as a smoke check; the underlying .eq('assembled_quiz_id', …) filter itself
+  // is verified at the source in __tests__/lib/sessionQueries.test.ts, since this harness's
+  // .eq() is a no-op and can't record it.
+  it('accepts an assembledQuizId query param without erroring', async () => {
+    queueValidActivityType();
+    queue('session_log', { data: [sessionRow()], error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+    queue('answered_question_log', { data: [], error: null });
+
+    const response = await GET(req(`?activityType=${ACTIVITY_TYPE}&assembledQuizId=quiz-1`));
+
+    expect(response.status).toBe(200);
+  });
+
   it('never writes', async () => {
     queueValidActivityType();
     queue('session_log', { data: [sessionRow()], error: null });

--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -360,6 +360,33 @@ describe('POST /api/sessions', () => {
     links.forEach((l) => expect(pool.map((q) => q.question_id)).toContain(l.question_id));
   });
 
+  // GitHub #583: the resolved granting quiz (accessLink.assembledQuizId, from queueEnrolled's
+  // assembled_quiz_catalog fixture) is persisted onto the session, not just used transiently for
+  // exclusion filtering — this is what lets two quizzes sharing a catalog be tracked separately.
+  it("persists the granting quiz's id onto the session", async () => {
+    queueHappyPath();
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES' }));
+    expect(response.status).toBe(201);
+
+    const sessionInsert = h.state.inserts.find((i) => i.table === 'session_log')!.payload as Record<string, unknown>;
+    expect(sessionInsert).toMatchObject({ assembled_quiz_id: 'quiz-1' });
+  });
+
+  it('accepts an explicit assembledQuizId in the request body without erroring', async () => {
+    queueHappyPath();
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES', assembledQuizId: 'quiz-1' }));
+    expect(response.status).toBe(201);
+  });
+
+  it('returns 400 when assembledQuizId is not a string', async () => {
+    queueValidActivityType();
+
+    const response = await POST(req({ activityType: 'IDENTIFY_WEAK_USER_STORIES', assembledQuizId: 42 }));
+    expect(response.status).toBe(400);
+  });
+
   it('starts the next session at the next difficulty level once the current one is passed', async () => {
     queueValidActivityType();
     queue('session_log', { data: null, error: null }); // no session in progress

--- a/__tests__/lib/activityCourseQueries.test.ts
+++ b/__tests__/lib/activityCourseQueries.test.ts
@@ -185,6 +185,57 @@ describe('getAccessibleCourseForActivity', () => {
 
     expect(result).toEqual({ link: null, error: { message: 'db down' } });
   });
+
+  // GitHub #583: a caller that already knows which quiz it means (e.g. the ?quiz= a student
+  // followed from a course page card) can disambiguate instead of always taking .limit(1)'s
+  // arbitrary first match — needed once a catalog can be composed into more than one quiz in the
+  // same course.
+  it('filters by assembledQuizId when the caller supplies one', async () => {
+    queue('student_course', { data: [{ course_id: 'course-1' }], error: null });
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          assembled_quiz: {
+            assembled_quiz_id: 'quiz-b',
+            course_id: 'course-1',
+            quiz_name: 'Quiz B',
+            description: null,
+            course: { course_name: 'Intro to SE' },
+          },
+          catalog: { quiz_name: 'Sprint 1 Check', description: null },
+        },
+      ],
+      error: null,
+    });
+
+    const result = await getAccessibleCourseForActivity(makeSupabase(), 'CUSTOM_QUIZ', 'student-1', {
+      assembledQuizId: 'quiz-b',
+    });
+
+    expect(result.link?.name).toBe('Quiz B');
+    expect(state.filters).toContainEqual({
+      table: 'assembled_quiz_catalog',
+      column: 'assembled_quiz.assembled_quiz_id',
+      value: 'quiz-b',
+    });
+  });
+
+  it('omits the assembledQuizId filter when none is supplied, reproducing the old first-match behavior', async () => {
+    queue('student_course', { data: [{ course_id: 'course-1' }], error: null });
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          assembled_quiz: { assembled_quiz_id: 'quiz-a', course_id: 'course-1', quiz_name: 'Quiz A', description: null, course: null },
+          catalog: { quiz_name: 'Sprint 1 Check', description: null },
+        },
+      ],
+      error: null,
+    });
+
+    await getAccessibleCourseForActivity(makeSupabase(), 'CUSTOM_QUIZ', 'student-1');
+
+    expect(state.filters.some((f) => f.column === 'assembled_quiz.assembled_quiz_id')).toBe(false);
+  });
 });
 
 describe('checkActivityAccess', () => {
@@ -294,12 +345,12 @@ describe('listActivityTypesForCourses', () => {
         {
           activity_type: 'CUSTOM_QUIZ',
           catalog: { quiz_name: 'Sprint 1 Check', description: null },
-          assembled_quiz: { course_id: 'course-1', quiz_name: 'Course 1 Sprint Check', description: null, course: { course_name: 'Intro to SE' } },
+          assembled_quiz: { assembled_quiz_id: 'quiz-1', course_id: 'course-1', quiz_name: 'Course 1 Sprint Check', description: null, course: { course_name: 'Intro to SE' } },
         },
         {
           activity_type: 'CUSTOM_QUIZ',
           catalog: { quiz_name: 'Sprint 1 Check', description: null },
-          assembled_quiz: { course_id: 'course-2', quiz_name: 'Course 2 Sprint Check', description: null, course: { course_name: 'Advanced SE' } },
+          assembled_quiz: { assembled_quiz_id: 'quiz-2', course_id: 'course-2', quiz_name: 'Course 2 Sprint Check', description: null, course: { course_name: 'Advanced SE' } },
         },
       ],
       error: null,
@@ -310,6 +361,55 @@ describe('listActivityTypesForCourses', () => {
     expect(result.activities).toHaveLength(1);
     expect(result.activities?.[0].courseId).toBe('course-1');
     expect(result.activities?.[0].name).toBe('Course 1 Sprint Check');
+  });
+
+  // GitHub #583: two assembled_quiz rows in the SAME course, both linking the SAME catalog — the
+  // bug's exact reproduction. Default behavior (titles/leaderboard callers) must keep collapsing
+  // to one row; only a caller that opts in sees both.
+  it('dedupeByQuiz: false (default) still collapses two quizzes in the same course sharing a catalog to one row', async () => {
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          activity_type: 'SHARED_CATALOG',
+          catalog: { quiz_name: 'Shared Catalog', description: null },
+          assembled_quiz: { assembled_quiz_id: 'quiz-a', course_id: 'course-1', quiz_name: 'Quiz A', description: null, course: { course_name: 'Intro to SE' } },
+        },
+        {
+          activity_type: 'SHARED_CATALOG',
+          catalog: { quiz_name: 'Shared Catalog', description: null },
+          assembled_quiz: { assembled_quiz_id: 'quiz-b', course_id: 'course-1', quiz_name: 'Quiz B', description: null, course: { course_name: 'Intro to SE' } },
+        },
+      ],
+      error: null,
+    });
+
+    const result = await listActivityTypesForCourses(makeSupabase(), ['course-1']);
+
+    expect(result.activities).toHaveLength(1);
+  });
+
+  it('dedupeByQuiz: true surfaces both quizzes composed from the same catalog in the same course', async () => {
+    queue('assembled_quiz_catalog', {
+      data: [
+        {
+          activity_type: 'SHARED_CATALOG',
+          catalog: { quiz_name: 'Shared Catalog', description: null },
+          assembled_quiz: { assembled_quiz_id: 'quiz-a', course_id: 'course-1', quiz_name: 'Quiz A', description: null, course: { course_name: 'Intro to SE' } },
+        },
+        {
+          activity_type: 'SHARED_CATALOG',
+          catalog: { quiz_name: 'Shared Catalog', description: null },
+          assembled_quiz: { assembled_quiz_id: 'quiz-b', course_id: 'course-1', quiz_name: 'Quiz B', description: null, course: { course_name: 'Intro to SE' } },
+        },
+      ],
+      error: null,
+    });
+
+    const result = await listActivityTypesForCourses(makeSupabase(), ['course-1'], { dedupeByQuiz: true });
+
+    expect(result.activities).toHaveLength(2);
+    expect(result.activities?.map((a) => a.name).sort()).toEqual(['Quiz A', 'Quiz B']);
+    expect(result.activities?.map((a) => a.assembledQuizId).sort()).toEqual(['quiz-a', 'quiz-b']);
   });
 
   it('surfaces a query error', async () => {

--- a/__tests__/lib/activityLogTypes.test.ts
+++ b/__tests__/lib/activityLogTypes.test.ts
@@ -16,6 +16,7 @@ function session(overrides: Partial<SessionListEntry> = {}): SessionListEntry {
     session_id: 'session-1',
     user_id: 'student-1',
     activity_type: 'TEST_CATALOG',
+    assembled_quiz_id: null,
     difficulty_level: 1,
     started_at: '2026-08-01T10:00:00.000Z',
     ended_at: '2026-08-01T10:20:00.000Z',

--- a/__tests__/lib/scoreQueries.test.ts
+++ b/__tests__/lib/scoreQueries.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { computeStudentScore, sumBestScores, type SessionRow } from '../../lib/scoreQueries';
+
+function session(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    activity_type: 'CUSTOM_QUIZ',
+    difficulty_level: 1,
+    cumulative_score: 10,
+    assembled_quiz_id: null,
+    ...overrides,
+  };
+}
+
+describe('sumBestScores', () => {
+  it('sums the best score per (activity_type, difficulty_level) when no quiz is known', () => {
+    const total = sumBestScores([
+      session({ difficulty_level: 1, cumulative_score: 10 }),
+      session({ difficulty_level: 1, cumulative_score: 30 }), // best of the two at level 1
+      session({ difficulty_level: 2, cumulative_score: 20 }),
+    ]);
+
+    expect(total).toBe(50); // 30 (best at level 1) + 20 (level 2)
+  });
+
+  it('never counts a level twice even across many attempts', () => {
+    const total = sumBestScores([
+      session({ difficulty_level: 1, cumulative_score: 5 }),
+      session({ difficulty_level: 1, cumulative_score: 5 }),
+      session({ difficulty_level: 1, cumulative_score: 5 }),
+    ]);
+
+    expect(total).toBe(5);
+  });
+
+  // GitHub #583, confirmed product decision: two quizzes built on the same catalog each count
+  // independently — completing both is two distinct assignments, not one deduplicated best-of.
+  it('counts two quizzes built on the same catalog independently, not deduplicated', () => {
+    const total = sumBestScores([
+      session({ assembled_quiz_id: 'quiz-a', activity_type: 'SHARED_CATALOG', difficulty_level: 1, cumulative_score: 40 }),
+      session({ assembled_quiz_id: 'quiz-b', activity_type: 'SHARED_CATALOG', difficulty_level: 1, cumulative_score: 40 }),
+    ]);
+
+    expect(total).toBe(80); // both count, even though same catalog/level
+  });
+
+  it('still keeps only the best attempt within one quiz', () => {
+    const total = sumBestScores([
+      session({ assembled_quiz_id: 'quiz-a', difficulty_level: 1, cumulative_score: 20 }),
+      session({ assembled_quiz_id: 'quiz-a', difficulty_level: 1, cumulative_score: 40 }),
+    ]);
+
+    expect(total).toBe(40);
+  });
+
+  it('pools every quiz-less (legacy/no-context) session into one shared bucket per level, matching pre-#583 behavior', () => {
+    const total = sumBestScores([
+      session({ assembled_quiz_id: null, activity_type: 'CUSTOM_QUIZ', difficulty_level: 1, cumulative_score: 10 }),
+      session({ assembled_quiz_id: null, activity_type: 'CUSTOM_QUIZ', difficulty_level: 1, cumulative_score: 25 }),
+    ]);
+
+    expect(total).toBe(25);
+  });
+
+  it('returns 0 for no sessions', () => {
+    expect(sumBestScores([])).toBe(0);
+  });
+});
+
+// Same fake-client shape as __tests__/lib/activityCourseQueries.test.ts — computeStudentScore
+// takes `supabase` as a plain argument, so a locally built fake is enough (no vi.mock needed).
+type Result = { data?: unknown; error?: unknown };
+
+const state = {
+  queues: {} as Record<string, Result[]>,
+  filters: [] as { table: string; column: string; value: unknown }[],
+};
+
+function queue(table: string, result: Result) {
+  (state.queues[table] ??= []).push(result);
+}
+
+function makeBuilder(table: string, result: Result) {
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: (column: string, value: unknown) => {
+      state.filters.push({ table, column, value });
+      return builder;
+    },
+    then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) => Promise.resolve(result).then(onOk, onErr),
+  };
+  return builder;
+}
+
+function makeSupabase() {
+  return {
+    from: (table: string) => makeBuilder(table, state.queues[table]?.shift() ?? { data: null, error: null }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+beforeEach(() => {
+  state.queues = {};
+  state.filters = [];
+});
+
+describe('computeStudentScore', () => {
+  it('selects assembled_quiz_id alongside the other session columns', async () => {
+    queue('session_log', { data: [], error: null });
+    queue('daily_challenge_attempt', { data: [], error: null });
+
+    await computeStudentScore(makeSupabase(), 'student-1');
+
+    expect(state.filters).toContainEqual({ table: 'session_log', column: 'user_id', value: 'student-1' });
+    expect(state.filters).toContainEqual({ table: 'session_log', column: 'status', value: 'completed' });
+  });
+
+  it('sums independently across two quizzes on the same catalog, plus Daily Challenge points', async () => {
+    queue('session_log', {
+      data: [
+        { activity_type: 'SHARED_CATALOG', difficulty_level: 1, cumulative_score: 40, assembled_quiz_id: 'quiz-a' },
+        { activity_type: 'SHARED_CATALOG', difficulty_level: 1, cumulative_score: 40, assembled_quiz_id: 'quiz-b' },
+      ],
+      error: null,
+    });
+    queue('daily_challenge_attempt', { data: [{ score: 10 }], error: null });
+
+    const result = await computeStudentScore(makeSupabase(), 'student-1');
+
+    expect(result).toEqual({ score: 90, sessionsCompleted: 2, error: null });
+  });
+
+  it('surfaces a session_log query error', async () => {
+    queue('session_log', { data: null, error: { message: 'db down' } });
+
+    const result = await computeStudentScore(makeSupabase(), 'student-1');
+
+    expect(result).toEqual({ score: null, sessionsCompleted: null, error: { message: 'db down' } });
+  });
+});

--- a/__tests__/lib/sessionClient.test.ts
+++ b/__tests__/lib/sessionClient.test.ts
@@ -25,6 +25,7 @@ const SESSION: InstructorActivityEntry = {
   session_id: 'session-1',
   user_id: 'student-1',
   activity_type: 'weak-user-stories',
+  assembled_quiz_id: null,
   difficulty_level: 1,
   started_at: '2026-01-01T10:00:00.000Z',
   ended_at: '2026-01-01T10:05:00.000Z',
@@ -37,6 +38,8 @@ const SESSION: InstructorActivityEntry = {
   studentId: 'student-1',
   studentName: 'Ada Lovelace',
   nextPosition: null,
+  courses: [],
+  quizName: null,
 };
 
 afterEach(() => {

--- a/__tests__/lib/sessionQueries.test.ts
+++ b/__tests__/lib/sessionQueries.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { findInProgressSession, findStartDifficultyLevel, loadCompletedAttempts } from '../../lib/sessionQueries';
+
+// GitHub #583: findInProgressSession/findStartDifficultyLevel/loadCompletedAttempts all gained an
+// optional assembledQuizId parameter — these tests verify the actual .eq('assembled_quiz_id', …)
+// filter is (or isn't) applied, which the route-level test harnesses can't see since their .eq()
+// is a no-op. Same local-fake-builder shape as __tests__/lib/activityCourseQueries.test.ts and
+// __tests__/lib/scoreQueries.test.ts — these functions take `supabase` as a plain argument.
+
+type Result = { data?: unknown; error?: unknown };
+
+const state = {
+  queues: {} as Record<string, Result[]>,
+  filters: [] as { table: string; column: string; value: unknown }[],
+};
+
+function queue(table: string, result: Result) {
+  (state.queues[table] ??= []).push(result);
+}
+
+function makeBuilder(table: string, result: Result) {
+  const builder: Record<string, unknown> = {
+    select: () => builder,
+    eq: (column: string, value: unknown) => {
+      state.filters.push({ table, column, value });
+      return builder;
+    },
+    order: () => builder,
+    maybeSingle: async () => result,
+    then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) => Promise.resolve(result).then(onOk, onErr),
+  };
+  return builder;
+}
+
+function makeSupabase() {
+  return {
+    from: (table: string) => makeBuilder(table, state.queues[table]?.shift() ?? { data: null, error: null }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+beforeEach(() => {
+  state.queues = {};
+  state.filters = [];
+});
+
+describe('findInProgressSession', () => {
+  it('does not filter by assembled_quiz_id when none is given (matches the old, catalog-wide behavior)', async () => {
+    queue('session_log', { data: null, error: null });
+
+    await findInProgressSession(makeSupabase(), 'student-1', 'CUSTOM_QUIZ');
+
+    expect(state.filters.some((f) => f.column === 'assembled_quiz_id')).toBe(false);
+  });
+
+  it('filters by assembled_quiz_id when one is given, so two quizzes on the same catalog get independent slots', async () => {
+    queue('session_log', { data: null, error: null });
+
+    await findInProgressSession(makeSupabase(), 'student-1', 'CUSTOM_QUIZ', 'quiz-a');
+
+    expect(state.filters).toContainEqual({ table: 'session_log', column: 'assembled_quiz_id', value: 'quiz-a' });
+  });
+});
+
+describe('findStartDifficultyLevel', () => {
+  it('does not filter by assembled_quiz_id when none is given', async () => {
+    queue('session_log', { data: [], error: null });
+
+    await findStartDifficultyLevel(makeSupabase(), 'student-1', 'CUSTOM_QUIZ');
+
+    expect(state.filters.some((f) => f.column === 'assembled_quiz_id')).toBe(false);
+  });
+
+  it('scopes progression to one quiz when assembledQuizId is given', async () => {
+    // Only quiz-a's own passed level-2 session should count toward quiz-a's start level.
+    queue('session_log', {
+      data: [{ activity_type: 'CUSTOM_QUIZ', difficulty_level: 2, passed: true }],
+      error: null,
+    });
+
+    const result = await findStartDifficultyLevel(makeSupabase(), 'student-1', 'CUSTOM_QUIZ', 'quiz-a');
+
+    expect(state.filters).toContainEqual({ table: 'session_log', column: 'assembled_quiz_id', value: 'quiz-a' });
+    expect(result.startLevel).toBe(3); // one past the passed level
+  });
+});
+
+describe('loadCompletedAttempts', () => {
+  it('does not filter by assembled_quiz_id when none is given', async () => {
+    queue('session_log', { data: [], error: null });
+
+    await loadCompletedAttempts(makeSupabase(), 'student-1', 'CUSTOM_QUIZ');
+
+    expect(state.filters.some((f) => f.column === 'assembled_quiz_id')).toBe(false);
+  });
+
+  it('scopes history to one quiz when assembledQuizId is given', async () => {
+    queue('session_log', { data: [], error: null });
+
+    await loadCompletedAttempts(makeSupabase(), 'student-1', 'CUSTOM_QUIZ', 'quiz-b');
+
+    expect(state.filters).toContainEqual({ table: 'session_log', column: 'assembled_quiz_id', value: 'quiz-b' });
+  });
+});

--- a/app/activities/[slug]/page.tsx
+++ b/app/activities/[slug]/page.tsx
@@ -82,13 +82,18 @@ function ActivityDetailContent({
   // Also redirects an instructor account away (GitHub #82) — starting/resuming/abandoning a
   // quiz is exactly the "quiz durchführen" capability instructors must not have.
   const { token, profile, loading, authorized } = useRequireRole('student');
-  const { activity, status: activityStatus } = useResolvedActivity(token, params.slug);
+  const searchParams = useSearchParams();
+  // GitHub #583: the ?quiz= a student followed from a course page card, disambiguating which of
+  // possibly several assembled quizzes composing this catalog they mean — undefined for a bare/
+  // bookmarked link, which resolves the same first-match fallback as before this fix.
+  const quizParam = searchParams.get('quiz') ?? undefined;
+  const { activity, status: activityStatus } = useResolvedActivity(token, params.slug, quizParam);
 
   // The level ActivityCard was already showing for this activity on the activities list page
   // (components/ActivityCard.tsx's ?level= link) — used only to seed the first paint below so
   // it doesn't default to level 1 and then jump once this page's own data has loaded; the effect
   // further down still recomputes and corrects it from real data once that arrives.
-  const initialLevel = parseLevelParam(useSearchParams().get('level'));
+  const initialLevel = parseLevelParam(searchParams.get('level'));
 
   // The server is the only source of "does this activity have a run in progress" (REQ-PL-6.3) —
   // there is no local/mock notion of progress anymore. null means "not checked yet or nothing
@@ -157,12 +162,12 @@ function ActivityDetailContent({
   // would read as a two-level unlock that never happened.
   useEffect(() => {
     if (attempts === null || !profile?.user_id || !activity) return;
-    const seen = getSeenUnlockedLevel(profile.user_id, activity.activityType);
+    const seen = getSeenUnlockedLevel(profile.user_id, activity.activityType, activity.assembledQuizId);
     const newly = newlyUnlockedLevel(seen, highestSelectableLevel);
     // Recorded unconditionally, which is what makes this idempotent: loadCompletedAttempts's
     // background onRevalidate below re-runs this effect with a new attempts identity, and the
     // second pass must find nothing new rather than restart an animation already in flight.
-    recordSeenUnlockedLevel(profile.user_id, activity.activityType, highestSelectableLevel);
+    recordSeenUnlockedLevel(profile.user_id, activity.activityType, highestSelectableLevel, activity.assembledQuizId);
     if (newly !== null) setUnlockingLevel(newly);
   }, [attempts, profile?.user_id, activity, highestSelectableLevel]);
 
@@ -194,9 +199,11 @@ function ActivityDetailContent({
     // off session_log rows that both flows write identically.
     const llmGraded = activity.gradingKind === 'llm-graded';
 
+    const assembledQuizId = activity.assembledQuizId ?? undefined;
+
     Promise.all([
       llmGraded
-        ? loadCurrentLlmSession(token, activity.activityType).then((result) =>
+        ? loadCurrentLlmSession(token, activity.activityType, assembledQuizId).then((result) =>
             result.ok
               ? {
                   ok: true as const,
@@ -208,7 +215,7 @@ function ActivityDetailContent({
                 }
               : result,
           )
-        : loadCurrentSession(token, activity.activityType).then((result) =>
+        : loadCurrentSession(token, activity.activityType, assembledQuizId).then((result) =>
             result.ok
               ? {
                   ok: true as const,
@@ -230,7 +237,7 @@ function ActivityDetailContent({
       // pop in. See loadCompletedAttempts's own docblock (lib/sessionClient.ts) for the general
       // cache-first/onRevalidate mechanism — still the right choice for callers like
       // app/activities/page.tsx's cards, just not for a control whose shape depends on this data.
-      loadCompletedAttempts(token, profile.user_id, activity.activityType, { forceRefresh: true }),
+      loadCompletedAttempts(token, profile.user_id, activity.activityType, { forceRefresh: true, assembledQuizId }),
     ]).then(([currentResult, completed]) => {
       if (cancelled) return;
       if (currentResult.ok) setCurrent(currentResult.data);
@@ -288,6 +295,11 @@ function ActivityDetailContent({
     );
   }
 
+  // GitHub #583: appended to every internal navigation into/back from the play page, so the quiz
+  // context a student arrived with survives the round trip instead of silently falling back to
+  // the first-match quiz on return.
+  const quizQuery = activity?.assembledQuizId ? `?quiz=${encodeURIComponent(activity.assembledQuizId)}` : '';
+
   // Starts at selectedLevel when one has been picked via LevelReplaySelector, otherwise the
   // server's auto-advance level (undefined difficultyLevel) — Start is the only thing that ever
   // triggers the actual POST; selecting a level just sets what Start will use.
@@ -297,17 +309,18 @@ function ActivityDetailContent({
     setStarting(true);
     setError(null);
 
+    const startOptions = { difficultyLevel: selectedLevel ?? undefined, assembledQuizId: activity!.assembledQuizId ?? undefined };
     const result =
       activity!.gradingKind === 'llm-graded'
-        ? await startOrResumeLlmSession(token, activity!.activityType, { difficultyLevel: selectedLevel ?? undefined })
-        : await startSession(token, activity!.activityType, { difficultyLevel: selectedLevel ?? undefined });
+        ? await startOrResumeLlmSession(token, activity!.activityType, startOptions)
+        : await startSession(token, activity!.activityType, startOptions);
 
     if (result.ok) {
       // A fresh (or resumed) session now shows up in the activity log too.
       if (profile?.user_id) {
         void loadActivityLog(token, profile.user_id, { forceRefresh: true });
       }
-      router.push(`/activities/${activity!.slug}/play`);
+      router.push(`/activities/${activity!.slug}/play${quizQuery}`);
       return;
     }
 
@@ -326,7 +339,7 @@ function ActivityDetailContent({
   function handleResume() {
     // The whole point of a running session is that it is already in hand server-side —
     // resuming is just navigating there, not another start/resume network round trip.
-    router.push(`/activities/${activity!.slug}/play`);
+    router.push(`/activities/${activity!.slug}/play${quizQuery}`);
   }
 
   async function handleAbandon() {

--- a/app/activities/[slug]/play/page.tsx
+++ b/app/activities/[slug]/play/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { AppShell } from "../../../../components/AppShell";
 import { FeedbackCard } from "../../../../components/FeedbackCard";
 import { QuestionCard } from "../../../../components/QuestionCard";
@@ -42,15 +42,20 @@ type AnswerOutcome = {
  */
 function QuizPlayView({
   params,
+  assembledQuizId,
 }: {
   params: { slug: string };
+  /** GitHub #583: the ?quiz= the wrapper below already parsed — passed down rather than a second
+   *  useSearchParams() call, since this component's own useResolvedActivity call is otherwise the
+   *  only reason it needs to know about the URL at all (see this function's own header comment). */
+  assembledQuizId?: string;
 }) {
   const router = useRouter();
   // Also redirects an instructor account away (GitHub #82) — this page is the "quiz
   // durchführen" flow itself, exactly what an instructor must not be able to reach.
   const { token, profile, loading, authorized } = useRequireRole("student");
   const { refreshScore } = useUser();
-  const { activity, status: activityStatus } = useResolvedActivity(token, params.slug);
+  const { activity, status: activityStatus } = useResolvedActivity(token, params.slug, assembledQuizId);
 
   const [session, setSession] = useState<CurrentSessionResult | null>(null);
   const [nextPosition, setNextPosition] = useState<number | null>(null);
@@ -79,10 +84,14 @@ function QuizPlayView({
    * without any explicit reload: syncFromServer's identity changes whenever token does, and
    * UserProvider refreshes the token on its own 45-minute timer.
    */
+  // GitHub #583: appended to every internal navigation back to the detail page, so the quiz
+  // context this session was resolved through survives the round trip.
+  const quizQuery = activity?.assembledQuizId ? `?quiz=${encodeURIComponent(activity.assembledQuizId)}` : '';
+
   const syncFromServer = useCallback(async () => {
     if (!token || !activity || showSummary) return;
 
-    const result = await loadCurrentSession(token, activity.activityType);
+    const result = await loadCurrentSession(token, activity.activityType, activity.assembledQuizId ?? undefined);
 
     if (!result.ok) {
       // The session expired mid-play: back to login, not a dead-end error screen.
@@ -96,7 +105,7 @@ function QuizPlayView({
 
     // Nothing running: the student got here without starting, or already finished.
     if (!result.data.session) {
-      router.replace(`/activities/${activity.slug}`);
+      router.replace(`/activities/${activity.slug}${quizQuery}`);
       return;
     }
 
@@ -105,7 +114,7 @@ function QuizPlayView({
     setCumulativeScore(result.data.session.cumulative_score);
     setAnsweredCount(result.data.answers.length);
     setOutcome(null);
-  }, [token, activity, router, showSummary]);
+  }, [token, activity, router, showSummary, quizQuery]);
 
   useEffect(() => {
     void syncFromServer();
@@ -309,6 +318,7 @@ function QuizPlayView({
         }),
         loadCompletedAttempts(token, profile.user_id, activity!.activityType, {
           forceRefresh: true,
+          assembledQuizId: activity!.assembledQuizId ?? undefined,
         }),
       ]);
     }
@@ -318,7 +328,7 @@ function QuizPlayView({
     // caches above, not awaited: nothing on this page reads it, only the leaderboard page and
     // preview do, on their own next mount) rather than a targeted, per-course forceRefresh.
     clearCachedLeaderboard();
-    router.push(`/activities/${activity!.slug}`);
+    router.push(`/activities/${activity!.slug}${quizQuery}`);
   }
 
   // Once the session is complete, currentQuestion legitimately becomes undefined (nextPosition
@@ -440,14 +450,21 @@ function QuizPlayView({
  * slugs useResolvedActivity answers synchronously from the static ACTIVITIES array at zero network
  * cost, and paying one extra fetch in the custom-catalog case is cheaper than threading the
  * resolved activity through a body this issue is otherwise not touching at all.
+ *
+ * Split out because useSearchParams() (GitHub #583's ?quiz=) forces the nearest Suspense boundary
+ * to render client-side — without one, `npm run build` fails prerendering this route, the same
+ * reason app/activities/[slug]/page.tsx is split into a Content component this way.
  */
-export default function PlayActivityPage({
+function PlayActivityContent({
   params,
 }: {
   params: { slug: string };
 }) {
   const { token, loading, authorized } = useRequireRole("student");
-  const { activity, status: activityStatus } = useResolvedActivity(token, params.slug);
+  // GitHub #583: the ?quiz= a student followed from a course page card, or carried over from the
+  // detail page's own navigation into here (see QuizPlayView/LlmPlayView's quizQuery).
+  const quizParam = useSearchParams().get('quiz') ?? undefined;
+  const { activity, status: activityStatus } = useResolvedActivity(token, params.slug, quizParam);
 
   if (loading || !authorized) return null;
   if (activityStatus === 'loading') return null;
@@ -470,6 +487,18 @@ export default function PlayActivityPage({
   return activity.gradingKind === 'llm-graded' ? (
     <LlmPlayView activity={activity} />
   ) : (
-    <QuizPlayView params={params} />
+    <QuizPlayView params={params} assembledQuizId={quizParam} />
+  );
+}
+
+export default function PlayActivityPage({
+  params,
+}: {
+  params: { slug: string };
+}) {
+  return (
+    <Suspense fallback={null}>
+      <PlayActivityContent params={params} />
+    </Suspense>
   );
 }

--- a/app/api/activities/[activityType]/llm/sessions/current/route.ts
+++ b/app/api/activities/[activityType]/llm/sessions/current/route.ts
@@ -31,6 +31,9 @@ export async function GET(request: Request, { params }: { params: { activityType
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
 
   const { activityType } = params;
+  // GitHub #583: optional — scopes the lookup to a specific quiz when the caller knows one, so
+  // two quizzes composed from the same catalog don't resume each other's session.
+  const assembledQuizId = new URL(request.url).searchParams.get('assembledQuizId') ?? undefined;
 
   // Guarded so a mistyped or MCQ activityType is a clear error rather than a permanent, silent
   // "nothing in progress" — which is what the empty answer below would otherwise look like.
@@ -47,7 +50,7 @@ export async function GET(request: Request, { params }: { params: { activityType
   const { data: { user }, error: authError } = await supabase.auth.getUser(token);
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
-  const { session, error: sessionError } = await findInProgressSession(supabase, user.id, activityType);
+  const { session, error: sessionError } = await findInProgressSession(supabase, user.id, activityType, assembledQuizId);
   if (sessionError) return Response.json({ error: sessionError.message }, { status: 500 });
 
   // Nothing in progress is a normal answer, not a 404 — the client offers Start instead of

--- a/app/api/activities/[activityType]/llm/sessions/route.ts
+++ b/app/api/activities/[activityType]/llm/sessions/route.ts
@@ -54,11 +54,17 @@ export async function POST(request: Request, { params }: { params: { activityTyp
     body = null;
   }
 
-  const { difficultyLevel } = (body ?? {}) as { difficultyLevel?: unknown };
+  const { difficultyLevel, assembledQuizId } = (body ?? {}) as { difficultyLevel?: unknown; assembledQuizId?: unknown };
   const hasReplayLevel = difficultyLevel !== undefined && difficultyLevel !== null;
 
   if (hasReplayLevel && (typeof difficultyLevel !== 'number' || !Number.isInteger(difficultyLevel) || difficultyLevel < 1)) {
     return Response.json({ error: 'difficultyLevel must be a positive integer.' }, { status: 400 });
+  }
+
+  // GitHub #583: optional, same as POST /api/sessions — disambiguates which of possibly several
+  // assembled quizzes composing this catalog granted access.
+  if (assembledQuizId !== undefined && assembledQuizId !== null && typeof assembledQuizId !== 'string') {
+    return Response.json({ error: 'assembledQuizId must be a string.' }, { status: 400 });
   }
 
   const supabase = getSupabaseClient();
@@ -79,17 +85,24 @@ export async function POST(request: Request, { params }: { params: { activityTyp
   const { data: { user }, error: authError } = await supabase.auth.getUser(token);
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
-  const { link: accessLink, error: accessError } = await getAccessibleCourseForActivity(supabase, activityType, user.id);
+  const { link: accessLink, error: accessError } = await getAccessibleCourseForActivity(supabase, activityType, user.id, {
+    assembledQuizId: assembledQuizId as string | undefined,
+  });
   if (accessError) return Response.json({ error: accessError.message }, { status: 500 });
   if (!accessLink) {
     return Response.json({ error: 'You are not enrolled in a course that offers this activity.' }, { status: 403 });
   }
 
-  const existing = await findInProgressSession(supabase, user.id, activityType);
+  const existing = await findInProgressSession(supabase, user.id, activityType, accessLink.assembledQuizId);
   if (existing.error) return Response.json({ error: existing.error.message }, { status: 500 });
   if (existing.session) return respondWithSession(supabase, existing.session, { created: false });
 
-  const { startLevel: allowedLevel, error: levelError } = await findStartDifficultyLevel(supabase, user.id, activityType);
+  const { startLevel: allowedLevel, error: levelError } = await findStartDifficultyLevel(
+    supabase,
+    user.id,
+    activityType,
+    accessLink.assembledQuizId,
+  );
   if (levelError) return Response.json({ error: levelError.message }, { status: 500 });
 
   let startLevel: number;
@@ -138,6 +151,7 @@ export async function POST(request: Request, { params }: { params: { activityTyp
       session_id: sessionId,
       user_id: user.id,
       activity_type: activityType,
+      assembled_quiz_id: accessLink.assembledQuizId,
       difficulty_level: startLevel,
       status: 'in-progress',
       cumulative_score: 0,
@@ -150,7 +164,7 @@ export async function POST(request: Request, { params }: { params: { activityTyp
   if (insertError || !session) {
     // A parallel request won uq_session_log_one_active — return that session instead of failing.
     if (insertError?.code === UNIQUE_VIOLATION) {
-      const raced = await findInProgressSession(supabase, user.id, activityType);
+      const raced = await findInProgressSession(supabase, user.id, activityType, accessLink.assembledQuizId);
       if (raced.session) return respondWithSession(supabase, raced.session, { created: false });
     }
     // session_log.user_id references "user"(user_id): authenticated but no profile row yet.

--- a/app/api/activities/[activityType]/route.ts
+++ b/app/api/activities/[activityType]/route.ts
@@ -27,10 +27,16 @@ function getToken(request: Request): string | null {
  * assembled_quiz has no column for) — do not source name/description from it, that's the bug this
  * route used to have.
  *
+ * GitHub #583: an optional ?assembledQuizId= disambiguates which of possibly several assembled
+ * quizzes composing this catalog the caller means (the ?quiz= a student followed from a course
+ * page card) — passed straight through to getAccessibleCourseForActivity, which 403s if it names
+ * a quiz that doesn't actually grant access, the same as an unrecognized one would. Omitted ->
+ * today's first-match fallback, unchanged for a bare/bookmarked link.
+ *
  * - 401 missing/invalid bearer token
  * - 404 activityType matches no catalog
- * - 403 caller has no course granting access to this activity
- * - 200 { activity: { activityType, name, description, gradingKind, courseId, courseName } }
+ * - 403 caller has no course granting access to this activity (or the given assembledQuizId doesn't)
+ * - 200 { activity: { activityType, name, description, gradingKind, courseId, courseName, assembledQuizId } }
  * - 500 Supabase not configured, or a query fails
  */
 export async function GET(request: Request, { params }: { params: { activityType: string } }) {
@@ -44,12 +50,13 @@ export async function GET(request: Request, { params }: { params: { activityType
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
   const { activityType } = params;
+  const assembledQuizId = new URL(request.url).searchParams.get('assembledQuizId') ?? undefined;
 
   const { quiz, error: quizError } = await getQuizByActivityType(supabase, activityType);
   if (quizError) return Response.json({ error: quizError.message }, { status: 500 });
   if (!quiz) return Response.json({ error: 'Activity not found.' }, { status: 404 });
 
-  const { link, error: linkError } = await getAccessibleCourseForActivity(supabase, activityType, user.id);
+  const { link, error: linkError } = await getAccessibleCourseForActivity(supabase, activityType, user.id, { assembledQuizId });
   if (linkError) return Response.json({ error: linkError.message }, { status: 500 });
   if (!link) return new Response(null, { status: 403 });
 
@@ -65,6 +72,7 @@ export async function GET(request: Request, { params }: { params: { activityType
         gradingKind: quiz.gradingKind,
         courseId: link.courseId,
         courseName: link.courseName,
+        assembledQuizId: link.assembledQuizId,
       },
     },
     { status: 200 },

--- a/app/api/activities/route.ts
+++ b/app/api/activities/route.ts
@@ -29,9 +29,14 @@ function getToken(request: Request): string | null {
  * collapse to the same outcome, the same reasoning checkActivityAccess documents for its own
  * 'forbidden' status.
  *
+ * GitHub #583: dedupeByQuiz: true, so two assembled quizzes composed from the same catalog for
+ * the same course both appear here as distinct entries (each carrying its own assembledQuizId)
+ * rather than collapsing to one — previously a student enrolled in a course with two such quizzes
+ * only ever saw one of them.
+ *
  * - 401 missing/invalid bearer token
  * - 403 courseId given but the caller isn't enrolled in it (no body)
- * - 200 { activities: [{ activityType, name, description, courseId, courseName }] }
+ * - 200 { activities: [{ activityType, name, description, courseId, courseName, assembledQuizId }] }
  * - 500 Supabase not configured, or either query fails
  */
 export async function GET(request: Request) {
@@ -56,7 +61,11 @@ export async function GET(request: Request) {
     scopedCourseIds = [requestedCourseId];
   }
 
-  const { activities, error } = await listActivityTypesForCourses(supabase, scopedCourseIds);
+  // GitHub #583: dedupeByQuiz so two quizzes composed from the same catalog both surface here as
+  // distinct entries instead of collapsing to one — the direct fix for "only one of two quizzes
+  // shows to students". Other callers of listActivityTypesForCourses (loadAvailableTitleLadders,
+  // computeCourseLeaderboard) do not opt in, since titles stay catalog-scoped by design.
+  const { activities, error } = await listActivityTypesForCourses(supabase, scopedCourseIds, { dedupeByQuiz: true });
   if (error || !activities) {
     return Response.json({ error: error?.message ?? 'Could not load activities.' }, { status: 500 });
   }

--- a/app/api/sessions/completed/route.ts
+++ b/app/api/sessions/completed/route.ts
@@ -29,10 +29,15 @@ export async function GET(request: Request) {
   const token = getToken(request);
   if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const activityType = new URL(request.url).searchParams.get('activityType');
+  const searchParams = new URL(request.url).searchParams;
+  const activityType = searchParams.get('activityType');
   // Narrows activityType to string for the rest of the function — isActivityType's async check
   // below can no longer double as a type predicate the way the old synchronous version did.
   if (activityType === null) return Response.json({ error: 'Unknown activity type.' }, { status: 400 });
+
+  // GitHub #583: optional — scopes history to one specific quiz when the caller knows it, so two
+  // quizzes sharing a catalog don't show each other's attempts.
+  const assembledQuizId = searchParams.get('assembledQuizId') ?? undefined;
 
   const supabase = getSupabaseClient();
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
@@ -48,7 +53,7 @@ export async function GET(request: Request) {
   const { data: { user }, error: authError } = await supabase.auth.getUser(token);
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
-  const { attempts, error } = await loadCompletedAttempts(supabase, user.id, activityType);
+  const { attempts, error } = await loadCompletedAttempts(supabase, user.id, activityType, assembledQuizId);
   if (error) return Response.json({ error: error.message }, { status: 500 });
 
   return Response.json({ attempts }, { status: 200 });

--- a/app/api/sessions/current/route.ts
+++ b/app/api/sessions/current/route.ts
@@ -27,10 +27,15 @@ export async function GET(request: Request) {
   const token = getToken(request);
   if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const activityType = new URL(request.url).searchParams.get('activityType');
+  const searchParams = new URL(request.url).searchParams;
+  const activityType = searchParams.get('activityType');
   // Narrows activityType to string for the rest of the function — isActivityType's async check
   // below can no longer double as a type predicate the way the old synchronous version did.
   if (activityType === null) return Response.json({ error: 'Unknown activity type.' }, { status: 400 });
+
+  // GitHub #583: optional — scopes the lookup to a specific quiz when the caller knows one, so
+  // two quizzes composed from the same catalog don't resume each other's session.
+  const assembledQuizId = searchParams.get('assembledQuizId') ?? undefined;
 
   const supabase = getSupabaseClient();
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
@@ -45,7 +50,7 @@ export async function GET(request: Request) {
   const { data: { user }, error: authError } = await supabase.auth.getUser(token);
   if (authError || !user) return Response.json({ error: 'Invalid or expired token.' }, { status: 401 });
 
-  const { session, error: sessionError } = await findInProgressSession(supabase, user.id, activityType);
+  const { session, error: sessionError } = await findInProgressSession(supabase, user.id, activityType, assembledQuizId);
   if (sessionError) return Response.json({ error: sessionError.message }, { status: 500 });
 
   // Nothing in progress is a normal answer, not a 404: the client offers "start" instead of

--- a/app/api/sessions/in-progress/route.ts
+++ b/app/api/sessions/in-progress/route.ts
@@ -35,7 +35,11 @@ export async function GET(request: Request) {
   const token = getToken(request);
   if (!token) return Response.json({ error: 'Unauthorized' }, { status: 401 });
 
-  const activityType = new URL(request.url).searchParams.get('activityType');
+  const searchParams = new URL(request.url).searchParams;
+  const activityType = searchParams.get('activityType');
+  // GitHub #583: only meaningful alongside activityType — same "narrowed" semantics as that
+  // param — scopes the check to one specific quiz instead of any quiz on the catalog.
+  const assembledQuizId = searchParams.get('assembledQuizId');
 
   const supabase = getSupabaseClient();
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
@@ -68,6 +72,7 @@ export async function GET(request: Request) {
     .eq('status', 'in-progress');
 
   if (activityType !== null) query = query.eq('activity.activity_type', activityType);
+  if (assembledQuizId !== null) query = query.eq('assembled_quiz_id', assembledQuizId);
 
   const { data: rows, error } = await query.order('started_at', { ascending: false });
 

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -130,13 +130,25 @@ export async function POST(request: Request) {
     return Response.json({ error: 'Invalid JSON body.' }, { status: 400 });
   }
 
-  const { activityType, difficultyLevel } = (body ?? {}) as { activityType?: unknown; difficultyLevel?: unknown };
+  const { activityType, difficultyLevel, assembledQuizId } = (body ?? {}) as {
+    activityType?: unknown;
+    difficultyLevel?: unknown;
+    assembledQuizId?: unknown;
+  };
 
   // AC 4: unknown activity type is a client error. Narrows activityType to string for the rest
   // of the function — isActivityType's async check below can no longer double as a type
   // predicate the way the old synchronous version did.
   if (typeof activityType !== 'string') {
     return Response.json({ error: 'Unknown activity type.' }, { status: 400 });
+  }
+
+  // GitHub #583: optional — a client that already knows which quiz it means (the ?quiz= a
+  // student followed from a course page card) disambiguates which of possibly several assembled
+  // quizzes composing this catalog granted access. Omitted -> today's first-match fallback,
+  // unchanged for any caller that doesn't send it yet.
+  if (assembledQuizId !== undefined && typeof assembledQuizId !== 'string') {
+    return Response.json({ error: 'assembledQuizId must be a string.' }, { status: 400 });
   }
 
   // Replay override (optional): a student may ask to start at a specific level instead of the
@@ -167,21 +179,29 @@ export async function POST(request: Request) {
   // one needs the caller's identity. Resolved via the richer link (not the plain
   // checkActivityAccess wrapper) because the draw below needs assembledQuizId to know which
   // quiz's exclusions/hand-picks govern this catalog's pool for this caller.
-  const { link: accessLink, error: accessError } = await getAccessibleCourseForActivity(supabase, activityType, user.id);
+  const { link: accessLink, error: accessError } = await getAccessibleCourseForActivity(supabase, activityType, user.id, {
+    assembledQuizId: assembledQuizId as string | undefined,
+  });
   if (accessError) return Response.json({ error: accessError.message }, { status: 500 });
   if (!accessLink) {
     return Response.json({ error: 'You are not enrolled in a course that offers this activity.' }, { status: 403 });
   }
 
-  const existing = await findInProgressSession(supabase, user.id, activityType);
+  const existing = await findInProgressSession(supabase, user.id, activityType, accessLink.assembledQuizId);
   if (existing.error) return Response.json({ error: existing.error.message }, { status: 500 });
   if (existing.session) return respondWithSession(supabase, existing.session, { created: false });
 
   // The student's next unpassed level for this activity: one past the highest difficulty_level
   // they've passed, capped at MAX_DIFFICULTY_LEVEL. No prior passed session -> level 1. This is
   // also the ceiling a replay override may request — any already-passed level, or this exact
-  // auto-advance level, but never past it.
-  const { startLevel: allowedLevel, error: levelError } = await findStartDifficultyLevel(supabase, user.id, activityType);
+  // auto-advance level, but never past it. GitHub #583: scoped to the granting quiz when known,
+  // so progression is per-quiz rather than shared across every quiz on this catalog.
+  const { startLevel: allowedLevel, error: levelError } = await findStartDifficultyLevel(
+    supabase,
+    user.id,
+    activityType,
+    accessLink.assembledQuizId,
+  );
   if (levelError) return Response.json({ error: levelError.message }, { status: 500 });
 
   let startLevel: number;
@@ -244,12 +264,15 @@ export async function POST(request: Request) {
   const sessionId = crypto.randomUUID();
 
   // AC 2: defaults are set by the server; the client cannot influence score, status or passed.
+  // assembled_quiz_id (GitHub #583) is always accessLink's resolved id, never the raw request
+  // body value — same "server derives it, client only hints" pattern as startLevel above.
   const { data: session, error: insertError } = await supabase
     .from('session_log')
     .insert({
       session_id: sessionId,
       user_id: user.id,
       activity_type: activityType,
+      assembled_quiz_id: accessLink.assembledQuizId,
       difficulty_level: startLevel,
       status: 'in-progress',
       cumulative_score: 0,
@@ -262,7 +285,7 @@ export async function POST(request: Request) {
   if (insertError || !session) {
     // A parallel request won the unique index — return that session instead of failing.
     if (insertError?.code === UNIQUE_VIOLATION) {
-      const raced = await findInProgressSession(supabase, user.id, activityType);
+      const raced = await findInProgressSession(supabase, user.id, activityType, accessLink.assembledQuizId);
       if (raced.session) return respondWithSession(supabase, raced.session, { created: false });
     }
     // session_log.user_id references "user"(user_id): the student is authenticated but has

--- a/app/courses/[id]/page.tsx
+++ b/app/courses/[id]/page.tsx
@@ -26,6 +26,15 @@ type CardData = {
   best: { score: number; maxScore: number } | null;
 };
 
+/**
+ * GitHub #583: two quizzes composed from the same catalog share an activityType, so a lookup keyed
+ * on activityType alone would collide — the id used everywhere a running/completed session needs
+ * to be matched back to one specific card.
+ */
+function runningKey(activityType: string, assembledQuizId: string | null | undefined): string {
+  return `${activityType}:${assembledQuizId ?? 'none'}`;
+}
+
 /** Same lookup as app/activities/page.tsx used to have — see that file's git history. */
 function titleEntryFor(titles: StudentTitle[] | null, activityType: string | null): StudentTitle | null {
   if (!titles || !activityType) return null;
@@ -106,12 +115,21 @@ export default function CourseQuizzesPage({ params }: { params: { id: string } }
         return;
       }
 
-      const resolvedActivities: ActivityDefinition[] = discoveryResult.data.activities.map(
-        (entry) => getActivityByType(entry.activityType) ?? buildCustomActivityDefinition(entry),
-      );
+      // GitHub #583: attach each entry's own assembledQuizId regardless of which path produced
+      // the base definition — getActivityByType's built-in result carries none of its own (there
+      // is no DB row behind a static entry), and two quizzes sharing a catalog must not collapse
+      // into indistinguishable cards.
+      const resolvedActivities: ActivityDefinition[] = discoveryResult.data.activities.map((entry) => {
+        const base = getActivityByType(entry.activityType) ?? buildCustomActivityDefinition(entry);
+        return { ...base, assembledQuizId: entry.assembledQuizId };
+      });
 
       const attemptsPromises = profile
-        ? resolvedActivities.map((activity) => loadCompletedAttempts(token, profile.user_id, activity.activityType))
+        ? resolvedActivities.map((activity) =>
+            loadCompletedAttempts(token, profile.user_id, activity.activityType, {
+              assembledQuizId: activity.assembledQuizId ?? undefined,
+            }),
+          )
         : resolvedActivities.map(() => Promise.resolve({ ok: true as const, data: { attempts: [] } }));
 
       Promise.all([loadSessions(token, 'in-progress'), ...attemptsPromises]).then(([sessionsResult, ...attemptResults]) => {
@@ -123,13 +141,15 @@ export default function CourseQuizzesPage({ params }: { params: { id: string } }
           return;
         }
 
-        const runningByType = new Map(sessionsResult.data.sessions.map((session) => [session.activity_type, session]));
+        const runningByType = new Map(
+          sessionsResult.data.sessions.map((session) => [runningKey(session.activity_type, session.assembled_quiz_id), session]),
+        );
 
         const nextCards: CardData[] = resolvedActivities.map((activity, i) => {
           const attemptsResult = attemptResults[i];
           const attempts = attemptsResult.ok ? attemptsResult.data.attempts : [];
           const best = attempts.length === 0 ? null : attempts.reduce((b, a) => (a.score > b.score ? a : b), attempts[0]);
-          const running = runningByType.get(activity.activityType) ?? null;
+          const running = runningByType.get(runningKey(activity.activityType, activity.assembledQuizId)) ?? null;
           return {
             activity,
             activityType: activity.activityType,
@@ -241,7 +261,7 @@ export default function CourseQuizzesPage({ params }: { params: { id: string } }
 
                   return (
                     <ActivityCard
-                      key={card.activity.slug}
+                      key={runningKey(card.activity.slug, card.activity.assembledQuizId)}
                       activity={card.activity}
                       level={level}
                       title={earnedTitle(titleEntry)}

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -39,6 +39,10 @@ export type ActivityCardData = {
   slug: ActivitySlug;
   name: string;
   category: string;
+  /** GitHub #583: which assembled_quiz this card represents — see
+   *  lib/activityContent.ts's ActivityDefinition.assembledQuizId. Threaded onto the link so the
+   *  detail/play pages resolve the same specific quiz, not just "some quiz on this catalog". */
+  assembledQuizId: string | null;
 };
 
 export function CategoryIcon({ category }: { category: string }) {
@@ -83,12 +87,16 @@ export function ActivityCard({
 }) {
   const badgeBg = activity.category === 'Acceptance Criteria' || activity.category === 'Write Acceptance Criteria' ? 'bg-[#2DD4BF]/15' : 'bg-[#7C4DFF]/15';
 
+  // GitHub #583: quiz disambiguates two quizzes composed from the same catalog, so the detail/
+  // play pages resolve the exact one this card represents instead of an arbitrary first match.
+  const quizParam = activity.assembledQuizId ? `&quiz=${encodeURIComponent(activity.assembledQuizId)}` : '';
+
   return (
     <Link
       // The level query param lets the activity detail page (app/activities/[slug]/page.tsx)
       // render this exact level on its first paint instead of a hardcoded easy-level default
       // that then jumps once its own data finishes loading — see that page's initialLevel.
-      href={`/activities/${activity.slug}?level=${level}`}
+      href={`/activities/${activity.slug}?level=${level}${quizParam}`}
       className="flex flex-col gap-3 rounded-2xl border border-[#332b6b] bg-[#1b1642] p-5 text-left text-[#F3F1FF] transition hover:-translate-y-0.5 hover:border-[#8b5cf6] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[#2DD4BF]"
     >
       <span className={`flex h-11 w-11 items-center justify-center rounded-[10px] ${badgeBg}`}>

--- a/components/LlmPlayView.tsx
+++ b/components/LlmPlayView.tsx
@@ -62,10 +62,14 @@ export function LlmPlayView({ activity }: { activity: ActivityDefinition }) {
    * answers for an in-progress one), so re-syncing at that point would find session: null and
    * navigate away, discarding the summary before the student has dismissed it.
    */
+  // GitHub #583: appended to every internal navigation back to the detail page, so the quiz
+  // context this session was resolved through survives the round trip.
+  const quizQuery = activity.assembledQuizId ? `?quiz=${encodeURIComponent(activity.assembledQuizId)}` : '';
+
   const syncFromServer = useCallback(async () => {
     if (!token || showSummary) return;
 
-    const result = await loadCurrentLlmSession(token, activity.activityType);
+    const result = await loadCurrentLlmSession(token, activity.activityType, activity.assembledQuizId ?? undefined);
 
     if (!result.ok) {
       if (result.status === 401) {
@@ -78,7 +82,7 @@ export function LlmPlayView({ activity }: { activity: ActivityDefinition }) {
 
     // Nothing running: the student got here without starting, or already finished.
     if (!result.data.session) {
-      router.replace(`/activities/${activity.slug}`);
+      router.replace(`/activities/${activity.slug}${quizQuery}`);
       return;
     }
 
@@ -92,7 +96,7 @@ export function LlmPlayView({ activity }: { activity: ActivityDefinition }) {
     if (result.data.nextPosition === null) {
       setShowSummary(true);
     }
-  }, [token, router, showSummary, activity.activityType]);
+  }, [token, router, showSummary, activity.activityType, activity.assembledQuizId, activity.slug, quizQuery]);
 
   useEffect(() => {
     void syncFromServer();
@@ -235,7 +239,10 @@ export function LlmPlayView({ activity }: { activity: ActivityDefinition }) {
       // correctly; this brings the LLM-graded flow in line with the same call.
       await Promise.all([
         refreshScore(),
-        loadCompletedAttempts(token, profile.user_id, activity.activityType, { forceRefresh: true }),
+        loadCompletedAttempts(token, profile.user_id, activity.activityType, {
+          forceRefresh: true,
+          assembledQuizId: activity.assembledQuizId ?? undefined,
+        }),
         loadActivityLog(token, profile.user_id, { forceRefresh: true }),
       ]);
     }
@@ -244,7 +251,7 @@ export function LlmPlayView({ activity }: { activity: ActivityDefinition }) {
     // PlayActivityPage's own handleFinishSummary, which already clears this cache. Missing here
     // until now, so the leaderboard kept showing the pre-session rank after an LLM-graded pass.
     clearCachedLeaderboard();
-    router.push(`/activities/${activity.slug}`);
+    router.push(`/activities/${activity.slug}${quizQuery}`);
   }
 
   // Once the session is complete, currentStory legitimately becomes undefined (nextPosition is

--- a/lib/activityContent.ts
+++ b/lib/activityContent.ts
@@ -62,6 +62,15 @@ export type ActivityDefinition = {
   gradingKind: GradingKind;
   /** MCQ activities populate this; LLM-graded activities (e.g. WRITE_ACCEPTANCE_CRITERIA) omit it. */
   questionBank?: Question[];
+  /**
+   * GitHub #583: which assembled_quiz this definition was resolved through, when known — lets a
+   * caller disambiguate two quizzes composed from the same catalog (session start/resume,
+   * progress, completed-attempts). null for the three static entries above (there is no DB row to
+   * read synchronously for a built-in slug reached without a ?quiz= param) and for a custom
+   * catalog resolved without one; app/courses/[id]/page.tsx and useResolvedActivity are the two
+   * places that fill this in from a real assembled_quiz_id once one is known.
+   */
+  assembledQuizId: string | null;
 };
 
 function opt(id: string, text: string, score: number, correct: boolean, explanation: string): AnswerOption {
@@ -350,6 +359,7 @@ export const ACTIVITIES: ActivityDefinition[] = [
     titles: { 1: 'Story Apprentice', 2: 'Story Analyst', 3: 'Story Master' },
     gradingKind: 'mcq',
     questionBank: weakUserStories,
+    assembledQuizId: null,
   },
   {
     slug: 'weak-acceptance-criteria',
@@ -362,6 +372,7 @@ export const ACTIVITIES: ActivityDefinition[] = [
     titles: { 1: 'Criteria Novice', 2: 'Criteria Analyst', 3: 'Criteria Expert' },
     gradingKind: 'mcq',
     questionBank: weakAcceptanceCriteria,
+    assembledQuizId: null,
   },
   {
     slug: 'write-acceptance-criteria',
@@ -373,6 +384,7 @@ export const ACTIVITIES: ActivityDefinition[] = [
     category: 'Acceptance Criteria',
     titles: { 1: 'AC Beginner', 2: 'AC Practitioner', 3: 'AC Expert' },
     gradingKind: 'llm-graded',
+    assembledQuizId: null,
   },
 ];
 
@@ -404,6 +416,8 @@ export function buildCustomActivityDefinition(entry: {
   name: string;
   description: string | null;
   gradingKind: GradingKind;
+  /** GitHub #583: rides straight onto the built definition — see ActivityDefinition.assembledQuizId. */
+  assembledQuizId?: string | null;
 }): ActivityDefinition {
   const llmGraded = entry.gradingKind === 'llm-graded';
 
@@ -424,6 +438,7 @@ export function buildCustomActivityDefinition(entry: {
     category: 'Custom',
     titles: { 1: 'Level 1', 2: 'Level 2', 3: 'Level 3' },
     gradingKind: entry.gradingKind,
+    assembledQuizId: entry.assembledQuizId ?? null,
   };
 }
 

--- a/lib/activityCourseQueries.ts
+++ b/lib/activityCourseQueries.ts
@@ -59,24 +59,37 @@ type GrantingQuizRow = {
  * Two queries (enrolled course ids, then the quiz-catalog join filtered to them) rather than one
  * three-way join, matching the shape getCourseForActivityType + isEnrolledInAnyCourse used to
  * have as two separate calls — no round-trip regression, just a different second query.
+ *
+ * GitHub #583: options.assembledQuizId, when given, disambiguates which of possibly several
+ * granting quizzes was meant — two different assembled_quiz rows can compose the same catalog
+ * within the same course, in which case the plain `.limit(1)` below would otherwise pick an
+ * arbitrary one. Omitting it reproduces the exact old "first match" behavior, so every existing
+ * caller (checkActivityAccess, and any call site that doesn't yet know about a specific quiz) is
+ * unaffected.
  */
 export async function getAccessibleCourseForActivity(
   supabase: SupabaseClient,
   activityType: string,
   userId: string,
+  options: { assembledQuizId?: string } = {},
 ): Promise<{ link: ActivityCourseLink | null; error: { message: string } | null }> {
   const { courseIds, error: courseIdsError } = await getEnrolledCourseIds(supabase, userId);
   if (courseIdsError || !courseIds) return { link: null, error: courseIdsError };
   if (courseIds.length === 0) return { link: null, error: null };
 
-  const { data, error } = await supabase
+  let query = supabase
     .from('assembled_quiz_catalog')
     .select(
       'assembled_quiz:assembled_quiz_id!inner(assembled_quiz_id, course_id, quiz_name, description, questions_per_level, course:course_id(course_name)), catalog:activity_type(quiz_name, description)',
     )
     .eq('activity_type', activityType)
-    .in('assembled_quiz.course_id', courseIds)
-    .limit(1);
+    .in('assembled_quiz.course_id', courseIds);
+
+  if (options.assembledQuizId) {
+    query = query.eq('assembled_quiz.assembled_quiz_id', options.assembledQuizId);
+  }
+
+  const { data, error } = await query.limit(1);
 
   if (error) return { link: null, error };
 
@@ -130,12 +143,16 @@ export type CourseActivitySummary = {
   gradingKind: GradingKind;
   courseId: string;
   courseName: string;
+  /** GitHub #583: which assembled_quiz this entry came from — lets a caller that opts into
+   *  dedupeByQuiz (below) tell two quizzes composed from the same catalog apart. */
+  assembledQuizId: string;
 };
 
 type DiscoveryRow = {
   activity_type: string;
   catalog: { quiz_name: string; description: string | null; grading_kind: string } | null;
   assembled_quiz: {
+    assembled_quiz_id: string;
     course_id: string;
     quiz_name: string;
     description: string | null;
@@ -149,11 +166,16 @@ type DiscoveryRow = {
  * short-circuits to an empty list without a query, matching isEnrolledInAnyCourse's own
  * empty-input handling.
  *
- * A catalog composed into more than one quiz across the given courses appears only once here,
- * keyed by activityType — the caller's discovery list shows one card per catalog, not one per
- * quiz that happens to include it, so the first quiz/course found for a given catalog is what's
- * used to fill in every display field (courseId/courseName/name/description; access itself
- * doesn't depend on which one is picked, only that at least one exists).
+ * By default, a catalog composed into more than one quiz across the given courses appears only
+ * once here, keyed by activityType — one card per catalog, not one per quiz that happens to
+ * include it, so the first quiz/course found for a given catalog is what's used to fill in every
+ * display field. GitHub #583's options.dedupeByQuiz opts into keying by (activityType,
+ * assembledQuizId) instead, so two quizzes composed from the same catalog surface as two distinct
+ * entries — but this must stay opt-in, not the default: lib/titleQueries.ts's
+ * loadAvailableTitleLadders is also a caller, and mastery titles are catalog-scoped by design
+ * (confirmed decision) — it needs exactly one entry per catalog even when that catalog reaches a
+ * course through more than one quiz, or the mastery grid would show duplicate title-ladder rows
+ * for an already-working, unrelated scenario.
  *
  * name/description prefer the assembled quiz's own quiz_name/description — what the instructor
  * actually called it for this course — over the underlying catalog's, falling back to the
@@ -164,13 +186,14 @@ type DiscoveryRow = {
 export async function listActivityTypesForCourses(
   supabase: SupabaseClient,
   courseIds: string[],
+  options: { dedupeByQuiz?: boolean } = {},
 ): Promise<{ activities: CourseActivitySummary[] | null; error: { message: string } | null }> {
   if (courseIds.length === 0) return { activities: [], error: null };
 
   const { data, error } = await supabase
     .from('assembled_quiz_catalog')
     .select(
-      'activity_type, catalog:activity_type(quiz_name, description, grading_kind), assembled_quiz:assembled_quiz_id!inner(course_id, quiz_name, description, course:course_id(course_name))',
+      'activity_type, catalog:activity_type(quiz_name, description, grading_kind), assembled_quiz:assembled_quiz_id!inner(assembled_quiz_id, course_id, quiz_name, description, course:course_id(course_name))',
     )
     .in('assembled_quiz.course_id', courseIds);
 
@@ -180,8 +203,10 @@ export async function listActivityTypesForCourses(
   const activities: CourseActivitySummary[] = [];
 
   for (const row of (data ?? []) as unknown as DiscoveryRow[]) {
-    if (!row.assembled_quiz || seen.has(row.activity_type)) continue;
-    seen.add(row.activity_type);
+    if (!row.assembled_quiz) continue;
+    const dedupeKey = options.dedupeByQuiz ? `${row.activity_type}:${row.assembled_quiz.assembled_quiz_id}` : row.activity_type;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
 
     activities.push({
       activityType: row.activity_type,
@@ -192,6 +217,7 @@ export async function listActivityTypesForCourses(
       gradingKind: isGradingKind(row.catalog?.grading_kind) ? row.catalog.grading_kind : 'mcq',
       courseId: row.assembled_quiz.course_id,
       courseName: row.assembled_quiz.course?.course_name ?? 'Unknown course',
+      assembledQuizId: row.assembled_quiz.assembled_quiz_id,
     });
   }
 

--- a/lib/activityDiscoveryClient.ts
+++ b/lib/activityDiscoveryClient.ts
@@ -17,6 +17,9 @@ export type CourseActivity = {
   gradingKind: GradingKind;
   courseId: string;
   courseName: string;
+  /** GitHub #583: the specific assembled_quiz this entry came from — see
+   *  lib/activityContent.ts's ActivityDefinition.assembledQuizId for why this matters. */
+  assembledQuizId: string;
 };
 
 export type ApiResult<T> = { ok: true; data: T } | { ok: false; status: number; error: string };
@@ -62,7 +65,16 @@ export function loadAvailableActivities(
  * app/activities/[slug]/page.tsx and its play page use when the slug isn't one of the three
  * built-ins lib/activityContent.ts knows statically, i.e. a course-scoped custom catalog reached
  * directly by its activity_type key.
+ *
+ * GitHub #583: an optional assembledQuizId (the ?quiz= a student followed from a course page
+ * card) disambiguates which of possibly several assembled quizzes composing this catalog is
+ * meant; the route 403s if it names one that doesn't actually grant access.
  */
-export function loadActivityMeta(token: string, activityType: string): Promise<ApiResult<{ activity: CourseActivity }>> {
-  return request<{ activity: CourseActivity }>(`/api/activities/${encodeURIComponent(activityType)}`, token);
+export function loadActivityMeta(
+  token: string,
+  activityType: string,
+  assembledQuizId?: string,
+): Promise<ApiResult<{ activity: CourseActivity }>> {
+  const query = assembledQuizId ? `?assembledQuizId=${encodeURIComponent(assembledQuizId)}` : '';
+  return request<{ activity: CourseActivity }>(`/api/activities/${encodeURIComponent(activityType)}${query}`, token);
 }

--- a/lib/completedAttemptsStore.ts
+++ b/lib/completedAttemptsStore.ts
@@ -11,12 +11,20 @@ import type { CompletedAttempt } from './sessionClient';
 // instant (lib/dateTime.ts), so v1 entries hold the old zone-less form and would keep rendering
 // an hour or two off until something happened to force a refresh. This is what the version in
 // the key is for — the stale entries are simply never read again.
-const STORAGE_KEY = 'rc_completed_attempts_v2';
+//
+// Bumped to v3 (GitHub #583): cacheKey grew a third segment (assembledQuizId), so a v2 key
+// (`studentId:activityType`) would never match a v3 lookup (`studentId:activityType:none`) even
+// for the identical data — rather than leave v2 entries silently unreadable forever under the
+// same key, the whole store starts fresh, same as the v1 -> v2 migration.
+const STORAGE_KEY = 'rc_completed_attempts_v3';
 
 type CompletedAttemptsStore = Partial<Record<string, CompletedAttempt[]>>;
 
-function cacheKey(studentId: string, activityType: ActivityType): string {
-  return `${studentId}:${activityType}`;
+// GitHub #583: assembledQuizId disambiguates two quizzes sharing a catalog, so their completed-
+// attempt histories don't overwrite each other in the cache. Omitted -> the exact pre-#583 key,
+// for a caller that doesn't know a specific quiz (a bare/bookmarked link).
+function cacheKey(studentId: string, activityType: ActivityType, assembledQuizId?: string): string {
+  return `${studentId}:${activityType}:${assembledQuizId ?? 'none'}`;
 }
 
 function readStore(): CompletedAttemptsStore {
@@ -34,18 +42,23 @@ function writeStore(store: CompletedAttemptsStore) {
   window.localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
 }
 
-export function getCachedCompletedAttempts(studentId: string, activityType: ActivityType): CompletedAttempt[] | null {
+export function getCachedCompletedAttempts(
+  studentId: string,
+  activityType: ActivityType,
+  assembledQuizId?: string,
+): CompletedAttempt[] | null {
   const store = readStore();
-  return store[cacheKey(studentId, activityType)] ?? null;
+  return store[cacheKey(studentId, activityType, assembledQuizId)] ?? null;
 }
 
 export function setCachedCompletedAttempts(
   studentId: string,
   activityType: ActivityType,
   attempts: CompletedAttempt[],
+  assembledQuizId?: string,
 ): void {
   const store = readStore();
-  store[cacheKey(studentId, activityType)] = attempts;
+  store[cacheKey(studentId, activityType, assembledQuizId)] = attempts;
   writeStore(store);
 }
 

--- a/lib/leaderboardQueries.ts
+++ b/lib/leaderboardQueries.ts
@@ -156,7 +156,7 @@ export async function computeCourseLeaderboard(
 
   const { data: sessionData, error: sessionError } = await supabase
     .from('session_log')
-    .select('user_id, activity_type, difficulty_level, cumulative_score, ended_at, passed')
+    .select('user_id, activity_type, assembled_quiz_id, difficulty_level, cumulative_score, ended_at, passed')
     .in('user_id', studentIds)
     .eq('status', 'completed');
 
@@ -249,7 +249,7 @@ export async function computeGlobalLeaderboard(
 
   const { data: sessionData, error: sessionError } = await supabase
     .from('session_log')
-    .select('user_id, activity_type, difficulty_level, cumulative_score, ended_at, passed')
+    .select('user_id, activity_type, assembled_quiz_id, difficulty_level, cumulative_score, ended_at, passed')
     .in('user_id', studentIds)
     .eq('status', 'completed');
 

--- a/lib/llmActivityClient.ts
+++ b/lib/llmActivityClient.ts
@@ -105,9 +105,12 @@ export type CurrentLlmSessionResult = {
 export function startOrResumeLlmSession(
   token: string,
   activityType: string,
-  options: { difficultyLevel?: number } = {},
+  options: { difficultyLevel?: number; assembledQuizId?: string } = {},
 ): Promise<ApiResult<StartLlmSessionResult>> {
-  const body = options.difficultyLevel === undefined ? {} : { difficultyLevel: options.difficultyLevel };
+  const body = {
+    ...(options.difficultyLevel === undefined ? {} : { difficultyLevel: options.difficultyLevel }),
+    ...(options.assembledQuizId === undefined ? {} : { assembledQuizId: options.assembledQuizId }),
+  };
 
   return request<StartLlmSessionResult>(
     `/api/activities/${encodeURIComponent(activityType)}/llm/sessions`,
@@ -124,9 +127,11 @@ export function startOrResumeLlmSession(
 export function loadCurrentLlmSession(
   token: string,
   activityType: string,
+  assembledQuizId?: string,
 ): Promise<ApiResult<CurrentLlmSessionResult>> {
+  const query = assembledQuizId ? `?assembledQuizId=${encodeURIComponent(assembledQuizId)}` : '';
   return request<CurrentLlmSessionResult>(
-    `/api/activities/${encodeURIComponent(activityType)}/llm/sessions/current`,
+    `/api/activities/${encodeURIComponent(activityType)}/llm/sessions/current${query}`,
     { method: "GET" },
     token,
   );

--- a/lib/scoreQueries.ts
+++ b/lib/scoreQueries.ts
@@ -3,15 +3,27 @@
 
 import type { SupabaseClient } from './sessionQueries';
 
-export type SessionRow = { activity_type: string; difficulty_level: number; cumulative_score: number };
+export type SessionRow = {
+  activity_type: string;
+  difficulty_level: number;
+  cumulative_score: number;
+  /** GitHub #583: which assembled_quiz this session was started through, if known. */
+  assembled_quiz_id?: string | null;
+};
 
 /**
- * Sum of the best cumulative_score at each (activity_type, difficulty_level) pair across a set
- * of completed sessions — REQ-GAM-DL-1's "for each difficulty level, find the highest score out
- * of the completed sessions, add this score to the accumulated total".
+ * Sum of the best cumulative_score at each (assembled_quiz_id, activity_type, difficulty_level)
+ * key across a set of completed sessions — REQ-GAM-DL-1's "for each difficulty level, find the
+ * highest score out of the completed sessions, add this score to the accumulated total".
  *
  * Only a level's best attempt counts, so retaking one raises the total only by scoring higher;
- * a weaker retake changes nothing, and a level is never counted twice.
+ * a weaker retake changes nothing, and a level is never counted twice — but two different quizzes
+ * built on the same catalog now each get their own key (GitHub #583, confirmed product decision:
+ * completing both is two distinct assignments, not one deduplicated best-of), rather than
+ * silently sharing one (activity_type, difficulty_level) slot and having a weaker attempt on one
+ * quiz get overwritten by a stronger one on the other. Rows with no assembled_quiz_id (legacy, or
+ * a bare/bookmarked link with no quiz context) fall into one shared 'none' bucket per
+ * (activity_type, difficulty_level), matching the exact pre-#583 behavior for that population.
  *
  * Pulled out of computeStudentScore so lib/leaderboardQueries.ts's computeCourseLeaderboard can
  * reduce every enrolled student's rows through this exact function — the sidebar score pill and
@@ -21,7 +33,7 @@ export type SessionRow = { activity_type: string; difficulty_level: number; cumu
 export function sumBestScores(sessions: SessionRow[]): number {
   const bestByKey = new Map<string, number>();
   for (const row of sessions) {
-    const key = `${row.activity_type}:${row.difficulty_level}`;
+    const key = `${row.assembled_quiz_id ?? 'none'}:${row.activity_type}:${row.difficulty_level}`;
     const current = bestByKey.get(key) ?? 0;
     if (row.cumulative_score > current) bestByKey.set(key, row.cumulative_score);
   }
@@ -57,7 +69,7 @@ export function sumBestScores(sessions: SessionRow[]): number {
 export async function computeStudentScore(supabase: SupabaseClient, userId: string) {
   const { data, error } = await supabase
     .from('session_log')
-    .select('activity_type, difficulty_level, cumulative_score')
+    .select('activity_type, difficulty_level, cumulative_score, assembled_quiz_id')
     .eq('user_id', userId)
     .eq('status', 'completed');
 

--- a/lib/sessionClient.ts
+++ b/lib/sessionClient.ts
@@ -179,10 +179,18 @@ function patchJson(payload: unknown): RequestInit {
  * the student has already passed it (403 otherwise). Conditionally spread rather than always
  * sent, so an omitted level can't be confused with an explicit one server-side.
  */
-export function startSession(token: string, activityType: ActivityType, options: { difficultyLevel?: number } = {}) {
+export function startSession(
+  token: string,
+  activityType: ActivityType,
+  options: { difficultyLevel?: number; assembledQuizId?: string } = {},
+) {
   return request<StartSessionResult>(
     '/api/sessions',
-    postJson({ activityType, ...(options.difficultyLevel !== undefined ? { difficultyLevel: options.difficultyLevel } : {}) }),
+    postJson({
+      activityType,
+      ...(options.difficultyLevel !== undefined ? { difficultyLevel: options.difficultyLevel } : {}),
+      ...(options.assembledQuizId !== undefined ? { assembledQuizId: options.assembledQuizId } : {}),
+    }),
     token,
   );
 }
@@ -200,12 +208,11 @@ export function abandonSession(token: string, sessionId: string) {
  * The running session with its questions and the answers given so far.
  * session: null (with a 200) means nothing is in progress — not an error.
  */
-export function loadCurrentSession(token: string, activityType: ActivityType) {
-  return request<CurrentSessionResult>(
-    `/api/sessions/current?activityType=${encodeURIComponent(activityType)}`,
-    { method: 'GET' },
-    token,
-  );
+export function loadCurrentSession(token: string, activityType: ActivityType, assembledQuizId?: string) {
+  const query = assembledQuizId
+    ? `activityType=${encodeURIComponent(activityType)}&assembledQuizId=${encodeURIComponent(assembledQuizId)}`
+    : `activityType=${encodeURIComponent(activityType)}`;
+  return request<CurrentSessionResult>(`/api/sessions/current?${query}`, { method: 'GET' }, token);
 }
 
 /**
@@ -249,12 +256,12 @@ export function loadSessions(
   });
 }
 
-function fetchCompletedAttempts(token: string, studentId: string, activityType: ActivityType) {
-  return request<{ attempts: CompletedAttempt[] }>(
-    `/api/sessions/completed?activityType=${encodeURIComponent(activityType)}`,
-    { method: 'GET' },
-    token,
-  ).then((result) => {
+function fetchCompletedAttempts(token: string, studentId: string, activityType: ActivityType, assembledQuizId?: string) {
+  const query = assembledQuizId
+    ? `activityType=${encodeURIComponent(activityType)}&assembledQuizId=${encodeURIComponent(assembledQuizId)}`
+    : `activityType=${encodeURIComponent(activityType)}`;
+
+  return request<{ attempts: CompletedAttempt[] }>(`/api/sessions/completed?${query}`, { method: 'GET' }, token).then((result) => {
     if (!result.ok) return result;
 
     // completedAt comes from session_log.ended_at, which carries no zone — pinned to UTC before
@@ -264,7 +271,7 @@ function fetchCompletedAttempts(token: string, studentId: string, activityType: 
       completedAt: attempt.completedAt === null ? null : toInstant(attempt.completedAt),
     }));
 
-    setCachedCompletedAttempts(studentId, activityType, attempts);
+    setCachedCompletedAttempts(studentId, activityType, attempts, assembledQuizId);
     return { ok: true as const, data: { attempts } };
   });
 }
@@ -288,14 +295,14 @@ export function loadCompletedAttempts(
   token: string,
   studentId: string,
   activityType: ActivityType,
-  options: { forceRefresh?: boolean; onRevalidate?: (attempts: CompletedAttempt[]) => void } = {},
+  options: { forceRefresh?: boolean; onRevalidate?: (attempts: CompletedAttempt[]) => void; assembledQuizId?: string } = {},
 ) {
   if (!options.forceRefresh) {
-    const cached = getCachedCompletedAttempts(studentId, activityType);
+    const cached = getCachedCompletedAttempts(studentId, activityType, options.assembledQuizId);
     if (cached !== null) {
       if (options.onRevalidate) {
         const onRevalidate = options.onRevalidate;
-        fetchCompletedAttempts(token, studentId, activityType).then((result) => {
+        fetchCompletedAttempts(token, studentId, activityType, options.assembledQuizId).then((result) => {
           if (result.ok && JSON.stringify(result.data.attempts) !== JSON.stringify(cached)) {
             onRevalidate(result.data.attempts);
           }
@@ -305,7 +312,7 @@ export function loadCompletedAttempts(
     }
   }
 
-  return fetchCompletedAttempts(token, studentId, activityType);
+  return fetchCompletedAttempts(token, studentId, activityType, options.assembledQuizId);
 }
 
 function fetchStudentScore(token: string, studentId: string) {

--- a/lib/sessionQueries.ts
+++ b/lib/sessionQueries.ts
@@ -70,19 +70,30 @@ export type QuestionOption = {
   is_correct: boolean;
 };
 
-/** The student's running session for one activity type, or null. */
+/**
+ * The student's running session for one activity type, or null.
+ *
+ * GitHub #583: assembledQuizId, when given, scopes this to a session started through that
+ * specific quiz — two different quizzes composed from the same catalog otherwise collide on
+ * (user_id, activity_type) alone. Omitted -> the exact old behavior (matches any in-progress
+ * session for the catalog, regardless of quiz), for callers that don't know a specific quiz yet.
+ */
 export async function findInProgressSession(
   supabase: SupabaseClient,
   userId: string,
   activityType: string,
+  assembledQuizId?: string,
 ) {
-  const { data, error } = await supabase
+  let query = supabase
     .from('session_log')
     .select(SESSION_COLUMNS)
     .eq('user_id', userId)
     .eq('activity_type', activityType)
-    .eq('status', 'in-progress')
-    .maybeSingle();
+    .eq('status', 'in-progress');
+
+  if (assembledQuizId) query = query.eq('assembled_quiz_id', assembledQuizId);
+
+  const { data, error } = await query.maybeSingle();
 
   return { session: error ? null : data, error };
 }
@@ -95,17 +106,26 @@ export async function findInProgressSession(
  * This is also the ceiling POST /api/sessions's difficultyLevel replay override validates
  * against: a student may start at any level up to and including this one (any already-passed
  * level, or the one they'd auto-advance to anyway), never beyond it.
+ *
+ * GitHub #583: assembledQuizId, when given, makes difficulty progression per-quiz — a student's
+ * level on one quiz no longer has to match their level on a different quiz sharing the same
+ * catalog. highestPassedLevelByType itself is untouched; only the query feeding it is pre-filtered.
  */
 export async function findStartDifficultyLevel(
   supabase: SupabaseClient,
   userId: string,
   activityType: string,
+  assembledQuizId?: string,
 ) {
-  const { data, error } = await supabase
+  let query = supabase
     .from('session_log')
     .select('activity_type, difficulty_level, passed')
     .eq('user_id', userId)
     .eq('activity_type', activityType);
+
+  if (assembledQuizId) query = query.eq('assembled_quiz_id', assembledQuizId);
+
+  const { data, error } = await query;
 
   if (error) return { startLevel: null, error };
 
@@ -313,18 +333,27 @@ type CompletedAttemptRow = {
  * Sorted by ended_at, with started_at as a tiebreaker. Postgres orders DESC as NULLS FIRST,
  * so a completed row without ended_at would otherwise jump to the top — completeSession always
  * sets it, but the secondary key makes the order stable without relying on that.
+ *
+ * GitHub #583: assembledQuizId, when given, scopes the history to attempts made through that
+ * specific quiz — otherwise two quizzes sharing a catalog would show each other's history.
+ * Omitted -> the exact old behavior (every attempt at the catalog, regardless of quiz).
  */
 export async function loadCompletedAttempts(
   supabase: SupabaseClient,
   userId: string,
   activityType: string,
+  assembledQuizId?: string,
 ) {
-  const { data, error } = await supabase
+  let query = supabase
     .from('session_log')
     .select(COMPLETED_ATTEMPT_COLUMNS)
     .eq('user_id', userId)
     .eq('activity_type', activityType)
-    .eq('status', 'completed')
+    .eq('status', 'completed');
+
+  if (assembledQuizId) query = query.eq('assembled_quiz_id', assembledQuizId);
+
+  const { data, error } = await query
     .order('ended_at', { ascending: false })
     .order('started_at', { ascending: false });
 

--- a/lib/sessionRules.ts
+++ b/lib/sessionRules.ts
@@ -42,7 +42,7 @@ export const MAX_DIFFICULTY_LEVEL = 3;
 export const PASS_RATIO = 0.75;
 
 export const SESSION_COLUMNS =
-  'session_id, user_id, activity_type, difficulty_level, started_at, ended_at, status, cumulative_score, max_score, passed';
+  'session_id, user_id, activity_type, assembled_quiz_id, difficulty_level, started_at, ended_at, status, cumulative_score, max_score, passed';
 
 // Mirrors ck_session_log_status in supabase/schema.sql.
 export const SESSION_STATUSES = ['in-progress', 'completed', 'abandoned'] as const;

--- a/lib/sessionTypes.ts
+++ b/lib/sessionTypes.ts
@@ -14,6 +14,9 @@ export type SessionRecord = {
   session_id: string;
   user_id: string;
   activity_type: string;
+  /** Which assembled_quiz this session was started through — GitHub #583. Null for a bare/
+   *  bookmarked link with no quiz context, or a legacy row from before this column existed. */
+  assembled_quiz_id: string | null;
   difficulty_level: number;
   started_at: string;
   ended_at: string | null;

--- a/lib/unlockedLevelStore.ts
+++ b/lib/unlockedLevelStore.ts
@@ -19,20 +19,31 @@
 
 import { clearJsonStore, readJsonStore, writeJsonStore } from './clientStorage';
 
-const STORAGE_KEY = 'rc_seen_unlocked_level_v1';
+// Bumped to v2 (GitHub #583): the per-activity key grew a third segment (assembledQuizId), so a
+// v1 key (bare activityType) would never match a v2 lookup for the identical activity — rather
+// than leave v1 entries silently unreadable forever under the same key, the whole store starts
+// fresh, same as lib/completedAttemptsStore.ts's v2 -> v3 migration.
+const STORAGE_KEY = 'rc_seen_unlocked_level_v2';
 
-/** activityType -> the highest selectable level as of this student's last visit. */
+/** "activityType:assembledQuizId" -> the highest selectable level as of this student's last visit. */
 type SeenLevelMap = Partial<Record<string, number>>;
 
 type SeenUnlockedLevelStore = Partial<Record<string, SeenLevelMap>>; // studentId -> SeenLevelMap
+
+// GitHub #583: assembledQuizId disambiguates two quizzes sharing a catalog, so their unlock
+// animations don't share one baseline. Omitted -> the exact pre-#583 key, for a caller that
+// doesn't know a specific quiz (a bare/bookmarked link).
+function levelKey(activityType: string, assembledQuizId?: string | null): string {
+  return `${activityType}:${assembledQuizId ?? 'none'}`;
+}
 
 /**
  * The highest selectable level this device last recorded for the student on one activity, or null
  * if it has never recorded one — a first visit, or the store was cleared on logout.
  */
-export function getSeenUnlockedLevel(studentId: string, activityType: string): number | null {
+export function getSeenUnlockedLevel(studentId: string, activityType: string, assembledQuizId?: string | null): number | null {
   const store = readJsonStore<SeenUnlockedLevelStore>(STORAGE_KEY);
-  return store[studentId]?.[activityType] ?? null;
+  return store[studentId]?.[levelKey(activityType, assembledQuizId)] ?? null;
 }
 
 /**
@@ -40,9 +51,9 @@ export function getSeenUnlockedLevel(studentId: string, activityType: string): n
  * animate: recording unconditionally is what makes the diff idempotent, so a background
  * revalidation of the same data cannot re-trigger an animation that is already playing.
  */
-export function recordSeenUnlockedLevel(studentId: string, activityType: string, level: number): void {
+export function recordSeenUnlockedLevel(studentId: string, activityType: string, level: number, assembledQuizId?: string | null): void {
   const store = readJsonStore<SeenUnlockedLevelStore>(STORAGE_KEY);
-  store[studentId] = { ...store[studentId], [activityType]: level };
+  store[studentId] = { ...store[studentId], [levelKey(activityType, assembledQuizId)]: level };
   writeJsonStore(STORAGE_KEY, store);
 }
 

--- a/lib/useResolvedActivity.ts
+++ b/lib/useResolvedActivity.ts
@@ -24,16 +24,23 @@ export type ResolvedActivity = { activity: ActivityDefinition | null; status: Re
  * enforces the same course-enrollment gate POST /api/sessions does — a 403 there means the caller
  * genuinely cannot see this activity, not that it doesn't exist, and the two are surfaced
  * separately (status: 'forbidden' vs 'not-found') so the page can say which.
+ *
+ * GitHub #583: an optional assembledQuizId (the ?quiz= a student followed from a course page
+ * card) always triggers the network call, even for a static slug — a built-in activity is equally
+ * subject to two-quizzes-one-catalog, so its own zero-network-cost fast path is deliberately
+ * skipped in this case to validate+attach the specific quiz. Omitted -> today's behavior,
+ * unchanged (a bare/bookmarked link resolves the static entry with assembledQuizId: null).
  */
-export function useResolvedActivity(token: string | null, slug: string): ResolvedActivity {
+export function useResolvedActivity(token: string | null, slug: string, assembledQuizId?: string): ResolvedActivity {
   const staticActivity = getActivity(slug);
+  const skipFastPath = Boolean(staticActivity && assembledQuizId);
 
   const [dynamic, setDynamic] = useState<ResolvedActivity>(
-    staticActivity ? { activity: staticActivity, status: 'found' } : { activity: null, status: 'loading' },
+    staticActivity && !skipFastPath ? { activity: staticActivity, status: 'found' } : { activity: null, status: 'loading' },
   );
 
   useEffect(() => {
-    if (staticActivity) {
+    if (staticActivity && !skipFastPath) {
       setDynamic({ activity: staticActivity, status: 'found' });
       return;
     }
@@ -45,7 +52,7 @@ export function useResolvedActivity(token: string | null, slug: string): Resolve
     let cancelled = false;
     setDynamic({ activity: null, status: 'loading' });
 
-    loadActivityMeta(token, slug).then((result) => {
+    loadActivityMeta(token, slug, assembledQuizId).then((result) => {
       if (cancelled) return;
       if (result.ok) {
         setDynamic({ activity: buildCustomActivityDefinition(result.data.activity), status: 'found' });
@@ -61,7 +68,7 @@ export function useResolvedActivity(token: string | null, slug: string): Resolve
     return () => {
       cancelled = true;
     };
-  }, [token, slug, staticActivity]);
+  }, [token, slug, staticActivity, skipFastPath, assembledQuizId]);
 
   return dynamic;
 }

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -439,6 +439,15 @@ CREATE TABLE session_log (
     session_id        uuid        NOT NULL,
     user_id           uuid        NOT NULL,
     activity_type     varchar(50) NOT NULL,
+    -- Which assembled_quiz a session was started through, so two different quizzes composed from
+    -- the same catalog can be tracked as genuinely separate attempts instead of colliding on
+    -- (user_id, activity_type) alone. Nullable: a bare/bookmarked /activities/{activityType} link
+    -- with no ?quiz= context, or a legacy row from before this column existed, has no quiz to
+    -- attribute the session to and falls back to the same "first match" resolution
+    -- getAccessibleCourseForActivity already uses when no specific quiz is requested. ON DELETE
+    -- SET NULL (below) rather than CASCADE: deleting the quiz must not destroy attempt history,
+    -- same reasoning as every other assembled_quiz-owned table that protects student history.
+    assembled_quiz_id uuid,
     difficulty_level  int2        NOT NULL DEFAULT 1,
     started_at        timestamp   NOT NULL DEFAULT now(),
     ended_at          timestamp,
@@ -620,6 +629,8 @@ ALTER TABLE answered_question_log ADD CONSTRAINT fk_answered_question_log_sessio
 
 ALTER TABLE session_log ADD CONSTRAINT fk_session_log_user FOREIGN KEY (user_id) REFERENCES "user" (user_id);
 ALTER TABLE session_log ADD CONSTRAINT fk_session_log_activity_type FOREIGN KEY (activity_type) REFERENCES activity_type (activity_type);
+-- ON DELETE SET NULL: see session_log.assembled_quiz_id's own column comment above.
+ALTER TABLE session_log ADD CONSTRAINT fk_session_log_assembled_quiz FOREIGN KEY (assembled_quiz_id) REFERENCES assembled_quiz (assembled_quiz_id) ON DELETE SET NULL;
 
 ALTER TABLE session_to_question ADD CONSTRAINT fk_session_to_question_session FOREIGN KEY (session_id) REFERENCES session_log (session_id) ON DELETE CASCADE;
 ALTER TABLE session_to_question ADD CONSTRAINT fk_session_to_question_question FOREIGN KEY (question_id) REFERENCES question (question_id);
@@ -738,12 +749,26 @@ CREATE INDEX ix_quiz_excluded_user_story_quiz_id ON quiz_excluded_user_story (as
 ALTER TABLE assembled_quiz_extra_user_story ADD CONSTRAINT uq_assembled_quiz_extra_user_story UNIQUE (assembled_quiz_id, user_story_id);
 CREATE INDEX ix_assembled_quiz_extra_user_story_quiz_id ON assembled_quiz_extra_user_story (assembled_quiz_id);
 
--- At most one running session per student and activity type. This is what
--- makes POST /api/sessions idempotent: "start" and "resume" are the same
--- call, and two devices cannot build up independent state.
+-- At most one running session per student, activity type, and quiz. This is what makes
+-- POST /api/sessions idempotent: "start" and "resume" are the same call, and two devices cannot
+-- build up independent state. assembled_quiz_id is the newer dimension (two different quizzes
+-- composed from the same catalog now get independent "in progress" slots); activity_type is kept
+-- alongside it because a single quiz can compose more than one catalog (assembled_quiz_catalog is
+-- m:n), so assembled_quiz_id alone wouldn't be enough to tell two of that quiz's catalogs apart.
+--
+-- Indexed via COALESCE to a fixed sentinel rather than the raw nullable column: Postgres treats
+-- every NULL as distinct from every other NULL, so indexing assembled_quiz_id directly would stop
+-- protecting the one-active-session guarantee entirely for any session with no quiz context (a
+-- bare/bookmarked link, or any caller that hasn't started sending assembledQuizId yet) — two such
+-- sessions on the same catalog would no longer collide. The sentinel makes every "no quiz known"
+-- session contend for one shared slot per (user, activity_type), exactly as before this column
+-- existed.
 CREATE UNIQUE INDEX uq_session_log_one_active
-  ON session_log (user_id, activity_type)
+  ON session_log (user_id, COALESCE(assembled_quiz_id, '00000000-0000-0000-0000-000000000000'::uuid), activity_type)
   WHERE status = 'in-progress';
+
+-- The reverse lookup ("every session started through this quiz") and the FK's own scan.
+CREATE INDEX ix_session_log_assembled_quiz_id ON session_log (assembled_quiz_id);
 
 -- At most one active LLM config across all instructors (global, unlike
 -- uq_session_log_one_active which partitions by user_id/activity_type).
@@ -1314,14 +1339,18 @@ CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
 -- and unlink (DELETE FROM assembled_quiz_catalog ...) the mismatched rows by hand.
 
 -- Custom grading rubric, per catalog: activity_type.rating_prompt. An earlier iteration of this
--- feature put the rubric on assembled_quiz (per quiz) instead — if your database still has that
--- column (and session_log.assembled_quiz_id, added alongside it), drop both as part of this same
--- migration:
+-- feature put the rubric on assembled_quiz (per quiz) instead, along with a session_log.assembled_quiz_id
+-- column to resolve which quiz's rubric a submission should be graded against — if your database
+-- still has the rubric column, drop it as part of this same migration:
 --
 --   ALTER TABLE activity_type ADD COLUMN IF NOT EXISTS rating_prompt text;
 --   ALTER TABLE assembled_quiz DROP COLUMN IF EXISTS rating_prompt;
---   ALTER TABLE session_log DROP CONSTRAINT IF EXISTS fk_session_log_assembled_quiz;
---   ALTER TABLE session_log DROP COLUMN IF EXISTS assembled_quiz_id;
+--
+-- Leave session_log.assembled_quiz_id alone (do NOT drop it) — a later, unrelated change
+-- reintroduced that exact column for session-identity tracking (see its own migration note further
+-- below, near "Two different quizzes composed from the same catalog"); if your database already
+-- has it from this earlier rubric iteration, it's already in the right shape for that migration to
+-- build on, no action needed here.
 --
 -- Additive only, no backfill possible: every catalog created before this column existed has no
 -- custom rubric until an instructor sets one (buildRatingPrompt, lib/llm/promptUtils.ts, already
@@ -1352,3 +1381,42 @@ CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
 -- Instructor → Settings after this deploys; grading against the old row 500s with "Configured
 -- LLM provider key could not be read" until they do. See docs/manuals/administrator-manual.md's
 -- "Setting up LLM grading" section for the operator-facing version of this note.
+
+-- session_log.assembled_quiz_id: two different quizzes composed from the same catalog used to be
+-- indistinguishable to a student — session identity was tracked purely by (user_id, activity_type),
+-- so completing one silently marked the other as already-completed, and only one showed up in the
+-- course's discovery list at all. This column records which assembled_quiz a session was actually
+-- started through. (If your database still has this exact column from the earlier, unrelated
+-- rubric-tracking attempt described further above, this is the same column, already the right
+-- shape — just run the backfill/index statements below, the ADD COLUMN/ADD CONSTRAINT are
+-- idempotent via IF NOT EXISTS either way.)
+--
+--   ALTER TABLE session_log ADD COLUMN IF NOT EXISTS assembled_quiz_id uuid;
+--   ALTER TABLE session_log DROP CONSTRAINT IF EXISTS fk_session_log_assembled_quiz;
+--   ALTER TABLE session_log ADD CONSTRAINT fk_session_log_assembled_quiz
+--     FOREIGN KEY (assembled_quiz_id) REFERENCES assembled_quiz (assembled_quiz_id) ON DELETE SET NULL;
+--
+-- Best-effort backfill for existing rows: attribute each one to the first assembled_quiz found for
+-- its catalog. Same accepted "first match wins" convention already used elsewhere in this schema
+-- (listCoursesForActivityTypes, getAccessibleCourseForActivity) for the identical ambiguity — a
+-- catalog composed into more than one quiz has no way to say, after the fact, which one a given
+-- historical session actually came through, because that information was never recorded. For a
+-- student who hit the original bug, this can attribute their pre-migration history to the "wrong"
+-- one of the two quizzes; there is no way to do better retroactively.
+--
+--   UPDATE session_log sl SET assembled_quiz_id = (
+--     SELECT aqc.assembled_quiz_id FROM assembled_quiz_catalog aqc
+--     WHERE aqc.activity_type = sl.activity_type
+--     ORDER BY aqc.assembled_quiz_catalog_id LIMIT 1
+--   ) WHERE sl.assembled_quiz_id IS NULL;
+--
+-- Then replace the old activity_type-only uniqueness guarantee with the quiz-aware one (see that
+-- index's own comment above for why it's COALESCE'd to a sentinel rather than indexing the raw
+-- nullable column):
+--
+--   DROP INDEX IF EXISTS uq_session_log_one_active;
+--   CREATE UNIQUE INDEX uq_session_log_one_active
+--     ON session_log (user_id, COALESCE(assembled_quiz_id, '00000000-0000-0000-0000-000000000000'::uuid), activity_type)
+--     WHERE status = 'in-progress';
+--
+--   CREATE INDEX IF NOT EXISTS ix_session_log_assembled_quiz_id ON session_log (assembled_quiz_id);


### PR DESCRIPTION
Summary
When an instructor composed two different quizzes (assembled_quiz rows) in the same course that both link the same question catalog (activity_type), students only ever saw one of them in their course's activity list, and completing one silently marked the other as already completed too. This PR fixes both symptoms by giving every session a real, persisted link to the specific quiz that granted it, and threading that link through every layer that used to assume "one catalog = one quiz."

The bug
Reported behavior:

A course with two quizzes built on the same catalog (e.g. "Sprint 2 Practice" and "Final Review," both drawing from the same question bank) only showed one of them on the course page — GET /api/activities?courseId= returned a single entry instead of two.
Progress was tracked per catalog, not per quiz: passing "Sprint 2 Practice" made "Final Review" appear as already passed too, and vice versa, even though they're conceptually separate assignments.
Root cause
session_log — the table backing every session's lifecycle (start, resume, progress, completion, score) — had never recorded which assembled_quiz a session was started through, only which catalog (activity_type) it drew from. Every session-lifecycle function (start/resume, current, completed, in-progress, difficulty progression, scoring, leaderboard ranking) keyed purely on (user_id, activity_type). Two quizzes sharing a catalog were, at the database level, literally the same thing.

This wasn't a misapplied filter somewhere — it was a missing column plus a chain of ~15 routes and pages built on its absence, once traced through.

What changed
The fix is organized into 10 commits, each a self-contained layer of the same change:

Schema — adds a nullable session_log.assembled_quiz_id column (FK to assembled_quiz, ON DELETE SET NULL), backfills existing rows with a best-effort "first quiz found for this catalog" guess, and widens the "one in-progress session" uniqueness index to scope by quiz (via COALESCE to a sentinel, so untagged sessions still contend for one shared slot — Postgres treats every NULL as distinct, which would otherwise have silently broken that guarantee for every session predating this column).
Shared types — SessionRecord/SessionListEntry carry the new column, so it flows to every route built on the shared SESSION_COLUMNS constant for free.
Query layer — findInProgressSession, findStartDifficultyLevel, loadCompletedAttempts, and getAccessibleCourseForActivity all gain an optional assembledQuizId parameter to scope to one specific quiz instead of "any quiz on this catalog." listActivityTypesForCourses gains an opt-in dedupeByQuiz mode.
Scoring & leaderboard — a student's best result on each of two quizzes built on the same catalog now counts independently toward their score and leaderboard rank (see Product decisions below). 5–6. Session routes — POST /api/sessions and its current/completed/in-progress siblings, plus the LLM-graded twins under .../llm/sessions*, accept and validate the new parameter and persist it onto the session.
Client wrappers — sessionClient/llmActivityClient forward the parameter; completedAttemptsStore's cache key grows a third segment (with a storage-key version bump, so stale entries are simply never read again rather than misread).
Discovery — GET /api/activities opts into dedupeByQuiz, which is the direct fix for symptom 1: two quizzes on the same catalog now surface as two distinct entries.
Frontend resolution — ActivityDefinition, useResolvedActivity, and ActivityCard all carry/validate a specific quiz; the per-device unlock-animation snapshot is keyed per quiz too.
Frontend pages — the course page, activity detail page, and both play views (MCQ and LLM-graded) read a ?quiz= param and thread it through every session call and internal navigation, so a student stays on the quiz they opened instead of falling back to an arbitrary match. Also fixes a related collision in the course page's running-session lookup, which was keyed by catalog alone and would show "Start" instead of "Resume" for one of two simultaneously in-progress sessions on the same catalog.
Every new parameter is optional and additive — a caller that doesn't know about a specific quiz gets exactly today's behavior (first-match), so this ships with zero regression risk for the overwhelming majority of catalogs, which are only ever linked to one quiz.

Product decisions (confirmed before implementation)
Scoring: two quizzes built on the same catalog score independently — a student's total is the sum of their best result on each, not deduplicated to one.
Mastery titles: stay catalog-scoped, unaffected by this fix — a title represents mastery of the content, not completion of a specific quiz assignment.
Migration
This requires a manual, one-time schema change on any existing deployment (this repo has no migration runner — DDL is applied by hand in the Supabase SQL editor, per supabase/schema.sql's own convention). The idempotent migration block is at the bottom of schema.sql: it adds the column, backfills it, and swaps the uniqueness index. Must be run before this branch is deployed.

Testing
Full existing suite plus ~30 new/extended tests (source-level filter verification for the query layer, route-level wiring tests, and a dedicated dedupeByQuiz discovery test proving the actual bug scenario is fixed): 1367/1367 passing, up from a 1348 baseline, zero regressions.
npm run build clean (this project's type-check, per CLAUDE.md).
Live end-to-end verification against a real throwaway course with two quizzes on one catalog: both now appear as distinct discovery entries, get independent in-progress session slots (starting one doesn't block or resume the other), complete independently without leaking history into each other, and difficulty progression is correctly scoped per quiz.