### PR TITLE
Allow question catalogs to be deleted after student attempts (GitHub #525)

### DIFF
--- a/__tests__/api/activities-meta.test.ts
+++ b/__tests__/api/activities-meta.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      is: () => builder,
       limit: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/__tests__/api/activities-questions.test.ts
+++ b/__tests__/api/activities-questions.test.ts
@@ -17,6 +17,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       in: () => builder,
+      is: () => builder,
       limit: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/__tests__/api/daily-challenge.test.ts
+++ b/__tests__/api/daily-challenge.test.ts
@@ -148,6 +148,22 @@ describe('GET /api/daily-challenge', () => {
     expect(body).toEqual({ attempt: null, available: true, question: null });
   });
 
+  // GitHub #525: a soft-deleted catalog's questions must not be eligible for a new draw, even
+  // though deleteCatalog never removes the question row itself.
+  it('reports unavailable when the only eligible question belongs to a soft-deleted catalog', async () => {
+    queue('daily_challenge_attempt', { data: null, error: null });
+    queue('student_course', { data: [{ course_id: 'c-1' }], error: null });
+    queue('course', { data: [{ creator_id: 'instr-1' }], error: null });
+    queue('question', {
+      data: [{ question_id: 'q-1', max_score: 25, catalog: { deleted_at: '2026-08-19T00:00:00.000Z' } }],
+      error: null,
+    });
+
+    const body = await (await GET(req('GET'))).json();
+
+    expect(body).toEqual({ attempt: null, available: false, question: null });
+  });
+
   it('returns the drawn question, undisclosed, for an in-progress attempt', async () => {
     queue('daily_challenge_attempt', { data: baseAttempt, error: null });
     queue('question', { data: questionWithOptions, error: null });

--- a/__tests__/api/instructor-assembled-quiz-catalog-detail.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-catalog-detail.test.ts
@@ -22,6 +22,7 @@ const h = vi.hoisted(() => {
         if (isDelete) state.deletes.push({ table, column, value });
         return builder;
       },
+      is: () => builder,
       order: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/__tests__/api/instructor-assembled-quiz-catalogs.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-catalogs.test.ts
@@ -17,6 +17,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       eq: () => builder,
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-assembled-quiz-create-question.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-create-question.test.ts
@@ -33,6 +33,7 @@ const h = vi.hoisted(() => {
       },
       order: () => builder,
       limit: () => builder,
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-assembled-quiz-create-user-story.test.ts
+++ b/__tests__/api/instructor-assembled-quiz-create-user-story.test.ts
@@ -27,6 +27,7 @@ const h = vi.hoisted(() => {
         if (isDelete) state.deletes.push({ table, column, value });
         return builder;
       },
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-assembled-quizzes.test.ts
+++ b/__tests__/api/instructor-assembled-quizzes.test.ts
@@ -42,6 +42,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       limit: () => builder,
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-question-update.test.ts
+++ b/__tests__/api/instructor-question-update.test.ts
@@ -41,6 +41,7 @@ const h = vi.hoisted(() => {
       },
       order: () => builder,
       limit: () => builder,
+      is: () => builder,
       maybeSingle: async () => result,
       single: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/__tests__/api/instructor-questions.test.ts
+++ b/__tests__/api/instructor-questions.test.ts
@@ -49,6 +49,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       limit: () => builder,
+      is: () => builder,
       maybeSingle: async () => result,
       single: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/__tests__/api/instructor-quiz-detail.test.ts
+++ b/__tests__/api/instructor-quiz-detail.test.ts
@@ -34,6 +34,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       limit: () => builder,
+      is: () => builder,
       order: (column: string, opts?: { ascending?: boolean }) => {
         state.orders.push({ table, column, ascending: opts?.ascending ?? true });
         return builder;
@@ -475,40 +476,32 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
     expect(h.state.tables).not.toContain('session_log');
   });
 
-  it('returns 409 and deletes nothing when a student has already started a session for this catalog', async () => {
+  // GitHub #525: deletion no longer checks session_log/daily_challenge_attempt at all — a
+  // catalog stays deletable regardless of how many students have already attempted it.
+  it('succeeds even when a student has already completed a session for this catalog', async () => {
     queueRole('instructor');
-    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
-    queue('session_log', { data: { session_id: 'session-1' }, error: null });
-
-    const res = await delReq();
-    expect(res.status).toBe(409);
-    const body = await res.json();
-    expect(body.error).toBe('This catalog has already been used by a student and cannot be deleted.');
-    expect(h.state.tables).not.toContain('question');
-    expect(h.state.deletes).toEqual([]);
-  });
-
-  // daily_challenge_attempt has no session_log/activity_type of its own, so a question can be
-  // "in use" there even with zero session_log rows for the catalog — the check this test locks in.
-  it('returns 409 when an mcq catalog\'s question has a daily_challenge_attempt, even with no session_log rows', async () => {
-    queueRole('instructor');
-    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
-    queue('session_log', { data: null, error: null });
+    queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null }); // getQuizByActivityType
     queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
-    queue('question', { data: [{ question_id: 'q-1' }], error: null });
-    queue('daily_challenge_attempt', { data: { daily_challenge_attempt_id: 'attempt-1' }, error: null });
+    queue('activity_type', { data: null, error: null }); // the soft-delete UPDATE
 
     const res = await delReq();
-    expect(res.status).toBe(409);
+    expect(res.status).toBe(200);
     const body = await res.json();
-    expect(body.error).toBe('This catalog has already been used by a student and cannot be deleted.');
-    expect(h.state.deletes).toEqual([]);
+    expect(body).toEqual({ activityType: 'IDENTIFY_WEAK_USER_STORIES' });
+
+    expect(h.state.tables).not.toContain('session_log');
+    expect(h.state.tables).not.toContain('daily_challenge_attempt');
+    expect(h.state.tables).not.toContain('question');
+    expect(h.state.deletes).toEqual([]); // nothing is ever hard-deleted any more
+    expect(h.state.updates).toContainEqual({
+      table: 'activity_type',
+      payload: { deleted_at: expect.any(String) },
+    });
   });
 
   it('returns 409 and deletes nothing when the catalog is still composed into one or more assembled quizzes', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null });
-    queue('session_log', { data: null, error: null });
     queue('assembled_quiz_catalog', {
       data: [
         { assembled_quiz: { assembled_quiz_id: 'quiz-1', quiz_name: 'Sprint 1 Quiz', course: { course_name: 'CS 101' } } },
@@ -526,85 +519,54 @@ describe('DELETE /api/instructor/quizzes/[activityType]', () => {
       { quizId: 'quiz-1', quizName: 'Sprint 1 Quiz', courseName: 'CS 101' },
       { quizId: 'quiz-2', quizName: 'Midterm Review', courseName: 'CS 201' },
     ]);
-    expect(h.state.tables).not.toContain('question');
-    expect(h.state.tables).not.toContain('user_story');
-    expect(h.state.deletes).toEqual([]);
+    expect(h.state.updates).toEqual([]);
   });
 
-  it('deletes an unused mcq catalog\'s questions/answers, unlinks it from every quiz, and deletes the catalog', async () => {
+  it('soft-deletes an mcq catalog: one activity_type update, nothing else touched', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ creator_id: 'instructor-1' }), error: null }); // getQuizByActivityType
-    queue('session_log', { data: null, error: null });
     queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
-    queue('question', { data: [{ question_id: 'q-1' }, { question_id: 'q-2' }], error: null }); // select ids
-    queue('daily_challenge_attempt', { data: null, error: null });
-    queue('question_to_answer', { data: [{ answer_id: 'a-1' }, { answer_id: 'a-2' }], error: null }); // select answer ids
-    queue('question_to_answer', { data: null, error: null }); // delete
-    queue('answer', { data: null, error: null }); // delete
-    queue('question', { data: null, error: null }); // delete
-    queue('title_definition', { data: null, error: null }); // delete
-    queue('assembled_quiz_catalog', { data: null, error: null }); // delete
-    queue('activity_type', { data: null, error: null }); // delete
+    queue('activity_type', { data: null, error: null }); // the soft-delete UPDATE
 
     const res = await delReq();
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ activityType: 'IDENTIFY_WEAK_USER_STORIES' });
 
-    expect(h.state.deletes).toContainEqual({ table: 'question_to_answer', column: 'question_id', value: ['q-1', 'q-2'] });
-    expect(h.state.deletes).toContainEqual({ table: 'answer', column: 'answer_id', value: ['a-1', 'a-2'] });
-    expect(h.state.deletes).toContainEqual({ table: 'question', column: 'question_id', value: ['q-1', 'q-2'] });
-    expect(h.state.deletes).toContainEqual({ table: 'title_definition', column: 'activity_type', value: 'IDENTIFY_WEAK_USER_STORIES' });
-    expect(h.state.deletes).toContainEqual({ table: 'assembled_quiz_catalog', column: 'activity_type', value: 'IDENTIFY_WEAK_USER_STORIES' });
-    expect(h.state.deletes).toContainEqual({ table: 'activity_type', column: 'activity_type', value: 'IDENTIFY_WEAK_USER_STORIES' });
+    expect(h.state.updates).toEqual([
+      { table: 'activity_type', payload: { deleted_at: expect.any(String) } },
+    ]);
+    expect(h.state.tables).not.toContain('question');
+    expect(h.state.tables).not.toContain('user_story');
+    expect(h.state.tables).not.toContain('title_definition');
   });
 
-  it('deletes an unused llm-graded catalog\'s prompts, unlinks it from every quiz, and deletes the catalog', async () => {
+  it('soft-deletes an llm-graded catalog the same way as mcq', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
-    queue('session_log', { data: null, error: null });
     queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
-    queue('user_story', { data: null, error: null }); // delete
-    queue('title_definition', { data: null, error: null });
-    queue('assembled_quiz_catalog', { data: null, error: null });
-    queue('activity_type', { data: null, error: null }); // delete
+    queue('activity_type', { data: null, error: null }); // the soft-delete UPDATE
 
     const res = await delReq('WRITE_ACCEPTANCE_CRITERIA');
     expect(res.status).toBe(200);
 
-    expect(h.state.deletes).toContainEqual({ table: 'user_story', column: 'activity_type', value: 'WRITE_ACCEPTANCE_CRITERIA' });
-    expect(h.state.deletes).toContainEqual({ table: 'assembled_quiz_catalog', column: 'activity_type', value: 'WRITE_ACCEPTANCE_CRITERIA' });
+    expect(h.state.updates).toEqual([
+      { table: 'activity_type', payload: { deleted_at: expect.any(String) } },
+    ]);
     expect(h.state.tables).not.toContain('question');
+    expect(h.state.tables).not.toContain('user_story');
     expect(h.state.tables).not.toContain('daily_challenge_attempt');
   });
 
-  it('returns 500 when the final delete fails for a reason other than a foreign key violation', async () => {
+  it('returns 500 when the soft-delete update fails', async () => {
     queueRole('instructor');
     queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
-    queue('session_log', { data: null, error: null });
     queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
-    queue('user_story', { data: null, error: null });
-    queue('title_definition', { data: null, error: null });
-    queue('assembled_quiz_catalog', { data: null, error: null });
-    queue('activity_type', { data: null, error: { message: 'DB down' } });
+    queue('activity_type', { data: null, error: { message: 'DB down' } }); // the soft-delete UPDATE
 
     const res = await delReq('WRITE_ACCEPTANCE_CRITERIA');
     expect(res.status).toBe(500);
     const body = await res.json();
     expect(body.error).toBe('DB down');
-  });
-
-  it('returns 409 (defense in depth) when the final delete hits a foreign key violation the earlier checks missed', async () => {
-    queueRole('instructor');
-    queue('activity_type', { data: quizRow({ grading_kind: 'llm-graded', creator_id: 'instructor-1' }), error: null });
-    queue('session_log', { data: null, error: null });
-    queue('assembled_quiz_catalog', { data: [], error: null }); // linkage check — no quiz links
-    queue('user_story', { data: null, error: null });
-    queue('title_definition', { data: null, error: null });
-    queue('assembled_quiz_catalog', { data: null, error: null });
-    queue('activity_type', { data: null, error: { message: 'update or delete violates foreign key constraint', code: '23503' } });
-
-    const res = await delReq('WRITE_ACCEPTANCE_CRITERIA');
-    expect(res.status).toBe(409);
   });
 });

--- a/__tests__/api/instructor-quiz-duplicate.test.ts
+++ b/__tests__/api/instructor-quiz-duplicate.test.ts
@@ -32,6 +32,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       limit: () => builder,
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-quiz-questions.test.ts
+++ b/__tests__/api/instructor-quiz-questions.test.ts
@@ -18,6 +18,7 @@ const h = vi.hoisted(() => {
         state.filters.push({ table, column, value });
         return builder;
       },
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-quiz-titles.test.ts
+++ b/__tests__/api/instructor-quiz-titles.test.ts
@@ -41,6 +41,7 @@ const h = vi.hoisted(() => {
         filters.push({ column, value });
         return builder;
       },
+      is: () => builder,
       order: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>

--- a/__tests__/api/instructor-student-detail.test.ts
+++ b/__tests__/api/instructor-student-detail.test.ts
@@ -184,6 +184,73 @@ describe('GET /api/instructor/students/:studentId/detail', () => {
     expect(body.attempts[0].courses).toEqual([{ courseId: 'course-a', courseName: 'Course A' }]);
   });
 
+  // GitHub #525: a catalog must be unlinked from every course before it can be deleted, so
+  // listActivityTypesForCourses alone would never see it again — this proves the instructor-owned
+  // union (listOwnedActivityTypeSummaries) keeps the student's attempt visible anyway.
+  it('still shows an attempt on a catalog this instructor owns but has since deleted/unlinked from every course', async () => {
+    queueCallerRole('instructor');
+    queueStudent();
+    queue('course', { data: [{ course_id: 'course-a' }], error: null }); // listOwnedCourseIds
+    queue('student_course', { data: [{ course_id: 'course-a' }], error: null }); // getEnrolledCourseIds
+
+    // listActivityTypesForCourses(['course-a']) — nothing currently composed for this course.
+    queue('assembled_quiz_catalog', { data: [], error: null });
+
+    // listOwnedActivityTypeSummaries('instructor-1') — the instructor still owns this catalog
+    // even though it's no longer linked to (or has been soft-deleted from) any course.
+    queue('activity_type', {
+      data: [{ activity_type: 'DELETED_CATALOG', quiz_name: 'Deleted Catalog', grading_kind: 'mcq' }],
+      error: null,
+    });
+
+    queue('session_log', {
+      data: [
+        {
+          session_id: 'session-1',
+          user_id: STUDENT_ID,
+          activity_type: 'DELETED_CATALOG',
+          difficulty_level: 1,
+          started_at: '2026-08-01T10:00:00',
+          ended_at: '2026-08-01T10:10:00',
+          status: 'completed',
+          cumulative_score: 40,
+          max_score: 40,
+          passed: true,
+        },
+      ],
+      error: null,
+    });
+
+    // loadProgressForSessions
+    queue('session_to_question', { data: [], error: null });
+    queue('answered_question_log', { data: [], error: null });
+    queue('session_to_user_story', { data: [], error: null });
+    queue('submission', { data: [], error: null });
+
+    // loadQuestionCorrectnessBySession
+    queue('session_to_question', { data: [], error: null });
+    queue('answered_question_log', { data: [], error: null });
+
+    // listCoursesForActivityTypes(visibleActivityTypes) — the catalog has no course links at all.
+    queue('assembled_quiz_catalog', { data: [], error: null });
+
+    // loadEnrolledStudentIdsForCourses(['course-a'])
+    queue('student_course', { data: [{ user_id: STUDENT_ID }], error: null });
+
+    // class average query
+    queue('session_log', { data: [{ cumulative_score: 40, max_score: 40 }], error: null });
+
+    const response = await GET(req(), PARAMS);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.attempts).toHaveLength(1);
+    expect(body.attempts[0].activity_type).toBe('DELETED_CATALOG');
+    expect(body.activityNames.DELETED_CATALOG).toBe('Deleted Catalog');
+    // No current course link, but the attempt itself still shows.
+    expect(body.attempts[0].courses).toEqual([]);
+  });
+
   it('computes the class average from every completed session in the shared courses, scoped to the shared activity types', async () => {
     queueCallerRole('instructor');
     queueStudent();

--- a/__tests__/api/instructor-student-history.test.ts
+++ b/__tests__/api/instructor-student-history.test.ts
@@ -57,6 +57,15 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
+// GitHub #525: wrapping (not replacing) the real implementation lets every existing test keep
+// exercising real isActivityType behavior against the mocked supabase client above, while this
+// file can also assert on what arguments the route actually passed it.
+vi.mock('../../lib/activityTypes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/activityTypes')>();
+  return { ...actual, isActivityType: vi.fn(actual.isActivityType) };
+});
+
+import { isActivityType } from '../../lib/activityTypes';
 import { GET } from '../../app/api/instructor/students/[studentId]/history/route';
 
 const STUDENT_ID = 'student-1';
@@ -84,6 +93,7 @@ beforeEach(() => {
   h.state.tables = [];
   h.state.filters = [];
   h.state.orders = [];
+  vi.mocked(isActivityType).mockClear();
 });
 
 describe('GET /api/instructor/students/:studentId/history', () => {
@@ -223,6 +233,21 @@ describe('GET /api/instructor/students/:studentId/history', () => {
 
     expect(response.status).toBe(200);
     expect(body.sessions).toEqual([]);
+  });
+
+  // GitHub #525: an instructor filtering a student's history by a since-deleted catalog must
+  // still get results, not a 400 — this route is one of the explicit includeDeleted opt-ins.
+  it('resolves a soft-deleted catalog too, when filtering history by activity type', async () => {
+    queueCallerRole('instructor');
+    queue('activity_type', { data: { activity_type: 'IDENTIFY_WEAK_USER_STORIES' }, error: null });
+    queueStudent();
+    queue('session_log', { data: [], error: null });
+
+    await GET(req('?activityType=IDENTIFY_WEAK_USER_STORIES'), PARAMS);
+
+    expect(isActivityType).toHaveBeenCalledWith(expect.anything(), 'IDENTIFY_WEAK_USER_STORIES', {
+      includeDeleted: true,
+    });
   });
 
   it('returns 500 when the session query fails', async () => {

--- a/__tests__/api/instructor-user-stories.test.ts
+++ b/__tests__/api/instructor-user-stories.test.ts
@@ -21,6 +21,7 @@ const h = vi.hoisted(() => {
         state.inserts.push({ table, payload });
         return builder;
       },
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/instructor-user-story-update.test.ts
+++ b/__tests__/api/instructor-user-story-update.test.ts
@@ -29,6 +29,7 @@ const h = vi.hoisted(() => {
         state.deletes.push(table);
         return builder;
       },
+      is: () => builder,
       maybeSingle: async () => result,
       then: (onOk: (r: Result) => unknown, onErr?: (e: unknown) => unknown) =>
         Promise.resolve(result).then(onOk, onErr),

--- a/__tests__/api/llm-sessions-current.test.ts
+++ b/__tests__/api/llm-sessions-current.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => {
     const builder: Record<string, unknown> = {
       select: () => builder,
       eq: () => builder,
+      is: () => builder,
       order: () => builder,
       maybeSingle: async () => result,
       single: async () => result,

--- a/__tests__/api/llm-sessions.test.ts
+++ b/__tests__/api/llm-sessions.test.ts
@@ -21,6 +21,7 @@ const h = vi.hoisted(() => {
         return builder;
       },
       in: () => builder,
+      is: () => builder,
       limit: () => builder,
       order: () => builder,
       insert: (payload: unknown) => {

--- a/__tests__/api/llm-submissions.test.ts
+++ b/__tests__/api/llm-submissions.test.ts
@@ -69,6 +69,15 @@ vi.mock('../../lib/llm/factory', async (importOriginal) => {
 // override it to simulate a decrypt failure.
 vi.mock('../../lib/secretEncryption', () => ({ decryptSecret: vi.fn((value: string) => value) }));
 
+// GitHub #525: wrapping (not replacing) the real implementation lets every existing test keep
+// exercising real getGradingKind behavior against the mocked supabase client above, while this
+// file can also assert on what arguments the route actually passed it.
+vi.mock('../../lib/activityTypes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/activityTypes')>();
+  return { ...actual, getGradingKind: vi.fn(actual.getGradingKind) };
+});
+
+import { getGradingKind } from '../../lib/activityTypes';
 import { getLLMProvider } from '../../lib/llm/factory';
 import { decryptSecret } from '../../lib/secretEncryption';
 import { POST } from '../../app/api/activities/[activityType]/llm/submissions/route';
@@ -167,6 +176,7 @@ beforeEach(() => {
   vi.mocked(getLLMProvider).mockReturnValue({ rateAcceptanceCriteria } as never);
   vi.mocked(decryptSecret).mockReset();
   vi.mocked(decryptSecret).mockImplementation((value: string) => value);
+  vi.mocked(getGradingKind).mockClear();
 });
 
 describe('POST /api/activities/[activityType]/llm/submissions', () => {
@@ -454,5 +464,16 @@ describe('POST /api/activities/[activityType]/llm/submissions', () => {
     await POST(req({ userStoryId: 'story-1', submittedText: 'x', sessionId: SESSION_ID }), PARAMS());
 
     expect(rateAcceptanceCriteria).toHaveBeenCalledWith(STORY.story_text, 'x', null);
+  });
+
+  // GitHub #525: a submission already loaded in an open tab must still be gradable after the
+  // catalog is deleted mid-session, matching the MCQ answer route's existing unconditional behavior.
+  it('resolves a soft-deleted catalog too, so a submission on it can still be graded mid-session', async () => {
+    queueUpToLLM();
+    queueSuccessfulWrite(submissionRow('story-1'));
+
+    await POST(req({ userStoryId: 'story-1', submittedText: 'x', sessionId: SESSION_ID }), PARAMS());
+
+    expect(getGradingKind).toHaveBeenCalledWith(expect.anything(), ACTIVITY, { includeDeleted: true });
   });
 });

--- a/__tests__/api/sessions-completed.test.ts
+++ b/__tests__/api/sessions-completed.test.ts
@@ -52,6 +52,15 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
+// GitHub #525: wrapping (not replacing) the real implementation lets every existing test keep
+// exercising real isActivityType behavior against the mocked supabase client above, while this
+// file can also assert on what arguments the route actually passed it.
+vi.mock('../../lib/activityTypes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/activityTypes')>();
+  return { ...actual, isActivityType: vi.fn(actual.isActivityType) };
+});
+
+import { isActivityType } from '../../lib/activityTypes';
 import { GET } from '../../app/api/sessions/completed/route';
 
 const ACTIVITY = 'IDENTIFY_WEAK_USER_STORIES';
@@ -85,6 +94,7 @@ describe('GET /api/sessions/completed', () => {
     h.state.queues = {};
     h.state.tables = [];
     h.state.filters = [];
+    vi.mocked(isActivityType).mockClear();
   });
 
   it('returns 401 without a token', async () => {
@@ -214,6 +224,18 @@ describe('GET /api/sessions/completed', () => {
     await GET(req());
 
     expect(h.state.filters.some((f) => f.column === 'assembled_quiz_id')).toBe(false);
+  });
+
+  // GitHub #525: this route must still serve a soft-deleted catalog's history, since a student
+  // filtering their own completed attempts by activity type is exactly the "keep history readable
+  // forever" case the feature promises.
+  it('resolves a soft-deleted catalog too, so completed history for it keeps working', async () => {
+    queueValidActivityType();
+    queue('session_log', { data: [], error: null });
+
+    await GET(req());
+
+    expect(isActivityType).toHaveBeenCalledWith(expect.anything(), ACTIVITY, { includeDeleted: true });
   });
 
   it('returns 500 when the session_log query fails', async () => {

--- a/__tests__/api/sessions-current.test.ts
+++ b/__tests__/api/sessions-current.test.ts
@@ -13,6 +13,7 @@ const h = vi.hoisted(() => {
     const builder: Record<string, unknown> = {
       select: () => builder,
       eq: () => builder,
+      is: () => builder,
       order: () => builder,
       maybeSingle: async () => result,
       single: async () => result,

--- a/__tests__/api/sessions-in-progress.test.ts
+++ b/__tests__/api/sessions-in-progress.test.ts
@@ -54,6 +54,15 @@ vi.mock('../../lib/supabase', () => ({
   }),
 }));
 
+// GitHub #525: wrapping (not replacing) the real implementation lets every existing test keep
+// exercising real isActivityType behavior against the mocked supabase client above, while this
+// file can also assert on what arguments the route actually passed it.
+vi.mock('../../lib/activityTypes', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../lib/activityTypes')>();
+  return { ...actual, isActivityType: vi.fn(actual.isActivityType) };
+});
+
+import { isActivityType } from '../../lib/activityTypes';
 import { GET } from '../../app/api/sessions/in-progress/route';
 
 const ACTIVITY_TYPE = 'IDENTIFY_WEAK_USER_STORIES';
@@ -98,6 +107,7 @@ describe('GET /api/sessions/in-progress', () => {
     h.state.queues = {};
     h.state.inserts = [];
     h.state.tables = [];
+    vi.mocked(isActivityType).mockClear();
   });
 
   it('returns 401 without a token', async () => {
@@ -245,6 +255,19 @@ describe('GET /api/sessions/in-progress', () => {
     const response = await GET(req(`?activityType=${ACTIVITY_TYPE}&assembledQuizId=quiz-1`));
 
     expect(response.status).toBe(200);
+  });
+
+  // GitHub #525: this route reports "what's currently running", including a session on a catalog
+  // that's since been deleted — it should not 400 while that session is still live.
+  it('resolves a soft-deleted catalog too, so a running session for it still shows', async () => {
+    queueValidActivityType();
+    queue('session_log', { data: [sessionRow()], error: null });
+    queue('session_to_question', { data: drawnQuestions, error: null });
+    queue('answered_question_log', { data: [], error: null });
+
+    await GET(req(`?activityType=${ACTIVITY_TYPE}`));
+
+    expect(isActivityType).toHaveBeenCalledWith(expect.anything(), ACTIVITY_TYPE, { includeDeleted: true });
   });
 
   it('never writes', async () => {

--- a/__tests__/api/sessions.test.ts
+++ b/__tests__/api/sessions.test.ts
@@ -19,6 +19,7 @@ const h = vi.hoisted(() => {
       select: () => builder,
       eq: () => builder,
       in: () => builder,
+      is: () => builder,
       range: () => builder,
       limit: () => builder,
       order: (column: string, opts?: { ascending?: boolean }) => {

--- a/__tests__/lib/activityTypes.test.ts
+++ b/__tests__/lib/activityTypes.test.ts
@@ -36,6 +36,10 @@ function makeBuilder(table: string, result: Result) {
       state.filters.push({ table, column, value });
       return builder;
     },
+    is: (column: string, value: unknown) => {
+      state.filters.push({ table, column, value });
+      return builder;
+    },
     maybeSingle: async () => result,
   };
   return builder;
@@ -83,6 +87,7 @@ describe('getGradingKind', () => {
     expect(state.selects).toEqual([{ table: 'activity_type', columns: 'grading_kind' }]);
     expect(state.filters).toEqual([
       { table: 'activity_type', column: 'activity_type', value: 'WRITE_ACCEPTANCE_CRITERIA' },
+      { table: 'activity_type', column: 'deleted_at', value: null },
     ]);
   });
 
@@ -136,6 +141,26 @@ describe('getGradingKind', () => {
       error: null,
     });
   });
+
+  // GitHub #525: excludes a soft-deleted catalog by default — the mock's own queued row doesn't
+  // matter here, the point is that the query is filtered before the caller's fixture data would
+  // even be consulted for a real database.
+  it('filters out a soft-deleted catalog by default', async () => {
+    queue('activity_type', { data: { grading_kind: 'llm-graded' }, error: null });
+
+    await getGradingKind(makeSupabase(), 'WRITE_ACCEPTANCE_CRITERIA');
+
+    expect(state.filters).toContainEqual({ table: 'activity_type', column: 'deleted_at', value: null });
+  });
+
+  it('does not filter by deleted_at when includeDeleted is true', async () => {
+    queue('activity_type', { data: { grading_kind: 'llm-graded' }, error: null });
+
+    const result = await getGradingKind(makeSupabase(), 'WRITE_ACCEPTANCE_CRITERIA', { includeDeleted: true });
+
+    expect(result).toEqual({ gradingKind: 'llm-graded', error: null });
+    expect(state.filters.some((f) => f.column === 'deleted_at')).toBe(false);
+  });
 });
 
 describe('isActivityType', () => {
@@ -146,6 +171,35 @@ describe('isActivityType', () => {
 
     expect(result).toEqual({ valid: true, error: null });
     expect(state.selects).toEqual([{ table: 'activity_type', columns: 'activity_type' }]);
+  });
+
+  // GitHub #525
+  it('filters out a soft-deleted catalog by default', async () => {
+    queue('activity_type', { data: null, error: null });
+
+    await isActivityType(makeSupabase(), 'IDENTIFY_WEAK_USER_STORIES');
+
+    expect(state.filters).toContainEqual({ table: 'activity_type', column: 'deleted_at', value: null });
+  });
+
+  it('does not filter by deleted_at when includeDeleted is true, so a deleted catalog still counts as valid', async () => {
+    queue('activity_type', { data: { activity_type: 'IDENTIFY_WEAK_USER_STORIES' }, error: null });
+
+    const result = await isActivityType(makeSupabase(), 'IDENTIFY_WEAK_USER_STORIES', { includeDeleted: true });
+
+    expect(result).toEqual({ valid: true, error: null });
+    expect(state.filters.some((f) => f.column === 'deleted_at')).toBe(false);
+  });
+
+  it('never queries at all for a non-string or blank key, regardless of includeDeleted', async () => {
+    for (const value of [null, undefined, 42, '', '   ']) {
+      expect(await isActivityType(makeSupabase(), value, { includeDeleted: true })).toEqual({
+        valid: false,
+        error: null,
+      });
+    }
+
+    expect(state.tables).toEqual([]);
   });
 });
 

--- a/app/api/activities/[activityType]/llm/submissions/route.ts
+++ b/app/api/activities/[activityType]/llm/submissions/route.ts
@@ -103,7 +103,10 @@ export async function POST(request: Request, { params }: { params: { activityTyp
 
   const { activityType } = params;
 
-  const { gradingKind, error: kindError } = await getGradingKind(supabase, activityType);
+  // GitHub #525: includeDeleted so a submission already loaded in an open tab can still be graded
+  // even if the catalog is deleted mid-session — matches the MCQ answer route, which has no
+  // dependency on the catalog's live status at all.
+  const { gradingKind, error: kindError } = await getGradingKind(supabase, activityType, { includeDeleted: true });
   if (kindError) return Response.json({ error: kindError.message }, { status: 500 });
   if (gradingKind === null) return Response.json({ error: "Unknown activity type." }, { status: 400 });
   if (gradingKind !== "llm-graded") {

--- a/app/api/instructor/assembled-quizzes/route.ts
+++ b/app/api/instructor/assembled-quizzes/route.ts
@@ -149,10 +149,13 @@ export async function POST(request: Request) {
 
   const uniqueCatalogIds = Array.from(new Set(catalogActivityTypes));
 
+  // GitHub #525: a soft-deleted catalog must not be composable into a new quiz — excluding it here
+  // makes it fail the same "does not exist" check below as a genuinely unknown key.
   const { data: validCatalogs, error: catalogError } = await supabase
     .from('activity_type')
     .select('activity_type, grading_kind')
-    .in('activity_type', uniqueCatalogIds);
+    .in('activity_type', uniqueCatalogIds)
+    .is('deleted_at', null);
 
   if (catalogError) return Response.json({ error: catalogError.message }, { status: 500 });
 

--- a/app/api/instructor/quizzes/[activityType]/route.ts
+++ b/app/api/instructor/quizzes/[activityType]/route.ts
@@ -147,15 +147,17 @@ export async function PATCH(request: Request, { params }: { params: { activityTy
 }
 
 /**
- * DELETE /api/instructor/quizzes/:activityType — deletes a catalog the caller owns: its own
- * questions/answers (mcq) or user_story prompts (llm-graded). Same 404-then-403 ownership check as
- * GET above.
+ * DELETE /api/instructor/quizzes/:activityType — soft-deletes a catalog the caller owns
+ * (deleteCatalog's own docblock has the mechanics: sets activity_type.deleted_at, never removes
+ * the row or anything referencing it). Same 404-then-403 ownership check as GET above.
+ *
+ * GitHub #525: a catalog is deletable regardless of whether students have already attempted it —
+ * their history stays fully intact and readable. The only remaining precondition is unchanged:
+ * the catalog must first be removed from every assembled quiz it's composed into.
  *
  * - 401 missing/invalid bearer token
  * - 403 caller isn't an instructor, or doesn't own this catalog (no body either way)
  * - 404 activityType matches no catalog
- * - 409 a student has already engaged with this catalog (deleteCatalog's own docblock has the
- *   exact usage this checks) — the catalog is left untouched
  * - 409 the catalog is still composed into one or more assembled quizzes — the catalog is left
  *   untouched, and the body names exactly which quiz(es)/course(s) still reference it so the
  *   instructor knows what to remove first (via the existing "remove a catalog from a quiz" action)
@@ -184,10 +186,7 @@ export async function DELETE(request: Request, { params }: { params: { activityT
   if (!quiz) return Response.json({ error: 'Catalog not found.' }, { status: 404 });
   if (creatorId !== guard.user_id) return new Response(null, { status: 403 });
 
-  const result = await deleteCatalog(supabase, activityType, quiz.gradingKind);
-  if (result.status === 'in_use') {
-    return Response.json({ error: 'This catalog has already been used by a student and cannot be deleted.' }, { status: 409 });
-  }
+  const result = await deleteCatalog(supabase, activityType);
   if (result.status === 'linked') {
     const names = result.quizzes.map((q) => `"${q.quizName}" (${q.courseName})`).join(', ');
     const plural = result.quizzes.length > 1;

--- a/app/api/instructor/students/[studentId]/history/route.ts
+++ b/app/api/instructor/students/[studentId]/history/route.ts
@@ -45,7 +45,9 @@ export async function GET(request: Request, { params }: { params: { studentId: s
 
   const activityType = new URL(request.url).searchParams.get('activityType');
   if (activityType !== null) {
-    const { valid: validActivityType, error: activityTypeError } = await isActivityType(supabase, activityType);
+    // GitHub #525: includeDeleted so an instructor can still filter a student's history by a
+    // catalog that's since been deleted — this is a history read, not a gate on new interaction.
+    const { valid: validActivityType, error: activityTypeError } = await isActivityType(supabase, activityType, { includeDeleted: true });
     if (activityTypeError) return Response.json({ error: activityTypeError.message }, { status: 500 });
     if (!validActivityType) {
       return Response.json({ error: 'Unknown activity type.' }, { status: 400 });

--- a/app/api/sessions/completed/route.ts
+++ b/app/api/sessions/completed/route.ts
@@ -42,7 +42,9 @@ export async function GET(request: Request) {
   const supabase = getSupabaseClient();
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
 
-  const { valid: validActivityType, error: activityTypeError } = await isActivityType(supabase, activityType);
+  // GitHub #525: includeDeleted so a student can still see their completed history on a catalog
+  // an instructor has since deleted — this is a history read, not a gate on new interaction.
+  const { valid: validActivityType, error: activityTypeError } = await isActivityType(supabase, activityType, { includeDeleted: true });
   if (activityTypeError) return Response.json({ error: activityTypeError.message }, { status: 500 });
   if (!validActivityType) {
     return Response.json({ error: 'Unknown activity type.' }, { status: 400 });

--- a/app/api/sessions/in-progress/route.ts
+++ b/app/api/sessions/in-progress/route.ts
@@ -45,7 +45,10 @@ export async function GET(request: Request) {
   if (!supabase) return Response.json({ error: 'Supabase credentials are not configured.' }, { status: 500 });
 
   if (activityType !== null) {
-    const { valid: validActivityType, error: activityTypeError } = await isActivityType(supabase, activityType);
+    // GitHub #525: includeDeleted — this reports "is something currently running", not a gate on
+    // starting something new, so it should stay honest about an in-progress session even if the
+    // catalog it's on has since been deleted.
+    const { valid: validActivityType, error: activityTypeError } = await isActivityType(supabase, activityType, { includeDeleted: true });
     if (activityTypeError) return Response.json({ error: activityTypeError.message }, { status: 500 });
     if (!validActivityType) {
       return Response.json({ error: 'Unknown activity type.' }, { status: 400 });

--- a/app/instructor/quizzes/[activityType]/page.tsx
+++ b/app/instructor/quizzes/[activityType]/page.tsx
@@ -642,8 +642,9 @@ export default function CatalogDetailPage({ params }: { params: { activityType: 
             <>
               <span className="block font-bold text-brand-ink">{quiz?.name ?? 'This catalog'}</span>
               <span className="mt-2 block">
-                This permanently deletes every question in this catalog and removes it
-                from any quiz it&apos;s linked to. This can&apos;t be undone.
+                This removes the catalog from Question Catalogs — it can&apos;t be added to a quiz
+                or answered by a student again. Students who already attempted it keep their scores
+                and history. This can&apos;t be undone.
               </span>
             </>
           }

--- a/lib/activityTypeQueries.ts
+++ b/lib/activityTypeQueries.ts
@@ -104,6 +104,8 @@ export async function listQuizzesWithAuthorAndCount(supabase: SupabaseClient, in
     .from('activity_type')
     .select(QUIZ_SUMMARY_SELECT)
     .eq('creator_id', instructorId)
+    // GitHub #525: a soft-deleted catalog no longer belongs on the browse page.
+    .is('deleted_at', null)
     .order('quiz_name', { ascending: true });
 
   if (error) return { quizzes: null, error };
@@ -124,6 +126,8 @@ export async function listExampleCatalogsWithCount(supabase: SupabaseClient) {
     .from('activity_type')
     .select(QUIZ_SUMMARY_SELECT)
     .is('creator_id', null)
+    // GitHub #525: a soft-deleted catalog no longer belongs on the browse page.
+    .is('deleted_at', null)
     .order('quiz_name', { ascending: true });
 
   if (error) return { quizzes: null, error };
@@ -152,6 +156,12 @@ export type QuizMeta = Omit<QuizSummary, 'questionCount' | 'quizCount'> & {
  * and the student-facing single-activity route (authorized via course enrollment). creatorId rides
  * along as a sibling field, not folded into QuizMeta, precisely so the two callers that don't need
  * it can keep destructuring only `quiz` without it ever reaching a JSON response by accident.
+ *
+ * GitHub #525: excludes a soft-deleted catalog — every one of its three callers treats a miss here
+ * as "doesn't exist" (404, or a fallback to a different resolution path), which is exactly the
+ * right behavior for a deleted catalog too. This is also what makes the duplicate route
+ * (app/api/instructor/quizzes/[activityType]/duplicate/route.ts) automatically 404 on a deleted
+ * source, with no separate check needed in duplicateCatalog itself.
  */
 export async function getQuizByActivityType(supabase: SupabaseClient, activityType: string) {
   const { data, error } = await supabase
@@ -160,6 +170,7 @@ export async function getQuizByActivityType(supabase: SupabaseClient, activityTy
       'activity_type, quiz_name, description, grading_kind, rating_prompt, creator_id, creator:creator_id(first_name, last_name, username)',
     )
     .eq('activity_type', activityType)
+    .is('deleted_at', null)
     .maybeSingle();
 
   if (error) return { quiz: null, creatorId: null, error };
@@ -356,51 +367,32 @@ type QuizLinkRow = {
 
 export type DeleteCatalogResult =
   | { status: 'ok' }
-  | { status: 'in_use' }
   | { status: 'linked'; quizzes: LinkedQuizSummary[] }
   | { status: 'error'; error: { message: string } };
 
 /**
- * Deletes a catalog (activity_type row) entirely: its own questions/answers (mcq) or user_story
- * prompts (llm-graded), and every assembled_quiz_catalog link that referenced it — a link to a
- * catalog that no longer exists is meaningless, so this is what removes a deleted catalog from
- * any quiz it was composed into. quiz_excluded_question and assembled_quiz_extra_question rows
- * cascade automatically (their FK to question is ON DELETE CASCADE, see supabase/schema.sql); no
- * manual cleanup needed for those.
+ * Soft-deletes a catalog (GitHub #525): sets activity_type.deleted_at rather than removing
+ * anything. The row itself, and every question/answer/user_story/title_definition that references
+ * it, stays exactly as it is — a student's history against this catalog is never touched, so it
+ * keeps reading correctly everywhere it's shown (completed-attempts lists, the instructor
+ * dashboard, per-student detail, class statistics). isActivityType/getGradingKind
+ * (lib/activityTypes.ts) exclude a soft-deleted catalog by default, which is what makes it stop
+ * being selectable, playable, or editable going forward without needing any cascading delete at
+ * all.
  *
- * Refuses with 'in_use' instead of deleting anything if a student has ever engaged with this
- * catalog: a session_log row for this activity_type — which a session_to_question or
- * session_to_user_story row always implies by construction, since a session only ever draws from
- * its own activity_type's pool — or, for an mcq catalog specifically, a daily_challenge_attempt
- * row for one of its questions (that table has no session_log/activity_type of its own to check
- * instead, unlike every other student-history table). None of session_to_question/
- * session_to_user_story/answered_question_log/submission/daily_challenge_attempt has an ON DELETE
- * clause on its FK into question/user_story, so a physical delete would either fail outright or,
- * attempted piecemeal, orphan a student's history — checking first avoids both, the same reasoning
- * DELETE /api/instructor/questions/{questionId} already documents for a single question.
+ * This used to hard-block ('in_use') the instant any student had ever engaged with the catalog —
+ * removed entirely per the product decision that historical attempts must never prevent deletion.
  *
- * Also refuses with 'linked' — a second, independent pre-flight check, orthogonal to the 'in_use'
- * one above — if any assembled_quiz_catalog row still references this catalog. Unlike deleting a
- * single question (which the DELETE /api/instructor/questions/{questionId}?force= path lets an
- * instructor push through with `force`), there is no "delete anyway" for a catalog: a catalog can
- * be composed into several quizzes/courses at once (see CLAUDE.md's Assembled quizzes section), so
- * silently cascading the unlink here — which is exactly what this function used to do, unyoking a
- * catalog from every quiz it was in without telling anyone — could quietly break a running course
- * out from under students. The instructor has to remove the catalog from each quiz by hand first
- * (DELETE /api/instructor/assembled-quizzes/{quizId}/catalogs/{activityType}, the existing "remove
- * a catalog from a quiz" action) before a delete here is allowed to proceed. This check runs before
- * the destructive per-kind deletes below so a rejection never leaves the catalog partially deleted.
+ * Still refuses with 'linked' if any assembled_quiz_catalog row references this catalog — the one
+ * precondition that remains. A catalog can be composed into several quizzes/courses at once (see
+ * CLAUDE.md's Assembled quizzes section), so silently unlinking it here on delete could quietly
+ * break a running course out from under students; the instructor removes it from each quiz by hand
+ * first (DELETE /api/instructor/assembled-quizzes/{quizId}/catalogs/{activityType}, the existing
+ * "remove a catalog from a quiz" action). This also guarantees a deletable catalog is already
+ * unreachable through any course/discovery/composition query before this even runs, since those
+ * all derive from assembled_quiz_catalog.
  */
-export async function deleteCatalog(supabase: SupabaseClient, activityType: string, gradingKind: GradingKind): Promise<DeleteCatalogResult> {
-  const { data: sessionUsage, error: sessionUsageError } = await supabase
-    .from('session_log')
-    .select('session_id')
-    .eq('activity_type', activityType)
-    .limit(1)
-    .maybeSingle();
-  if (sessionUsageError) return { status: 'error', error: sessionUsageError };
-  if (sessionUsage) return { status: 'in_use' };
-
+export async function deleteCatalog(supabase: SupabaseClient, activityType: string): Promise<DeleteCatalogResult> {
   const { data: quizLinkRows, error: quizLinkError } = await supabase
     .from('assembled_quiz_catalog')
     .select('assembled_quiz:assembled_quiz_id(assembled_quiz_id, quiz_name, course:course_id(course_name))')
@@ -417,59 +409,11 @@ export async function deleteCatalog(supabase: SupabaseClient, activityType: stri
     }));
   if (linkedQuizzes.length > 0) return { status: 'linked', quizzes: linkedQuizzes };
 
-  if (gradingKind === 'llm-graded') {
-    const { error: deleteStoriesError } = await supabase.from('user_story').delete().eq('activity_type', activityType);
-    if (deleteStoriesError) return { status: 'error', error: deleteStoriesError };
-  } else {
-    const { data: questionRows, error: questionsError } = await supabase
-      .from('question')
-      .select('question_id')
-      .eq('activity_type', activityType);
-    if (questionsError) return { status: 'error', error: questionsError };
-
-    const questionIds = ((questionRows ?? []) as { question_id: string }[]).map((row) => row.question_id);
-
-    if (questionIds.length > 0) {
-      const { data: dailyUsage, error: dailyUsageError } = await supabase
-        .from('daily_challenge_attempt')
-        .select('daily_challenge_attempt_id')
-        .in('question_id', questionIds)
-        .limit(1)
-        .maybeSingle();
-      if (dailyUsageError) return { status: 'error', error: dailyUsageError };
-      if (dailyUsage) return { status: 'in_use' };
-
-      const { data: linkRows, error: linkFetchError } = await supabase
-        .from('question_to_answer')
-        .select('answer_id')
-        .in('question_id', questionIds);
-      if (linkFetchError) return { status: 'error', error: linkFetchError };
-      const answerIds = ((linkRows ?? []) as { answer_id: string }[]).map((row) => row.answer_id);
-
-      const { error: unlinkError } = await supabase.from('question_to_answer').delete().in('question_id', questionIds);
-      if (unlinkError) return { status: 'error', error: unlinkError };
-
-      if (answerIds.length > 0) {
-        const { error: answerDeleteError } = await supabase.from('answer').delete().in('answer_id', answerIds);
-        if (answerDeleteError) return { status: 'error', error: answerDeleteError };
-      }
-
-      const { error: questionDeleteError } = await supabase.from('question').delete().in('question_id', questionIds);
-      if (questionDeleteError) return { status: 'error', error: questionDeleteError };
-    }
-  }
-
-  const { error: titleDeleteError } = await supabase.from('title_definition').delete().eq('activity_type', activityType);
-  if (titleDeleteError) return { status: 'error', error: titleDeleteError };
-
-  const { error: unlinkQuizError } = await supabase.from('assembled_quiz_catalog').delete().eq('activity_type', activityType);
-  if (unlinkQuizError) return { status: 'error', error: unlinkQuizError };
-
-  const { error: deleteError } = await supabase.from('activity_type').delete().eq('activity_type', activityType);
-  if (deleteError) {
-    if ((deleteError as { code?: string }).code === '23503') return { status: 'in_use' };
-    return { status: 'error', error: deleteError };
-  }
+  const { error: deleteError } = await supabase
+    .from('activity_type')
+    .update({ deleted_at: new Date().toISOString() })
+    .eq('activity_type', activityType);
+  if (deleteError) return { status: 'error', error: deleteError };
 
   return { status: 'ok' };
 }
@@ -487,13 +431,16 @@ export type CatalogEditableCheck = { ok: true } | { ok: false; response: Respons
  *
  * An unknown activityType is let through here (`data` comes back null) rather than surfaced as a
  * second error — the caller's own validation (isActivityType/getGradingKind) already 400s that
- * case before this runs.
+ * case before this runs. GitHub #525: excludes a soft-deleted catalog for the same reason — its
+ * content can't be edited once deleted, though in practice the caller's own isActivityType/
+ * getGradingKind check already 400s first, making this a defense-in-depth duplicate.
  */
 export async function assertCatalogIsEditable(supabase: SupabaseClient, activityType: string): Promise<CatalogEditableCheck> {
   const { data, error } = await supabase
     .from('activity_type')
     .select('creator_id')
     .eq('activity_type', activityType)
+    .is('deleted_at', null)
     .maybeSingle();
 
   if (error) return { ok: false, response: Response.json({ error: error.message }, { status: 500 }) };

--- a/lib/activityTypes.ts
+++ b/lib/activityTypes.ts
@@ -24,18 +24,24 @@ import type { SupabaseClient } from './sessionQueries';
  * error is only set on an actual database failure (distinct from "not found", which is a normal
  * `{ valid: false, error: null }`) so callers can tell "400: unknown activity type" apart from
  * "500: could not check".
+ *
+ * GitHub #525: excludes a soft-deleted catalog (activity_type.deleted_at) by default — a deleted
+ * catalog must act "unknown" for starting/resuming a session, authoring content, etc. The two or
+ * three callers that read a student's own already-recorded history (GET /api/sessions/completed,
+ * GET /api/instructor/students/{id}/history, GET /api/sessions/in-progress) pass
+ * includeDeleted: true, since that history must stay readable after the catalog is gone.
  */
 export async function isActivityType(
   supabase: SupabaseClient,
   value: unknown,
+  options: { includeDeleted?: boolean } = {},
 ): Promise<{ valid: boolean; error: { message: string } | null }> {
   if (typeof value !== 'string' || value.trim() === '') return { valid: false, error: null };
 
-  const { data, error } = await supabase
-    .from('activity_type')
-    .select('activity_type')
-    .eq('activity_type', value)
-    .maybeSingle();
+  let query = supabase.from('activity_type').select('activity_type').eq('activity_type', value);
+  if (!options.includeDeleted) query = query.is('deleted_at', null);
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) return { valid: false, error };
   return { valid: data !== null, error: null };
@@ -68,20 +74,25 @@ export function isGradingKind(value: unknown): value is GradingKind {
  * the CHECK constraint makes that unreachable through Postgres, and treating an unrecognised
  * value as "unknown activity" is the safe direction — it refuses the request rather than guessing
  * a grading path.
+ *
+ * GitHub #525: same includeDeleted escape hatch as isActivityType, for the same reason — a
+ * soft-deleted catalog must act "unknown" for new/ongoing interaction, but POST
+ * .../llm/submissions passes includeDeleted: true so a submission already in flight can still be
+ * graded even if the catalog is deleted mid-session.
  */
 export async function getGradingKind(
   supabase: SupabaseClient,
   activityType: unknown,
+  options: { includeDeleted?: boolean } = {},
 ): Promise<{ gradingKind: GradingKind | null; error: { message: string } | null }> {
   if (typeof activityType !== 'string' || activityType.trim() === '') {
     return { gradingKind: null, error: null };
   }
 
-  const { data, error } = await supabase
-    .from('activity_type')
-    .select('grading_kind')
-    .eq('activity_type', activityType)
-    .maybeSingle();
+  let query = supabase.from('activity_type').select('grading_kind').eq('activity_type', activityType);
+  if (!options.includeDeleted) query = query.is('deleted_at', null);
+
+  const { data, error } = await query.maybeSingle();
 
   if (error) return { gradingKind: null, error };
 

--- a/lib/dailyChallengeQueries.ts
+++ b/lib/dailyChallengeQueries.ts
@@ -67,6 +67,12 @@ export async function findTodayAttempt(supabase: SupabaseClient, userId: string,
  * difficulty_level filter: the issue asks for "one random question," not a leveled draw.
  *
  * A student enrolled in no courses short-circuits to an empty pool without querying course/question.
+ *
+ * GitHub #525: excludes a question whose catalog has been soft-deleted (activity_type.deleted_at)
+ * — this pool has no other awareness of activity_type at all, so without this a deleted catalog's
+ * questions would stay eligible for new Daily Challenge draws forever, even though the catalog
+ * itself is gone from every other part of the app. Fetched via a non-inner embed and filtered in
+ * JS (this codebase's existing convention) rather than an embedded-column WHERE filter.
  */
 export async function loadEligibleQuestionIds(supabase: SupabaseClient, userId: string) {
   const enrolled = await getEnrolledCourseIds(supabase, userId);
@@ -87,12 +93,22 @@ export async function loadEligibleQuestionIds(supabase: SupabaseClient, userId: 
 
   const { data: questions, error: questionsError } = await supabase
     .from('question')
-    .select('question_id, max_score')
+    .select('question_id, max_score, catalog:activity_type(deleted_at)')
     .in('user_id', instructorIds);
 
   if (questionsError) return { questions: null, error: questionsError };
 
-  return { questions: (questions ?? []) as { question_id: string; max_score: number | null }[], error: null };
+  const rows = (questions ?? []) as unknown as {
+    question_id: string;
+    max_score: number | null;
+    catalog: { deleted_at: string | null } | null;
+  }[];
+
+  const eligible = rows
+    .filter((row) => row.catalog?.deleted_at == null)
+    .map((row) => ({ question_id: row.question_id, max_score: row.max_score }));
+
+  return { questions: eligible, error: null };
 }
 
 /**

--- a/lib/studentDetailQueries.ts
+++ b/lib/studentDetailQueries.ts
@@ -14,6 +14,7 @@ import { loadProgressForSessions, type ActivityLogRow } from './sessionQueries';
 import { SESSION_COLUMNS } from './sessionRules';
 import { getEnrolledCourseIds, listOwnedCourseIds, loadEnrolledStudentIdsForCourses } from './courseQueries';
 import { listActivityTypesForCourses, listCoursesForActivityTypes, type ActivityCourseRef } from './activityCourseQueries';
+import { listOwnedActivityTypeSummaries } from './activityTypeQueries';
 import { fetchAllRowsByIds } from './supabasePaging';
 
 export type StudentDetailAttempt = ActivityLogRow & {
@@ -160,10 +161,27 @@ export async function loadStudentDetailForInstructor(
   const { activities: sharedActivities, error: activitiesError } = await listActivityTypesForCourses(supabase, sharedCourseIds);
   if (activitiesError || !sharedActivities) return { status: 'error', error: activitiesError! };
 
-  const sharedActivityTypes = [...new Set(sharedActivities.map((activity) => activity.activityType))];
-  const activityNames = Object.fromEntries(sharedActivities.map((activity) => [activity.activityType, activity.name]));
+  // GitHub #525: listActivityTypesForCourses only ever reflects *current* course linkage, and a
+  // catalog must be unlinked from every quiz before it can be deleted — so relying on it alone
+  // would silently drop a catalog's attempts from this view the moment it's deleted (or simply
+  // unlinked). Unioning in every catalog this instructor owns (listOwnedActivityTypeSummaries,
+  // deliberately never filtered by deleted_at) keeps that history visible, the same "my catalogs'
+  // history never disappears" guarantee GET /api/instructor/activities already gives on the
+  // dashboard. The sharedCourseIds authorization gate above is untouched — this only widens which
+  // activity types' history is shown once that gate is already passed.
+  const { activityTypeSummaries: ownedActivities, error: ownedActivitiesError } = await listOwnedActivityTypeSummaries(supabase, instructorId);
+  if (ownedActivitiesError || !ownedActivities) return { status: 'error', error: ownedActivitiesError! };
 
-  if (sharedActivityTypes.length === 0) {
+  const activityNameMap = new Map<string, string>();
+  for (const activity of ownedActivities) activityNameMap.set(activity.activityType, activity.name);
+  for (const activity of sharedActivities) activityNameMap.set(activity.activityType, activity.name); // currently-linked name wins
+
+  const visibleActivityTypes = [
+    ...new Set([...ownedActivities.map((activity) => activity.activityType), ...sharedActivities.map((activity) => activity.activityType)]),
+  ];
+  const activityNames = Object.fromEntries(activityNameMap);
+
+  if (visibleActivityTypes.length === 0) {
     return { status: 'ok', detail: { studentName, activityNames, attempts: [], classAveragePercent: null } };
   }
 
@@ -171,7 +189,7 @@ export async function loadStudentDetailForInstructor(
     .from('session_log')
     .select(SESSION_COLUMNS)
     .eq('user_id', studentId)
-    .in('activity_type', sharedActivityTypes)
+    .in('activity_type', visibleActivityTypes)
     .order('ended_at', { ascending: false })
     .order('started_at', { ascending: false });
   if (sessionError) return { status: 'error', error: sessionError };
@@ -188,7 +206,7 @@ export async function loadStudentDetailForInstructor(
   ] = await Promise.all([
     loadProgressForSessions(supabase, sessionIds),
     loadQuestionCorrectnessBySession(supabase, sessionIds),
-    listCoursesForActivityTypes(supabase, sharedActivityTypes),
+    listCoursesForActivityTypes(supabase, visibleActivityTypes),
     loadEnrolledStudentIdsForCourses(supabase, sharedCourseIds),
   ]);
   if (progressError) return { status: 'error', error: progressError };
@@ -216,7 +234,7 @@ export async function loadStudentDetailForInstructor(
     .from('session_log')
     .select('cumulative_score, max_score')
     .in('user_id', rosterIds)
-    .in('activity_type', sharedActivityTypes)
+    .in('activity_type', visibleActivityTypes)
     .eq('status', 'completed');
   if (classSessionError) return { status: 'error', error: classSessionError };
 

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -110,6 +110,14 @@ CREATE TABLE activity_type (
     grading_kind  text        NOT NULL DEFAULT 'mcq',
     rating_prompt text,
     creator_id    uuid,
+    -- GitHub #525: soft delete. NULL = active. Deleting a catalog only ever sets this — the row
+    -- itself, and everything referencing it (question, session_log, title_definition, user_story),
+    -- is never removed, so historical attempts stay fully readable forever. isActivityType/
+    -- getGradingKind (lib/activityTypes.ts) exclude a soft-deleted catalog by default; a handful of
+    -- history-reading routes opt back in via their includeDeleted param. A catalog must already be
+    -- unlinked from every assembled_quiz before it can be deleted at all (deleteCatalog's 'linked'
+    -- guard, unchanged), so a soft-deleted catalog is never still reachable through a course.
+    deleted_at    timestamp,
     PRIMARY KEY (activity_type));
 
 -- ---------------------------------------------------------------------
@@ -1420,3 +1428,16 @@ CREATE POLICY own_daily_challenge_attempt_insert ON daily_challenge_attempt
 --     WHERE status = 'in-progress';
 --
 --   CREATE INDEX IF NOT EXISTS ix_session_log_assembled_quiz_id ON session_log (assembled_quiz_id);
+
+-- activity_type.deleted_at (GitHub #525): a question catalog used to be permanently undeletable
+-- the instant any student had a session_log row against it (deleteCatalog's old 'in_use' guard),
+-- with no way around it. Deleting now soft-deletes instead — the row, and everything referencing
+-- it, is never removed, so history stays readable everywhere. The only remaining precondition is
+-- unchanged: the catalog must already be unlinked from every assembled_quiz ('linked' guard). If
+-- your database predates this column:
+--
+--   ALTER TABLE activity_type ADD COLUMN IF NOT EXISTS deleted_at timestamp;
+--
+-- No backfill needed: every existing catalog is implicitly active (deleted_at IS NULL already,
+-- the column's own default), and nothing was ever hard-deleted under the old guard for this to
+-- need to account for.


### PR DESCRIPTION
Soft-delete activity_type via a nullable deleted_at column instead of
hard-blocking on any historical session and cascading deletes on
success. The catalog row and everything referencing it (questions,
answers, sessions, title ladders) is never removed, so attempt history
stays fully readable in student history, the instructor dashboard,
per-student detail, statistics, and the leaderboard. The only
remaining precondition to delete a catalog is that it must already be
unlinked from every assembled quiz, matching the guard that already
existed for that case.

isActivityType/getGradingKind exclude soft-deleted catalogs by
default; four read paths that must keep serving already-existing data
(a student's own completed history, an instructor's per-student
history, mid-session LLM grading, and the in-progress status check)
opt back in via an includeDeleted flag. Also closes two gaps found
during review: Daily Challenge draws now exclude a deleted catalog's
questions, and the instructor per-student detail page unions owned
catalogs so a deleted/unlinked catalog's attempts don't silently drop
out of that view.
